### PR TITLE
fix: Type errors and missing dotenv config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ axum-extra = { version = "0.9", features = ["typed-header"] }
 headers = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+dotenv = "0.15.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -302,6 +302,8 @@ async fn get_amounts_out(
 
 #[tokio::main]
 async fn main() {
+    dotenv::dotenv().ok();
+
     let tycho_url = std::env::var("TYCHO_URL")
         .unwrap_or_else(|_| "tycho-beta.propellerheads.xyz".to_string());
     let api_key = std::env::var("TYCHO_API_KEY")
@@ -314,10 +316,10 @@ async fn main() {
     println!("Initializing price service...");
     
     let tvl_filter = ComponentFilter::with_tvl_range(tvl_threshold, tvl_threshold);
-    let all_tokens = load_all_tokens(&tycho_url, false, Some(&api_key), Chain::Ethereum).await;
+    let all_tokens = load_all_tokens(&tycho_url, false, Some(&api_key), Chain::Ethereum.into(), None, None).await;
     println!("Loaded {} tokens", all_tokens.len());
 
-    let raw_stream = ProtocolStreamBuilder::new(&tycho_url, Chain::Ethereum)
+    let raw_stream = ProtocolStreamBuilder::new(&tycho_url, Chain::Ethereum.into())
         .exchange::<UniswapV2State>("uniswap_v2", tvl_filter.clone(), None)
         .exchange::<UniswapV3State>("uniswap_v3", tvl_filter.clone(), None)
         .exchange::<UniswapV4State>("uniswap_v4", tvl_filter.clone(), None)


### PR DESCRIPTION
# Fix Build Issues

- Added the `dotenv` crate 
- Implemented dotenv initialization at the beginning of the main function
- Fixed `cargo build` issues by adding `.into()` to convert `Chain::Ethereum` to the expected type (tycho_simulation::evm::tycho_models::Chain)
- Added the missing `Option<i32>` and `Option<u64>` parameters at `tycho_simulation::utils::load_all_tokens`.