### PR TITLE
feat: Refactor and unify pool runtime checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,7 @@ RUST_LOG=info
 # Quote & simulation timeouts (milliseconds)
 # Max total time a quote can run before canceling outstanding pool sims
 QUOTE_TIMEOUT_MS=50
-# Per-pool watchdogs; native and VM can be tuned independently
+# Per-pool watchdogs; native and VM can be tuned independently and start when blocking work begins
 POOL_TIMEOUT_NATIVE_MS=5
 POOL_TIMEOUT_VM_MS=50
 # Request-level guard applied at handler; router adds +250ms headroom
@@ -31,8 +31,9 @@ REQUEST_TIMEOUT_MS=4000
 TOKEN_REFRESH_TIMEOUT_MS=1000
 
 # Simulation concurrency caps (global)
-GLOBAL_NATIVE_SIM_CONCURRENCY=8000
-GLOBAL_VM_SIM_CONCURRENCY=4000
+# Defaults already scale with CPU count. Uncomment only when intentionally overriding locally.
+# GLOBAL_NATIVE_SIM_CONCURRENCY=<override>
+# GLOBAL_VM_SIM_CONCURRENCY=<override>
 
 # VM pool feeds (default true)
 ENABLE_VM_POOLS=true

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The following environment variables are read at startup:
 - `STREAM_MEM_LOG_MIN_NEW_PAIRS` – Only snapshot on stream updates with at least this many new pairs (default: `1000`)
 - `STREAM_MEM_LOG_EMF` – Emit CloudWatch EMF metrics for snapshots (default: `true`)
 
-Note: when concurrency caps are saturated or a pool would exceed the quote deadline, pools are skipped instead of queued. `meta.status` remains an operational/reliability signal, while `meta.result_quality` and `meta.pool_results` explain quote completeness and per-pool anomalies.
+Note: when concurrency caps are saturated or a pool would exceed the quote deadline, pools are skipped instead of queued. The runtime's blocking-thread budget is aligned to the resolved native + VM concurrency caps, so those semaphore caps remain the real limiter. `meta.status` remains an operational/reliability signal, while `meta.result_quality` and `meta.pool_results` explain quote completeness and per-pool anomalies.
 
 ## Docs
 
@@ -136,7 +136,7 @@ Response body:
 
 `meta.pool_results` contains anomaly-only per-pool outcomes (`partial_output`, `zero_output`, `skipped_concurrency`, `skipped_deadline`, `skipped_precheck`, `timed_out`, `simulator_error`, `internal_error`). `meta.vm_unavailable=true` indicates VM pools were skipped because VM state was not ready.
 
-`gas_in_sell` is computed per pool from the latest background-refreshed cached `eth_gasPrice` (from `RPC_URL`), the request-scoped `spot_price(ETH, sellToken)`, and the pool's last `gas_used` ladder entry; it is returned in sell-token base units. When spot price, gas reporting is disabled due to consecutive RPC failures, cached gas price, or gas usage is unavailable, it is `"0"`.
+`gas_in_sell` is computed per pool from the latest background-refreshed cached `eth_gasPrice` (from `RPC_URL`) and the pool's last `gas_used` ladder entry. For ETH/WETH sell tokens it uses a direct `1.0` conversion into sell-token base units; for every other sell token in the current implementation it is `"0"`. It is also `"0"` when gas reporting is disabled due to consecutive RPC failures, cached gas price is unavailable, or gas usage is unavailable.
 
 `block_number` is the native stream block; `vm_block_number` is the last VM stream block when VM pools are enabled (it may be omitted while VM pools are disabled or still warming up).
 

--- a/scripts/encode_smoke.py
+++ b/scripts/encode_smoke.py
@@ -67,18 +67,30 @@ def apply_slippage(amount: str | int, bps: int) -> str:
     return str((value * safe_bps) // 10_000)
 
 
-def select_pool(response: dict, label: str) -> dict:
+def select_pool(response: dict, label: str, expected_len: int) -> dict:
     data = response.get("data")
     if not isinstance(data, list) or not data:
         raise AssertionError(f"{label}: no pool data")
-    pool = data[0]
     required = ["pool", "amounts_out", "gas_used", "gas_in_sell", "block_number", "pool_name", "pool_address"]
-    for key in required:
-        if key not in pool:
-            raise AssertionError(f"{label}: missing {key}")
-    if not is_int_string(pool.get("gas_in_sell")):
-        raise AssertionError(f'{label}: gas_in_sell must be an integer string ("0" is valid)')
-    return pool
+    last_error = f"{label}: no pool data"
+    for pool in data:
+        missing = [key for key in required if key not in pool]
+        if missing:
+            last_error = f"{label}: missing {', '.join(missing)}"
+            continue
+        if not is_int_string(pool.get("gas_in_sell")):
+            last_error = f'{label}: gas_in_sell must be an integer string ("0" is valid)'
+            continue
+        amounts_out = pool.get("amounts_out")
+        gas_used = pool.get("gas_used")
+        if not isinstance(amounts_out, list) or len(amounts_out) != expected_len:
+            last_error = f"{label}: amounts_out length mismatch (expected {expected_len})"
+            continue
+        if not isinstance(gas_used, list) or len(gas_used) != expected_len:
+            last_error = f"{label}: gas_used length mismatch (expected {expected_len})"
+            continue
+        return pool
+    raise AssertionError(last_error)
 
 
 def protocol_from_pool_name(pool_name: str) -> str:
@@ -186,7 +198,7 @@ def main() -> int:
         print(f"[FAIL] simulate dai->usdc had {len(failures_list)} failures")
         return 1
 
-    pool_first = select_pool(response, "simulate dai->usdc")
+    pool_first = select_pool(response, "simulate dai->usdc", len(amounts))
 
     hop_amounts_out = pool_first["amounts_out"]
     hop_amounts_in = [apply_slippage(value, DEFAULT_SLIPPAGE_BPS) for value in hop_amounts_out]
@@ -219,7 +231,7 @@ def main() -> int:
         print(f"[FAIL] simulate usdc->usdt had {len(failures_list)} failures")
         return 1
 
-    pool_second = select_pool(response_second, "simulate usdc->usdt")
+    pool_second = select_pool(response_second, "simulate usdc->usdt", len(hop_amounts_in))
 
     protocol_first = protocol_from_pool_name(pool_first.get("pool_name", ""))
     protocol_second = protocol_from_pool_name(pool_second.get("pool_name", ""))

--- a/scripts/run_suite.sh
+++ b/scripts/run_suite.sh
@@ -25,7 +25,7 @@ Options:
   --stop             Stop server when done (only if started by this script)
   -h, --help         Show this help
 
-Tip: For mainnet variability, use --allow-partial --allow-no-liquidity for local runs.
+Tip: For mainnet variability, use --allow-partial --allow-no-liquidity for local runs; the smoke validator will then accept non-empty partial ladders in `data`.
 USAGE
 }
 

--- a/scripts/simulate_smoke.py
+++ b/scripts/simulate_smoke.py
@@ -48,19 +48,24 @@ def is_int_string(value) -> bool:
     return value.isdigit()
 
 
-def validate_pool_entry(entry, expected_len: int) -> tuple[bool, str]:
+def validate_pool_entry(entry, expected_len: int, allow_partial_output: bool) -> tuple[bool, str]:
     if not isinstance(entry, dict):
         return False, "pool entry is not an object"
 
     amounts_out = entry.get("amounts_out")
-    if not isinstance(amounts_out, list) or len(amounts_out) != expected_len:
+    if not isinstance(amounts_out, list) or not amounts_out:
+        return False, "amounts_out must be a non-empty list"
+    if allow_partial_output:
+        if len(amounts_out) > expected_len:
+            return False, f"amounts_out length mismatch (expected <= {expected_len})"
+    elif len(amounts_out) != expected_len:
         return False, f"amounts_out length mismatch (expected {expected_len})"
     if not all(is_int_string(v) for v in amounts_out):
         return False, "amounts_out contains non-integer strings"
 
     gas_used = entry.get("gas_used")
-    if not isinstance(gas_used, list) or len(gas_used) != expected_len:
-        return False, f"gas_used length mismatch (expected {expected_len})"
+    if not isinstance(gas_used, list) or len(gas_used) != len(amounts_out):
+        return False, "gas_used length mismatch with amounts_out"
     if not all(isinstance(v, int) and v >= 0 for v in gas_used):
         return False, "gas_used contains non-integers"
 
@@ -97,7 +102,7 @@ def main() -> int:
         action="store_true",
         help=(
             "Validate response pool entries (amounts_out/gas_used lengths, gas_in_sell integer-string, "
-            "block_number, monotonicity)"
+            "block_number, monotonicity; with --allow-failures, partial ladders are allowed)"
         ),
     )
     parser.add_argument("--list-suites", action="store_true", help="List available suites and exit")
@@ -212,7 +217,11 @@ def main() -> int:
 
         if args.validate_data and isinstance(data, list):
             for entry in data:
-                ok, error = validate_pool_entry(entry, expected_len=len(amounts))
+                ok, error = validate_pool_entry(
+                    entry,
+                    expected_len=len(amounts),
+                    allow_partial_output=args.allow_failures,
+                )
                 if not ok:
                     print(f"[FAIL] {pair_label} invalid pool entry: {error}")
                     failures += 1

--- a/skills/simulation-service-tests/SKILL.md
+++ b/skills/simulation-service-tests/SKILL.md
@@ -30,7 +30,7 @@ cd /path/to/tycho-simulation-server
 scripts/run_suite.sh --repo . --suite core --stop
 ```
 
-`run_suite.sh` smoke checks now require non-empty `data` and validate pool entry schema (`amounts_out`, `gas_used`, `gas_in_sell`, monotonicity, and `block_number`). `gas_in_sell` is a decimal-string sell-token amount computed from request-scoped pricing inputs and can legitimately be `"0"` when gas reporting or pricing inputs are unavailable.
+`run_suite.sh` smoke checks require non-empty `data` and validate pool entry schema (`amounts_out`, `gas_used`, `gas_in_sell`, monotonicity, and `block_number`). `gas_in_sell` is a decimal-string sell-token amount: ETH/WETH sell tokens use direct `1.0` conversion from gas-in-ETH, other sell tokens currently return `"0"`, and `"0"` is also valid when gas reporting inputs are unavailable.
 
 VM pools (Curve/Balancer/Maverick feeds) are enabled by default. To exclude them:
 ```bash
@@ -41,6 +41,7 @@ If you need to tolerate partial failures or empty-liquidity responses while stil
 ```bash
 scripts/run_suite.sh --repo . --suite core --allow-partial --allow-no-liquidity --stop
 ```
+With `--allow-partial`, smoke validation now accepts partial-ladder pool entries as long as `amounts_out` and `gas_used` stay aligned, monotonic, and non-empty.
 
 ## Smoke test /simulate
 
@@ -63,6 +64,8 @@ Allow partial responses explicitly:
 ```bash
 python3 scripts/simulate_smoke.py --suite smoke --allow-status ready,partial_success --allow-failures
 ```
+Quote handler logs now keep request-guard and zero-result timeout completions at `WARN` (`scope="handler_timeout"`), while partial-success responses that still return usable quotes log at `INFO` (`scope="handler_complete"`).
+When `--allow-failures` is set together with `--validate-data`, partial ladders are accepted.
 
 ## Smoke test /encode
 

--- a/skills/simulation-service-tests/SKILL.md
+++ b/skills/simulation-service-tests/SKILL.md
@@ -30,7 +30,7 @@ cd /path/to/tycho-simulation-server
 scripts/run_suite.sh --repo . --suite core --stop
 ```
 
-`run_suite.sh` smoke checks require non-empty `data` and validate pool entry schema (`amounts_out`, `gas_used`, `gas_in_sell`, monotonicity, and `block_number`). `gas_in_sell` is a decimal-string sell-token amount: ETH/WETH sell tokens use direct `1.0` conversion from gas-in-ETH, other sell tokens currently return `"0"`, and `"0"` is also valid when gas reporting inputs are unavailable.
+`run_suite.sh` smoke checks require non-empty `data` and validate pool entry schema (`amounts_out`, `gas_used`, `gas_in_sell`, monotonicity, and `block_number`). `gas_in_sell` is a decimal-string sell-token amount: ETH/WETH sell tokens use direct `1.0` conversion from gas-in-ETH, non-native sell tokens may return a non-zero value when a sell-token/native or sell-token/wrapped-native spot source is available, and `"0"` remains valid when gas reporting inputs are unavailable or no usable spot source exists.
 
 VM pools (Curve/Balancer/Maverick feeds) are enabled by default. To exclude them:
 ```bash
@@ -55,7 +55,7 @@ python3 scripts/simulate_smoke.py --pair DAI:USDC --pair WETH:USDC
 python3 scripts/simulate_smoke.py --list-tokens
 ```
 
-For stricter checks (fail on empty data and validate pool entries, including `gas_in_sell`; `"0"` is valid):
+For stricter checks (fail on empty data and validate pool entries, including `gas_in_sell`; `"0"` is still valid when reporting inputs or spot conversion data are unavailable):
 ```bash
 python3 scripts/simulate_smoke.py --suite smoke --require-data --validate-data
 ```
@@ -138,7 +138,7 @@ zsh skills/simulation-service-tests/scripts/run_checks.zsh --repo /path/to/tycho
 
 1. Bump `tycho-simulation` tag/version (or other deps).
 2. Run: `cargo fmt`, `cargo clippy ...`, `cargo nextest run`, `cargo build --release`.
-3. Run the end-to-end suite (`run_suite.zsh`) with and without VM pools.
+3. Run the end-to-end suite (`scripts/run_suite.sh`) with and without VM pools.
 4. If infra changes are involved: `npm ci`, `npx cdk synth`, `npx cdk diff`.
 
 ## Deploy workflow (CDK + Docker)
@@ -147,7 +147,8 @@ See `references/deploy.md`.
 
 ## Included scripts
 
-- Repo (source of truth): `scripts/start_server.sh`, `scripts/stop_server.sh`, `scripts/wait_ready.sh`, `scripts/run_suite.sh`, plus the Python runners in `scripts/`.
+- Repo scripts are the canonical entrypoints: `scripts/start_server.sh`, `scripts/stop_server.sh`, `scripts/wait_ready.sh`, `scripts/run_suite.sh`, plus the Python runners in `scripts/`.
+- Skill-local wrappers and helper utilities are not kept in lockstep with every repo-script change in this pass. Use repo `scripts/` for start/stop/wait/suite flows.
 - Skill utilities: `scripts/run_checks.zsh` (CI-like `cargo fmt/clippy/nextest/build` + optional `cdk synth`/`docker build`).
 
 ## References

--- a/skills/simulation-service-tests/references/project.md
+++ b/skills/simulation-service-tests/references/project.md
@@ -36,7 +36,8 @@
   - `scripts/run_suite.sh --repo . --suite core --stop`
   - VM pools are enabled by default; add `--disable-vm-pools` to skip VM feeds (Curve/Balancer/Maverick).
   - Use `--allow-partial` or `--allow-no-liquidity` if you expect partial/no-liquidity responses.
-  - Smoke validation checks non-empty `data` and pool fields including `gas_in_sell` (decimal string, `"0"` is valid when reporting is disabled/unavailable; pricing inputs are request-scoped).
+  - Smoke validation checks non-empty `data` and pool fields including `gas_in_sell` (decimal string; ETH/WETH sell tokens use direct gas-in-ETH conversion, other sell tokens currently return `"0"`, and `"0"` is also valid when reporting inputs are unavailable).
+  - With `--allow-partial`, smoke validation accepts partial-ladder pool entries as long as `amounts_out` and `gas_used` stay aligned, monotonic, and non-empty.
   - Core coverage now includes `GHO:USDC`, `ETH:RETH`, and `RETH:ETH`.
 - Individual runners:
   - `python3 scripts/simulate_smoke.py --suite smoke`

--- a/skills/simulation-service-tests/references/project.md
+++ b/skills/simulation-service-tests/references/project.md
@@ -36,7 +36,7 @@
   - `scripts/run_suite.sh --repo . --suite core --stop`
   - VM pools are enabled by default; add `--disable-vm-pools` to skip VM feeds (Curve/Balancer/Maverick).
   - Use `--allow-partial` or `--allow-no-liquidity` if you expect partial/no-liquidity responses.
-  - Smoke validation checks non-empty `data` and pool fields including `gas_in_sell` (decimal string; ETH/WETH sell tokens use direct gas-in-ETH conversion, other sell tokens currently return `"0"`, and `"0"` is also valid when reporting inputs are unavailable).
+  - Smoke validation checks non-empty `data` and pool fields including `gas_in_sell` (decimal string; ETH/WETH sell tokens use direct gas-in-ETH conversion, non-native sell tokens may return a non-zero value when a sell-token/native or sell-token/wrapped-native spot source is available, and `"0"` remains valid when reporting inputs are unavailable or no usable spot source exists).
   - With `--allow-partial`, smoke validation accepts partial-ladder pool entries as long as `amounts_out` and `gas_used` stay aligned, monotonic, and non-empty.
   - Core coverage now includes `GHO:USDC`, `ETH:RETH`, and `RETH:ETH`.
 - Individual runners:

--- a/skills/simulation-service-tests/references/protocols.md
+++ b/skills/simulation-service-tests/references/protocols.md
@@ -24,7 +24,7 @@ The service subscribes to specific Tycho exchanges at startup (see `src/services
 - **VM pools are on by default**. Disable them if you want to validate native-only behavior:
   - `scripts/run_suite.sh --repo . --suite core --disable-vm-pools --stop`
   - Or start the server with `ENABLE_VM_POOLS=false`:
-    - `zsh skills/simulation-service-tests/scripts/start_server.zsh --repo /path/to/tycho-simulation-server --env ENABLE_VM_POOLS=false`
+    - `scripts/start_server.sh --repo . --env ENABLE_VM_POOLS=false`
 - **Core suite coverage** includes `GHO:USDC`, `ETH:RETH`, and `RETH:ETH` to exercise Maverick/Rocketpool/native paths in normal runs.
 - **TVL filtering matters**: pools are included/removed based on `TVL_THRESHOLD` + `TVL_KEEP_RATIO`.
   - If your tests miss protocols/pools, try lowering `TVL_THRESHOLD` (at the cost of ingesting more pools).

--- a/src/handlers/encode.rs
+++ b/src/handlers/encode.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use axum::{
     extract::State,
@@ -6,11 +6,19 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use crate::models::messages::{EncodeErrorResponse, RouteEncodeRequest, RouteEncodeResponse};
 use crate::models::state::AppState;
-use crate::services::encode::{encode_route, EncodeErrorKind};
+use crate::services::encode::{encode_route, EncodeError, EncodeErrorKind};
+
+enum EncodeComputation {
+    Completed(Result<RouteEncodeResponse, EncodeError>),
+    JoinFailed(tokio::task::JoinError),
+    TimedOut,
+}
 
 pub async fn encode(
     State(state): State<AppState>,
@@ -29,27 +37,53 @@ pub async fn encode(
     let state_for_computation = state.clone();
     let request_for_computation = request.clone();
 
-    let computation_future = encode_route(state_for_computation, request_for_computation);
-
-    let computation = match tokio::time::timeout(request_timeout, computation_future).await {
-        Ok(result) => result,
-        Err(_) => {
-            let timeout_ms = request_timeout.as_millis() as u64;
-            warn!(
-                scope = "handler_timeout",
-                request_id,
-                timeout_ms,
-                latency_ms = started_at.elapsed().as_millis() as u64,
-                "Encode request timed out at request-level guard"
-            );
-
-            let body = Json(EncodeErrorResponse {
-                error: format!("Encode request timed out after {}ms", timeout_ms),
-                request_id: request.request_id.clone(),
-            });
-            return (StatusCode::REQUEST_TIMEOUT, body).into_response();
+    let request_cancel = CancellationToken::new();
+    let computation_task = tokio::spawn({
+        let request_cancel = request_cancel.clone();
+        async move {
+            encode_route(
+                state_for_computation,
+                request_for_computation,
+                Some(request_cancel),
+            )
+            .await
         }
-    };
+    });
+
+    let computation =
+        match await_encode_computation(computation_task, request_timeout, request_cancel).await {
+            EncodeComputation::Completed(result) => result,
+            EncodeComputation::JoinFailed(join_err) => {
+                warn!(
+                    scope = "handler_internal",
+                    request_id,
+                    latency_ms = started_at.elapsed().as_millis() as u64,
+                    error = %join_err,
+                    "Encode task failed"
+                );
+                let body = Json(EncodeErrorResponse {
+                    error: "Encode task failed".to_string(),
+                    request_id: request.request_id.clone(),
+                });
+                return (StatusCode::INTERNAL_SERVER_ERROR, body).into_response();
+            }
+            EncodeComputation::TimedOut => {
+                let timeout_ms = request_timeout.as_millis() as u64;
+                warn!(
+                    scope = "handler_timeout",
+                    request_id,
+                    timeout_ms,
+                    latency_ms = started_at.elapsed().as_millis() as u64,
+                    "Encode request timed out at request-level guard"
+                );
+
+                let body = Json(EncodeErrorResponse {
+                    error: format!("Encode request timed out after {}ms", timeout_ms),
+                    request_id: request.request_id.clone(),
+                });
+                return (StatusCode::REQUEST_TIMEOUT, body).into_response();
+            }
+        };
 
     let latency_ms = started_at.elapsed().as_millis() as u64;
     match computation {
@@ -96,5 +130,69 @@ pub async fn encode(
             }
             (status, body).into_response()
         }
+    }
+}
+
+async fn await_encode_computation(
+    computation_task: JoinHandle<Result<RouteEncodeResponse, EncodeError>>,
+    request_timeout: Duration,
+    request_cancel: CancellationToken,
+) -> EncodeComputation {
+    let timeout = tokio::time::sleep(request_timeout);
+    tokio::pin!(timeout);
+    tokio::pin!(computation_task);
+
+    tokio::select! {
+        result = computation_task.as_mut() => match result {
+            Ok(result) => EncodeComputation::Completed(result),
+            Err(join_err) => EncodeComputation::JoinFailed(join_err),
+        },
+        _ = &mut timeout => {
+            // `tokio::time::timeout` would drop the JoinHandle here, which detaches the task.
+            request_cancel.cancel();
+            computation_task.as_mut().abort();
+            EncodeComputation::TimedOut
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio_util::sync::CancellationToken;
+
+    use super::{await_encode_computation, EncodeComputation};
+    use crate::models::messages::RouteEncodeResponse;
+    use crate::services::encode::EncodeError;
+
+    #[tokio::test]
+    async fn await_encode_computation_aborts_timed_out_task() {
+        let task_finished = Arc::new(AtomicBool::new(false));
+        let task_finished_flag = Arc::clone(&task_finished);
+        let request_cancel = CancellationToken::new();
+        let computation_task = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(60)).await;
+            task_finished_flag.store(true, Ordering::SeqCst);
+            Ok::<_, EncodeError>(RouteEncodeResponse {
+                interactions: Vec::new(),
+                debug: None,
+            })
+        });
+
+        let result = await_encode_computation(
+            computation_task,
+            Duration::from_millis(10),
+            request_cancel.clone(),
+        )
+        .await;
+
+        assert!(matches!(result, EncodeComputation::TimedOut));
+        assert!(request_cancel.is_cancelled());
+
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        assert!(!task_finished.load(Ordering::SeqCst));
     }
 }

--- a/src/handlers/encode.rs
+++ b/src/handlers/encode.rs
@@ -20,6 +20,29 @@ enum EncodeComputation {
     TimedOut,
 }
 
+struct CancelOnDrop {
+    token: CancellationToken,
+    armed: bool,
+}
+
+impl CancelOnDrop {
+    fn new(token: CancellationToken) -> Self {
+        Self { token, armed: true }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for CancelOnDrop {
+    fn drop(&mut self) {
+        if self.armed {
+            self.token.cancel();
+        }
+    }
+}
+
 pub async fn encode(
     State(state): State<AppState>,
     Json(request): Json<RouteEncodeRequest>,
@@ -49,11 +72,16 @@ pub async fn encode(
             .await
         }
     });
+    let mut cancel_guard = CancelOnDrop::new(request_cancel.clone());
 
     let computation =
         match await_encode_computation(computation_task, request_timeout, request_cancel).await {
-            EncodeComputation::Completed(result) => result,
+            EncodeComputation::Completed(result) => {
+                cancel_guard.disarm();
+                result
+            }
             EncodeComputation::JoinFailed(join_err) => {
+                cancel_guard.disarm();
                 warn!(
                     scope = "handler_internal",
                     request_id,
@@ -140,17 +168,20 @@ async fn await_encode_computation(
 ) -> EncodeComputation {
     let timeout = tokio::time::sleep(request_timeout);
     tokio::pin!(timeout);
-    tokio::pin!(computation_task);
+    let mut computation_task = computation_task;
 
     tokio::select! {
-        result = computation_task.as_mut() => match result {
+        result = &mut computation_task => match result {
             Ok(result) => EncodeComputation::Completed(result),
             Err(join_err) => EncodeComputation::JoinFailed(join_err),
         },
         _ = &mut timeout => {
-            // `tokio::time::timeout` would drop the JoinHandle here, which detaches the task.
             request_cancel.cancel();
-            computation_task.as_mut().abort();
+            // Keep awaiting the spawned task in the background so it can propagate cancellation
+            // into any in-flight pool jobs instead of getting detached here.
+            tokio::spawn(async move {
+                let _ = computation_task.await;
+            });
             EncodeComputation::TimedOut
         }
     }
@@ -162,19 +193,26 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
+    use tokio::sync::Semaphore;
     use tokio_util::sync::CancellationToken;
 
-    use super::{await_encode_computation, EncodeComputation};
+    use super::{await_encode_computation, CancelOnDrop, EncodeComputation};
     use crate::models::messages::RouteEncodeResponse;
     use crate::services::encode::EncodeError;
+    use crate::services::pool_runtime::{run_blocking_pool_job, PoolJobError};
 
     #[tokio::test]
-    async fn await_encode_computation_aborts_timed_out_task() {
+    async fn await_encode_computation_cancels_timed_out_task_without_aborting_it() {
         let task_finished = Arc::new(AtomicBool::new(false));
+        let task_cancelled = Arc::new(AtomicBool::new(false));
         let task_finished_flag = Arc::clone(&task_finished);
+        let task_cancelled_flag = Arc::clone(&task_cancelled);
         let request_cancel = CancellationToken::new();
+        let request_cancel_for_task = request_cancel.clone();
         let computation_task = tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(60)).await;
+            request_cancel_for_task.cancelled().await;
+            task_cancelled_flag.store(true, Ordering::SeqCst);
+            tokio::time::sleep(Duration::from_millis(5)).await;
             task_finished_flag.store(true, Ordering::SeqCst);
             Ok::<_, EncodeError>(RouteEncodeResponse {
                 interactions: Vec::new(),
@@ -192,7 +230,100 @@ mod tests {
         assert!(matches!(result, EncodeComputation::TimedOut));
         assert!(request_cancel.is_cancelled());
 
-        tokio::time::sleep(Duration::from_millis(80)).await;
-        assert!(!task_finished.load(Ordering::SeqCst));
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        assert!(task_cancelled.load(Ordering::SeqCst));
+        assert!(task_finished.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn cancel_on_drop_cancels_work_when_handler_exits_early() {
+        let task_finished = Arc::new(AtomicBool::new(false));
+        let task_finished_flag = Arc::clone(&task_finished);
+        let request_cancel = CancellationToken::new();
+        let request_cancel_for_task = request_cancel.clone();
+        let computation_task = tokio::spawn(async move {
+            request_cancel_for_task.cancelled().await;
+            task_finished_flag.store(true, Ordering::SeqCst);
+            Ok::<_, EncodeError>(RouteEncodeResponse {
+                interactions: Vec::new(),
+                debug: None,
+            })
+        });
+        let guard = CancelOnDrop::new(request_cancel.clone());
+
+        drop(guard);
+        drop(computation_task);
+
+        assert!(request_cancel.is_cancelled());
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(task_finished.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn await_encode_computation_lets_cancellation_reach_blocking_pool_job() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .max_blocking_threads(1)
+            .build()
+            .expect("runtime");
+
+        runtime.block_on(async {
+            let request_cancel = CancellationToken::new();
+            let blocking_permit = Arc::new(Semaphore::new(1))
+                .acquire_owned()
+                .await
+                .expect("permit");
+            let job_started = Arc::new(AtomicBool::new(false));
+            let job_started_flag = Arc::clone(&job_started);
+
+            let (occupier_started_tx, occupier_started_rx) = tokio::sync::oneshot::channel();
+            let occupier = tokio::task::spawn_blocking(move || {
+                let _ = occupier_started_tx.send(());
+                std::thread::sleep(Duration::from_millis(80));
+            });
+            occupier_started_rx.await.expect("occupier should start");
+
+            let computation_task = tokio::spawn({
+                let request_cancel = request_cancel.clone();
+                async move {
+                    match run_blocking_pool_job(
+                        blocking_permit,
+                        Duration::from_millis(200),
+                        Some(request_cancel),
+                        move |_| {
+                            job_started_flag.store(true, Ordering::SeqCst);
+                            std::thread::sleep(Duration::from_millis(20));
+                            Ok::<_, EncodeError>(RouteEncodeResponse {
+                                interactions: Vec::new(),
+                                debug: None,
+                            })
+                        },
+                    )
+                    .await
+                    {
+                        Ok(result) => result,
+                        Err(PoolJobError::Cancelled) => Err(EncodeError::simulation("cancelled")),
+                        Err(PoolJobError::TimedOut) => Err(EncodeError::simulation("timed out")),
+                        Err(PoolJobError::JoinFailed(join_err)) => {
+                            Err(EncodeError::internal(format!("join failed: {join_err}")))
+                        }
+                    }
+                }
+            });
+
+            let result = await_encode_computation(
+                computation_task,
+                Duration::from_millis(10),
+                request_cancel.clone(),
+            )
+            .await;
+
+            assert!(matches!(result, EncodeComputation::TimedOut));
+            assert!(request_cancel.is_cancelled());
+
+            occupier.await.expect("occupier should finish");
+            tokio::time::sleep(Duration::from_millis(30)).await;
+            assert!(!job_started.load(Ordering::SeqCst));
+        });
     }
 }

--- a/src/handlers/quote.rs
+++ b/src/handlers/quote.rs
@@ -156,7 +156,7 @@ pub async fn simulate(
         };
     }
 
-    if timed_out {
+    if timed_out && computation.responses.is_empty() {
         log_completion!(
             tracing::Level::WARN,
             "handler_timeout",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::runtime::Builder;
 use tokio::sync::Semaphore;
 use tracing::{debug, error, info};
 
@@ -21,13 +22,22 @@ use tycho_simulation_server::services::stream_builder::{build_native_stream, bui
 #[global_allocator]
 static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
-    // Initialize logging
+fn main() -> anyhow::Result<()> {
     init_logging();
-
-    // Load configuration
     let config = load_config();
+    let max_blocking_threads = std::cmp::max(
+        512,
+        config.global_native_sim_concurrency + config.global_vm_sim_concurrency + 32,
+    );
+    let runtime = Builder::new_multi_thread()
+        .enable_all()
+        .max_blocking_threads(max_blocking_threads)
+        .build()?;
+
+    runtime.block_on(async_main(config))
+}
+
+async fn async_main(config: tycho_simulation_server::config::AppConfig) -> anyhow::Result<()> {
     info!("Initializing price service...");
 
     info!(

--- a/src/models/state.rs
+++ b/src/models/state.rs
@@ -689,7 +689,12 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
+    use crate::models::messages::AmountOutRequest;
+    use crate::models::stream_health::StreamHealth;
+    use crate::services::quotes::get_amounts_out;
     use num_bigint::BigUint;
+    use num_traits::Zero;
+    use tokio::sync::RwLock;
     use tycho_simulation::{
         protocol::models::ProtocolComponent,
         tycho_common::{
@@ -760,6 +765,66 @@ mod tests {
 
         fn eq(&self, other: &dyn ProtocolSim) -> bool {
             other.as_any().is::<DummySim>()
+        }
+    }
+
+    #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+    struct QuoteableSim;
+
+    #[typetag::serde]
+    impl ProtocolSim for QuoteableSim {
+        fn fee(&self) -> f64 {
+            0.0
+        }
+
+        fn spot_price(&self, _base: &Token, _quote: &Token) -> Result<f64, SimulationError> {
+            Err(SimulationError::FatalError("spot unavailable".to_string()))
+        }
+
+        fn get_amount_out(
+            &self,
+            amount_in: BigUint,
+            _token_in: &Token,
+            _token_out: &Token,
+        ) -> Result<GetAmountOutResult, SimulationError> {
+            Ok(GetAmountOutResult::new(
+                amount_in.clone(),
+                BigUint::from(21_000u64),
+                Box::new(self.clone()),
+            ))
+        }
+
+        fn get_limits(
+            &self,
+            _sell_token: Bytes,
+            _buy_token: Bytes,
+        ) -> Result<(BigUint, BigUint), SimulationError> {
+            Ok((BigUint::from(1_000_000u64), BigUint::zero()))
+        }
+
+        fn delta_transition(
+            &mut self,
+            _delta: ProtocolStateDelta,
+            _tokens: &HashMap<Bytes, Token>,
+            _balances: &Balances,
+        ) -> Result<(), TransitionError<String>> {
+            Ok(())
+        }
+
+        fn clone_box(&self) -> Box<dyn ProtocolSim> {
+            Box::new(self.clone())
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn as_any_mut(&mut self) -> &mut dyn Any {
+            self
+        }
+
+        fn eq(&self, other: &dyn ProtocolSim) -> bool {
+            other.as_any().is::<QuoteableSim>()
         }
     }
 
@@ -1345,6 +1410,99 @@ mod tests {
         let ids: HashSet<String> = matches.into_iter().map(|(id, _)| id).collect();
 
         assert_eq!(ids, HashSet::from(["pool-native".to_string()]));
+    }
+
+    #[tokio::test]
+    async fn get_amounts_out_uses_alias_fallback_when_exact_ids_are_stale() {
+        let wrapped_address =
+            Bytes::from_str("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2").expect("valid address");
+        let native_address = native_token_address();
+        let token_x = mk_token(12, "TKNX");
+        let native_token = Token::new(&native_address, "ETH", 18, 0, &[], Chain::Ethereum, 100);
+        let wrapped_token = Token::new(&wrapped_address, "WETH", 18, 0, &[], Chain::Ethereum, 100);
+
+        let token_store = Arc::new(TokenStore::new(
+            HashMap::from([
+                (wrapped_address.clone(), wrapped_token.clone()),
+                (native_address.clone(), native_token.clone()),
+                (token_x.address.clone(), token_x.clone()),
+            ]),
+            "http://localhost".to_string(),
+            "test".to_string(),
+            Chain::Ethereum,
+            Duration::from_secs(1),
+        ));
+        let native_state_store = Arc::new(StateStore::new(Arc::clone(&token_store)));
+        let vm_state_store = Arc::new(StateStore::new(Arc::clone(&token_store)));
+
+        native_state_store
+            .apply_update(mk_update(vec![(
+                "pool-native".to_string(),
+                mk_component(
+                    23,
+                    "rocketpool",
+                    "rocketpool",
+                    vec![native_token, token_x.clone()],
+                ),
+                Box::new(QuoteableSim),
+            )]))
+            .await;
+
+        let mut index_guard = native_state_store.token_index.write().await;
+        *index_guard = HashMap::from([
+            (
+                wrapped_address.clone(),
+                HashSet::from(["pool-stale".to_string()]),
+            ),
+            (
+                native_address.clone(),
+                HashSet::from(["pool-native".to_string()]),
+            ),
+            (
+                token_x.address.clone(),
+                HashSet::from(["pool-stale".to_string(), "pool-native".to_string()]),
+            ),
+        ]);
+        drop(index_guard);
+
+        let app_state = AppState {
+            tokens: Arc::clone(&token_store),
+            native_state_store,
+            vm_state_store,
+            native_stream_health: Arc::new(StreamHealth::new()),
+            vm_stream_health: Arc::new(StreamHealth::new()),
+            vm_stream: Arc::new(RwLock::new(VmStreamStatus::default())),
+            latest_native_gas_price_wei: Arc::new(RwLock::new(None)),
+            native_gas_price_reporting_enabled: Arc::new(RwLock::new(false)),
+            enable_vm_pools: false,
+            readiness_stale: Duration::from_secs(120),
+            quote_timeout: Duration::from_secs(1),
+            pool_timeout_native: Duration::from_millis(50),
+            pool_timeout_vm: Duration::from_millis(50),
+            request_timeout: Duration::from_secs(2),
+            native_sim_semaphore: Arc::new(tokio::sync::Semaphore::new(1)),
+            vm_sim_semaphore: Arc::new(tokio::sync::Semaphore::new(1)),
+            reset_allowance_tokens: Arc::new(HashMap::new()),
+            native_sim_concurrency: 1,
+            vm_sim_concurrency: 1,
+        };
+
+        let computation = get_amounts_out(
+            app_state,
+            AmountOutRequest {
+                request_id: "req-stale-alias-quote".to_string(),
+                auction_id: None,
+                token_in: wrapped_address.to_string(),
+                token_out: token_x.address.to_string(),
+                amounts: vec!["2".to_string()],
+            },
+            None,
+        )
+        .await;
+
+        assert_eq!(computation.responses.len(), 1);
+        assert_eq!(computation.responses[0].pool, "pool-native");
+        assert_eq!(computation.responses[0].amounts_out, vec!["2".to_string()]);
     }
 
     #[tokio::test]

--- a/src/services/encode.rs
+++ b/src/services/encode.rs
@@ -14,12 +14,15 @@ mod test_support;
 
 pub use error::{EncodeError, EncodeErrorKind};
 
+use tokio_util::sync::CancellationToken;
+
 use crate::models::messages::{RouteEncodeRequest, RouteEncodeResponse};
 use crate::models::state::AppState;
 
 pub async fn encode_route(
     state: AppState,
     request: RouteEncodeRequest,
+    request_cancel: Option<CancellationToken>,
 ) -> Result<RouteEncodeResponse, EncodeError> {
     let chain = request::validate_chain(request.chain_id)?;
     request::validate_swap_kinds(&request)?;
@@ -37,8 +40,15 @@ pub async fn encode_route(
     let is_native_input = token_in == native_address;
     let normalized =
         normalize::normalize_route(&request, &token_in, &token_out, &amount_in, &native_address)?;
-    let resimulated =
-        resimulate::resimulate_route(&state, &normalized, chain, &token_in, &token_out).await?;
+    let resimulated = resimulate::resimulate_route(
+        &state,
+        &normalized,
+        chain,
+        &token_in,
+        &token_out,
+        request_cancel.as_ref(),
+    )
+    .await?;
     response::log_resimulation_amounts(request.request_id.as_deref(), &resimulated);
     let encoder = calldata::build_encoder(chain, router_address.clone())?;
     let expected_total = response::compute_expected_total(&resimulated);

--- a/src/services/encode/resimulate.rs
+++ b/src/services/encode/resimulate.rs
@@ -14,7 +14,7 @@ use tycho_simulation::{
 
 use crate::models::state::AppState;
 use crate::services::native_wrapped::normalize_native_to_wrapped;
-use crate::services::pool_runtime::{run_blocking_pool_job, PermitAcquire, PoolJobError};
+use crate::services::pool_runtime::{run_blocking_pool_job, PoolJobError};
 
 use super::allocation::allocate_swaps_by_bps;
 use super::model::{
@@ -110,49 +110,60 @@ pub(super) async fn resimulate_route(
 
                 let pool_state = Arc::clone(&pool_entry.0);
                 let amount_in_for_sim = allocated.amount_in.clone();
-                let pool_timeout = if pool_entry.1.protocol_system.starts_with("vm:") {
+                let is_vm_pool = pool_entry.1.protocol_system.starts_with("vm:");
+                let pool_timeout = if is_vm_pool {
                     state.pool_timeout_vm()
                 } else {
                     state.pool_timeout_native()
                 };
+                let permit = if is_vm_pool {
+                    state
+                        .vm_sim_semaphore()
+                        .acquire_owned()
+                        .await
+                        .map_err(|_| {
+                            EncodeError::internal(format!(
+                                "Pool {} semaphore closed",
+                                allocated.pool.component_id
+                            ))
+                        })?
+                } else {
+                    state
+                        .native_sim_semaphore()
+                        .acquire_owned()
+                        .await
+                        .map_err(|_| {
+                            EncodeError::internal(format!(
+                                "Pool {} semaphore closed",
+                                allocated.pool.component_id
+                            ))
+                        })?
+                };
 
                 let component_id = allocated.pool.component_id.clone();
-                let (pre_state, result) = run_blocking_pool_job(
-                    state,
-                    &pool_entry.1.protocol_system,
-                    pool_timeout,
-                    PermitAcquire::Acquire,
-                    None,
-                    move |_| {
+                let (pre_state, result) =
+                    run_blocking_pool_job(permit, pool_timeout, None, move |_| {
                         let pre_state = pool_state;
                         let result =
                             pre_state.get_amount_out(amount_in_for_sim, &token_in, &token_out);
                         (pre_state, result)
-                    },
-                )
-                .await
-                .map_err(|error| match error {
-                    PoolJobError::TimedOut => EncodeError::simulation(format!(
-                        "Pool {} simulation timed out after {}ms",
-                        component_id,
-                        pool_timeout.as_millis()
-                    )),
-                    PoolJobError::Cancelled => EncodeError::simulation(format!(
-                        "Pool {} simulation cancelled",
-                        component_id
-                    )),
-                    PoolJobError::SemaphoreClosed => {
-                        EncodeError::internal(format!("Pool {} semaphore closed", component_id))
-                    }
-                    PoolJobError::JoinFailed(join_err) => EncodeError::internal(format!(
-                        "Pool {} simulation task failed: {}",
-                        component_id, join_err
-                    )),
-                    PoolJobError::NoPermit => EncodeError::internal(format!(
-                        "Pool {} unexpectedly skipped permit acquisition",
-                        component_id
-                    )),
-                })?;
+                    })
+                    .await
+                    .map_err(|error| match error {
+                        PoolJobError::TimedOut => EncodeError::simulation(format!(
+                            "Pool {} simulation timed out after {}ms",
+                            component_id,
+                            pool_timeout.as_millis()
+                        )),
+                        PoolJobError::Cancelled => EncodeError::simulation(format!(
+                            "Pool {} simulation cancelled",
+                            component_id
+                        )),
+                        PoolJobError::JoinFailed(join_err) => EncodeError::internal(format!(
+                            "Pool {} simulation task failed: {}",
+                            component_id, join_err
+                        )),
+                    })?;
                 let result = result.map_err(|err| {
                     EncodeError::simulation(format!(
                         "Pool {} simulation failed: {}",

--- a/src/services/encode/resimulate.rs
+++ b/src/services/encode/resimulate.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 
 use num_bigint::BigUint;
 use num_traits::Zero;
+use tokio::sync::OwnedSemaphorePermit;
+use tokio_util::sync::CancellationToken;
 use tycho_simulation::{
     protocol::models::ProtocolComponent,
     tycho_common::{
@@ -30,6 +32,7 @@ pub(super) async fn resimulate_route(
     chain: Chain,
     request_token_in: &Bytes,
     request_token_out: &Bytes,
+    request_cancel: Option<&CancellationToken>,
 ) -> Result<ResimulatedRouteInternal, EncodeError> {
     let mut token_cache = TokenCache::new(state);
     let mut pool_cache: HashMap<String, (Arc<dyn ProtocolSim>, Arc<ProtocolComponent>)> =
@@ -116,54 +119,42 @@ pub(super) async fn resimulate_route(
                 } else {
                     state.pool_timeout_native()
                 };
-                let permit = if is_vm_pool {
-                    state
-                        .vm_sim_semaphore()
-                        .acquire_owned()
-                        .await
-                        .map_err(|_| {
-                            EncodeError::internal(format!(
-                                "Pool {} semaphore closed",
-                                allocated.pool.component_id
-                            ))
-                        })?
-                } else {
-                    state
-                        .native_sim_semaphore()
-                        .acquire_owned()
-                        .await
-                        .map_err(|_| {
-                            EncodeError::internal(format!(
-                                "Pool {} semaphore closed",
-                                allocated.pool.component_id
-                            ))
-                        })?
-                };
+                let permit = acquire_pool_permit(
+                    state,
+                    is_vm_pool,
+                    allocated.pool.component_id.as_str(),
+                    request_cancel,
+                )
+                .await?;
 
                 let component_id = allocated.pool.component_id.clone();
-                let (pre_state, result) =
-                    run_blocking_pool_job(permit, pool_timeout, None, move |_| {
+                let (pre_state, result) = run_blocking_pool_job(
+                    permit,
+                    pool_timeout,
+                    request_cancel.map(CancellationToken::child_token),
+                    move |_| {
                         let pre_state = pool_state;
                         let result =
                             pre_state.get_amount_out(amount_in_for_sim, &token_in, &token_out);
                         (pre_state, result)
-                    })
-                    .await
-                    .map_err(|error| match error {
-                        PoolJobError::TimedOut => EncodeError::simulation(format!(
-                            "Pool {} simulation timed out after {}ms",
-                            component_id,
-                            pool_timeout.as_millis()
-                        )),
-                        PoolJobError::Cancelled => EncodeError::simulation(format!(
-                            "Pool {} simulation cancelled",
-                            component_id
-                        )),
-                        PoolJobError::JoinFailed(join_err) => EncodeError::internal(format!(
-                            "Pool {} simulation task failed: {}",
-                            component_id, join_err
-                        )),
-                    })?;
+                    },
+                )
+                .await
+                .map_err(|error| match error {
+                    PoolJobError::TimedOut => EncodeError::simulation(format!(
+                        "Pool {} simulation timed out after {}ms",
+                        component_id,
+                        pool_timeout.as_millis()
+                    )),
+                    PoolJobError::Cancelled => EncodeError::simulation(format!(
+                        "Pool {} simulation cancelled",
+                        component_id
+                    )),
+                    PoolJobError::JoinFailed(join_err) => EncodeError::internal(format!(
+                        "Pool {} simulation task failed: {}",
+                        component_id, join_err
+                    )),
+                })?;
                 let result = result.map_err(|err| {
                     EncodeError::simulation(format!(
                         "Pool {} simulation failed: {}",
@@ -282,6 +273,36 @@ fn ensure_native_swap_supported(
 
 fn map_swap_token(address: &Bytes, chain: Chain, keep_native_unwrapped: bool) -> Bytes {
     normalize_native_to_wrapped(address, chain, keep_native_unwrapped)
+}
+
+async fn acquire_pool_permit(
+    state: &AppState,
+    is_vm_pool: bool,
+    component_id: &str,
+    request_cancel: Option<&CancellationToken>,
+) -> Result<OwnedSemaphorePermit, EncodeError> {
+    let semaphore = if is_vm_pool {
+        state.vm_sim_semaphore()
+    } else {
+        state.native_sim_semaphore()
+    };
+
+    let acquire_result = if let Some(request_cancel) = request_cancel {
+        tokio::select! {
+            permit = semaphore.acquire_owned() => permit,
+            _ = request_cancel.cancelled() => {
+                return Err(EncodeError::simulation(format!(
+                    "Pool {} simulation cancelled",
+                    component_id
+                )));
+            }
+        }
+    } else {
+        semaphore.acquire_owned().await
+    };
+
+    acquire_result
+        .map_err(|_| EncodeError::internal(format!("Pool {} semaphore closed", component_id)))
 }
 
 struct TokenCache<'a> {
@@ -525,6 +546,7 @@ mod tests {
             Chain::Ethereum,
             &token_in.address,
             &token_out.address,
+            None,
         )
         .await
         .unwrap();
@@ -653,6 +675,7 @@ mod tests {
             Chain::Ethereum,
             &token_a.address,
             &token_c.address,
+            None,
         )
         .await
         .unwrap();
@@ -753,6 +776,7 @@ mod tests {
             Chain::Ethereum,
             &token_in.address,
             &token_out.address,
+            None,
         )
         .await
         {
@@ -859,6 +883,7 @@ mod tests {
             Chain::Ethereum,
             &token_in.address,
             &token_out.address,
+            None,
         )
         .await
         {
@@ -875,6 +900,137 @@ mod tests {
             "unexpected error: {}",
             err.message()
         );
+    }
+
+    #[test]
+    fn resimulate_route_cancels_while_waiting_for_blocking_worker() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .max_blocking_threads(1)
+            .build()
+            .expect("runtime");
+
+        runtime.block_on(async {
+            let token_in = dummy_token("0x0000000000000000000000000000000000000001");
+            let token_out = dummy_token("0x0000000000000000000000000000000000000002");
+            let mut tokens = HashMap::new();
+            tokens.insert(token_in.address.clone(), token_in.clone());
+            tokens.insert(token_out.address.clone(), token_out.clone());
+
+            let tokens_store = Arc::new(TokenStore::new(
+                tokens,
+                "http://localhost".to_string(),
+                "test".to_string(),
+                Chain::Ethereum,
+                Duration::from_millis(10),
+            ));
+            let native_state_store = Arc::new(StateStore::new(Arc::clone(&tokens_store)));
+            let vm_state_store = Arc::new(StateStore::new(Arc::clone(&tokens_store)));
+
+            let component = ProtocolComponent::new(
+                Bytes::from_str("0x0000000000000000000000000000000000000009").unwrap(),
+                "uniswap_v2".to_string(),
+                "uniswap_v2".to_string(),
+                Chain::Ethereum,
+                vec![token_in.clone(), token_out.clone()],
+                Vec::new(),
+                HashMap::new(),
+                Bytes::default(),
+                NaiveDateTime::default(),
+            );
+            let mut states = HashMap::new();
+            states.insert(
+                "pool-fast".to_string(),
+                Box::new(StepProtocolSim { multiplier: 1 }) as Box<dyn ProtocolSim>,
+            );
+            let mut new_pairs = HashMap::new();
+            new_pairs.insert("pool-fast".to_string(), component);
+            native_state_store
+                .apply_update(Update::new(1, states, new_pairs))
+                .await;
+
+            let app_state = AppState {
+                tokens: Arc::clone(&tokens_store),
+                native_state_store: Arc::clone(&native_state_store),
+                vm_state_store: Arc::clone(&vm_state_store),
+                native_stream_health: Arc::new(StreamHealth::new()),
+                vm_stream_health: Arc::new(StreamHealth::new()),
+                vm_stream: Arc::new(tokio::sync::RwLock::new(VmStreamStatus::default())),
+                latest_native_gas_price_wei: Arc::new(tokio::sync::RwLock::new(None)),
+                native_gas_price_reporting_enabled: Arc::new(tokio::sync::RwLock::new(false)),
+                enable_vm_pools: false,
+                readiness_stale: Duration::from_secs(120),
+                quote_timeout: Duration::from_millis(1000),
+                pool_timeout_native: Duration::from_millis(200),
+                pool_timeout_vm: Duration::from_millis(1000),
+                request_timeout: Duration::from_millis(1000),
+                native_sim_semaphore: Arc::new(Semaphore::new(1)),
+                vm_sim_semaphore: Arc::new(Semaphore::new(1)),
+                reset_allowance_tokens: Arc::new(HashMap::new()),
+                native_sim_concurrency: 1,
+                vm_sim_concurrency: 1,
+            };
+
+            let normalized = NormalizedRouteInternal {
+                segments: vec![NormalizedSegmentInternal {
+                    share_bps: 10_000,
+                    amount_in: BigUint::from(10u32),
+                    hops: vec![NormalizedHopInternal {
+                        token_in: token_in.address.clone(),
+                        token_out: token_out.address.clone(),
+                        swaps: vec![NormalizedSwapDraftInternal {
+                            pool: pool_ref("pool-fast"),
+                            token_in: token_in.address.clone(),
+                            token_out: token_out.address.clone(),
+                            split_bps: 0,
+                        }],
+                    }],
+                }],
+            };
+
+            let (occupier_started_tx, occupier_started_rx) = tokio::sync::oneshot::channel();
+            let occupier = tokio::task::spawn_blocking(move || {
+                let _ = occupier_started_tx.send(());
+                std::thread::sleep(Duration::from_millis(80));
+            });
+            occupier_started_rx.await.expect("occupier should start");
+
+            let cancel = CancellationToken::new();
+            let cancel_for_task = cancel.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                cancel_for_task.cancel();
+            });
+
+            let started_at = std::time::Instant::now();
+            let err = match resimulate_route(
+                &app_state,
+                &normalized,
+                Chain::Ethereum,
+                &token_in.address,
+                &token_out.address,
+                Some(&cancel),
+            )
+            .await
+            {
+                Ok(_) => panic!("queued route should be cancelled"),
+                Err(err) => err,
+            };
+            let elapsed = started_at.elapsed();
+
+            occupier.await.expect("occupier should finish");
+
+            assert!(elapsed < Duration::from_millis(50));
+            assert_eq!(
+                err.kind(),
+                crate::services::encode::EncodeErrorKind::Simulation
+            );
+            assert!(
+                err.message().contains("pool-fast") && err.message().contains("cancelled"),
+                "unexpected error: {}",
+                err.message()
+            );
+        });
     }
 
     #[test]
@@ -976,6 +1132,7 @@ mod tests {
                 Chain::Ethereum,
                 &token_in.address,
                 &token_out.address,
+                None,
             )
             .await
             .expect("queued route should still resimulate");

--- a/src/services/encode/resimulate.rs
+++ b/src/services/encode/resimulate.rs
@@ -3,8 +3,6 @@ use std::sync::Arc;
 
 use num_bigint::BigUint;
 use num_traits::Zero;
-use tokio::task::spawn_blocking;
-use tokio::time::sleep;
 use tycho_simulation::{
     protocol::models::ProtocolComponent,
     tycho_common::{
@@ -15,6 +13,8 @@ use tycho_simulation::{
 };
 
 use crate::models::state::AppState;
+use crate::services::native_wrapped::normalize_native_to_wrapped;
+use crate::services::pool_runtime::{run_blocking_pool_job, PermitAcquire, PoolJobError};
 
 use super::allocation::allocate_swaps_by_bps;
 use super::model::{
@@ -108,72 +108,51 @@ pub(super) async fn resimulate_route(
                 let token_in = token_cache.get(&sim_token_in).await?;
                 let token_out = token_cache.get(&sim_token_out).await?;
 
-                // Offload pool simulation to the blocking pool (VM pools can be CPU-heavy).
-                //
-                // Mirror `/simulate` guardrails: hold a semaphore permit inside the blocking task
-                // so timeouts/cancellation don't accidentally uncap concurrent CPU-bound work.
-                let is_vm = pool_entry.1.protocol_system.starts_with("vm:");
-                let permit = if is_vm {
-                    state
-                        .vm_sim_semaphore()
-                        .acquire_owned()
-                        .await
-                        .map_err(|_| EncodeError::internal("VM pool semaphore closed"))?
-                } else {
-                    state
-                        .native_sim_semaphore()
-                        .acquire_owned()
-                        .await
-                        .map_err(|_| EncodeError::internal("Native pool semaphore closed"))?
-                };
                 let pool_state = Arc::clone(&pool_entry.0);
                 let amount_in_for_sim = allocated.amount_in.clone();
-                let pool_timeout = if is_vm {
+                let pool_timeout = if pool_entry.1.protocol_system.starts_with("vm:") {
                     state.pool_timeout_vm()
                 } else {
                     state.pool_timeout_native()
                 };
 
-                let handle = spawn_blocking(move || {
-                    // Hold the permit until the blocking work exits.
-                    let _permit = permit;
-                    // Move the pool state into the blocking task and return it so the caller can
-                    // attach it to the response without an extra clone.
-                    let pre_state = pool_state;
-                    let result = pre_state.get_amount_out(amount_in_for_sim, &token_in, &token_out);
-                    (pre_state, result)
-                });
-                tokio::pin!(handle);
-
-                let (pre_state, result) = tokio::select! {
-                    res = handle.as_mut() => {
-                        res.map_err(|join_err| {
-                            let reason = if join_err.is_panic() {
-                                "panicked"
-                            } else if join_err.is_cancelled() {
-                                "was cancelled"
-                            } else {
-                                "failed"
-                            };
-                            EncodeError::internal(format!(
-                                "Pool {} simulation task {}: {}",
-                                allocated.pool.component_id, reason, join_err
-                            ))
-                        })?
+                let component_id = allocated.pool.component_id.clone();
+                let (pre_state, result) = run_blocking_pool_job(
+                    state,
+                    &pool_entry.1.protocol_system,
+                    pool_timeout,
+                    PermitAcquire::Acquire,
+                    None,
+                    move |_| {
+                        let pre_state = pool_state;
+                        let result =
+                            pre_state.get_amount_out(amount_in_for_sim, &token_in, &token_out);
+                        (pre_state, result)
+                    },
+                )
+                .await
+                .map_err(|error| match error {
+                    PoolJobError::TimedOut => EncodeError::simulation(format!(
+                        "Pool {} simulation timed out after {}ms",
+                        component_id,
+                        pool_timeout.as_millis()
+                    )),
+                    PoolJobError::Cancelled => EncodeError::simulation(format!(
+                        "Pool {} simulation cancelled",
+                        component_id
+                    )),
+                    PoolJobError::SemaphoreClosed => {
+                        EncodeError::internal(format!("Pool {} semaphore closed", component_id))
                     }
-                    _ = sleep(pool_timeout) => {
-                        // Best-effort attempt to stop waiting on the blocking task after a pool-level
-                        // timeout; this doesn't reliably prevent `spawn_blocking` work from running
-                        // once scheduled. The semaphore permit is held inside the closure to cap
-                        // concurrent CPU usage even if the task keeps running.
-                        handle.as_mut().abort();
-                        return Err(EncodeError::simulation(format!(
-                            "Pool {} simulation timed out after {}ms",
-                            allocated.pool.component_id,
-                            pool_timeout.as_millis()
-                        )));
-                    }
-                };
+                    PoolJobError::JoinFailed(join_err) => EncodeError::internal(format!(
+                        "Pool {} simulation task failed: {}",
+                        component_id, join_err
+                    )),
+                    PoolJobError::NoPermit => EncodeError::internal(format!(
+                        "Pool {} unexpectedly skipped permit acquisition",
+                        component_id
+                    )),
+                })?;
                 let result = result.map_err(|err| {
                     EncodeError::simulation(format!(
                         "Pool {} simulation failed: {}",
@@ -291,11 +270,7 @@ fn ensure_native_swap_supported(
 }
 
 fn map_swap_token(address: &Bytes, chain: Chain, keep_native_unwrapped: bool) -> Bytes {
-    if !keep_native_unwrapped && *address == chain.native_token().address {
-        chain.wrapped_native_token().address
-    } else {
-        address.clone()
-    }
+    normalize_native_to_wrapped(address, chain, keep_native_unwrapped)
 }
 
 struct TokenCache<'a> {
@@ -889,5 +864,117 @@ mod tests {
             "unexpected error: {}",
             err.message()
         );
+    }
+
+    #[test]
+    fn resimulate_route_waits_for_blocking_thread_before_starting_timeout() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .max_blocking_threads(1)
+            .build()
+            .expect("runtime");
+
+        runtime.block_on(async {
+            let token_in = dummy_token("0x0000000000000000000000000000000000000001");
+            let token_out = dummy_token("0x0000000000000000000000000000000000000002");
+            let mut tokens = HashMap::new();
+            tokens.insert(token_in.address.clone(), token_in.clone());
+            tokens.insert(token_out.address.clone(), token_out.clone());
+
+            let tokens_store = Arc::new(TokenStore::new(
+                tokens,
+                "http://localhost".to_string(),
+                "test".to_string(),
+                Chain::Ethereum,
+                Duration::from_millis(10),
+            ));
+            let native_state_store = Arc::new(StateStore::new(Arc::clone(&tokens_store)));
+            let vm_state_store = Arc::new(StateStore::new(Arc::clone(&tokens_store)));
+
+            let component = ProtocolComponent::new(
+                Bytes::from_str("0x0000000000000000000000000000000000000009").unwrap(),
+                "uniswap_v2".to_string(),
+                "uniswap_v2".to_string(),
+                Chain::Ethereum,
+                vec![token_in.clone(), token_out.clone()],
+                Vec::new(),
+                HashMap::new(),
+                Bytes::default(),
+                NaiveDateTime::default(),
+            );
+            let mut states = HashMap::new();
+            states.insert(
+                "pool-fast".to_string(),
+                Box::new(StepProtocolSim { multiplier: 1 }) as Box<dyn ProtocolSim>,
+            );
+            let mut new_pairs = HashMap::new();
+            new_pairs.insert("pool-fast".to_string(), component);
+            native_state_store
+                .apply_update(Update::new(1, states, new_pairs))
+                .await;
+
+            let app_state = AppState {
+                tokens: Arc::clone(&tokens_store),
+                native_state_store: Arc::clone(&native_state_store),
+                vm_state_store: Arc::clone(&vm_state_store),
+                native_stream_health: Arc::new(StreamHealth::new()),
+                vm_stream_health: Arc::new(StreamHealth::new()),
+                vm_stream: Arc::new(tokio::sync::RwLock::new(VmStreamStatus::default())),
+                latest_native_gas_price_wei: Arc::new(tokio::sync::RwLock::new(None)),
+                native_gas_price_reporting_enabled: Arc::new(tokio::sync::RwLock::new(false)),
+                enable_vm_pools: false,
+                readiness_stale: Duration::from_secs(120),
+                quote_timeout: Duration::from_millis(1000),
+                pool_timeout_native: Duration::from_millis(20),
+                pool_timeout_vm: Duration::from_millis(1000),
+                request_timeout: Duration::from_millis(1000),
+                native_sim_semaphore: Arc::new(Semaphore::new(1)),
+                vm_sim_semaphore: Arc::new(Semaphore::new(1)),
+                reset_allowance_tokens: Arc::new(HashMap::new()),
+                native_sim_concurrency: 1,
+                vm_sim_concurrency: 1,
+            };
+
+            let normalized = NormalizedRouteInternal {
+                segments: vec![NormalizedSegmentInternal {
+                    share_bps: 10_000,
+                    amount_in: BigUint::from(10u32),
+                    hops: vec![NormalizedHopInternal {
+                        token_in: token_in.address.clone(),
+                        token_out: token_out.address.clone(),
+                        swaps: vec![NormalizedSwapDraftInternal {
+                            pool: pool_ref("pool-fast"),
+                            token_in: token_in.address.clone(),
+                            token_out: token_out.address.clone(),
+                            split_bps: 0,
+                        }],
+                    }],
+                }],
+            };
+
+            let (occupier_started_tx, occupier_started_rx) = tokio::sync::oneshot::channel();
+            let occupier = tokio::task::spawn_blocking(move || {
+                let _ = occupier_started_tx.send(());
+                std::thread::sleep(Duration::from_millis(60));
+            });
+            occupier_started_rx.await.expect("occupier should start");
+
+            let resimulated = resimulate_route(
+                &app_state,
+                &normalized,
+                Chain::Ethereum,
+                &token_in.address,
+                &token_out.address,
+            )
+            .await
+            .expect("queued route should still resimulate");
+
+            occupier.await.expect("occupier should finish");
+
+            assert_eq!(
+                resimulated.segments[0].hops[0].swaps[0].expected_amount_out,
+                BigUint::from(10u32)
+            );
+        });
     }
 }

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,4 +1,6 @@
 pub mod encode;
 pub mod gas_price;
+pub(crate) mod native_wrapped;
+pub(crate) mod pool_runtime;
 pub mod quotes;
 pub mod stream_builder;

--- a/src/services/native_wrapped.rs
+++ b/src/services/native_wrapped.rs
@@ -1,0 +1,86 @@
+use tycho_simulation::{
+    protocol::models::ProtocolComponent,
+    tycho_common::{
+        models::{token::Token, Chain},
+        Bytes,
+    },
+};
+
+const NATIVE_TOKEN_ADDRESS_BYTES: [u8; 20] = [0u8; 20];
+
+pub(crate) fn native_token_address() -> Bytes {
+    Bytes::from(NATIVE_TOKEN_ADDRESS_BYTES)
+}
+
+pub(crate) fn is_native_or_wrapped_token(token: &Token) -> bool {
+    let native = token.chain.native_token();
+    let wrapped_native = token.chain.wrapped_native_token();
+    token.address == native.address || token.address == wrapped_native.address
+}
+
+pub(crate) fn is_direct_native_wrapped_pair(
+    token_in: &Bytes,
+    token_out: &Bytes,
+    wrapped_native: Option<&Bytes>,
+) -> bool {
+    let Some(wrapped_native) = wrapped_native else {
+        return false;
+    };
+
+    (token_in == &native_token_address() && token_out == wrapped_native)
+        || (token_in == wrapped_native && token_out == &native_token_address())
+}
+
+pub(crate) fn simulation_tokens_for_pool(
+    request_token_in: &Token,
+    request_token_out: &Token,
+    component: &ProtocolComponent,
+) -> (Token, Token) {
+    (
+        remap_request_token_for_pool(request_token_in, component),
+        remap_request_token_for_pool(request_token_out, component),
+    )
+}
+
+pub(crate) fn remap_request_token_for_pool(
+    request_token: &Token,
+    component: &ProtocolComponent,
+) -> Token {
+    let native = request_token.chain.native_token();
+    let wrapped_native = request_token.chain.wrapped_native_token();
+
+    if native.address == wrapped_native.address {
+        return request_token.clone();
+    }
+
+    let pool_has_native = component
+        .tokens
+        .iter()
+        .any(|token| token.address == native.address);
+    let pool_has_wrapped = component
+        .tokens
+        .iter()
+        .any(|token| token.address == wrapped_native.address);
+
+    if request_token.address == wrapped_native.address && pool_has_native && !pool_has_wrapped {
+        return native;
+    }
+
+    if request_token.address == native.address && pool_has_wrapped && !pool_has_native {
+        return wrapped_native;
+    }
+
+    request_token.clone()
+}
+
+pub(crate) fn normalize_native_to_wrapped(
+    address: &Bytes,
+    chain: Chain,
+    keep_native_unwrapped: bool,
+) -> Bytes {
+    if !keep_native_unwrapped && *address == chain.native_token().address {
+        chain.wrapped_native_token().address
+    } else {
+        address.clone()
+    }
+}

--- a/src/services/native_wrapped.rs
+++ b/src/services/native_wrapped.rs
@@ -12,12 +12,6 @@ pub(crate) fn native_token_address() -> Bytes {
     Bytes::from(NATIVE_TOKEN_ADDRESS_BYTES)
 }
 
-pub(crate) fn is_native_or_wrapped_token(token: &Token) -> bool {
-    let native = token.chain.native_token();
-    let wrapped_native = token.chain.wrapped_native_token();
-    token.address == native.address || token.address == wrapped_native.address
-}
-
 pub(crate) fn is_direct_native_wrapped_pair(
     token_in: &Bytes,
     token_out: &Bytes,

--- a/src/services/pool_runtime.rs
+++ b/src/services/pool_runtime.rs
@@ -1,32 +1,20 @@
 use std::time::{Duration, Instant};
 
-use tokio::sync::{AcquireError, TryAcquireError};
+use tokio::sync::OwnedSemaphorePermit;
 use tokio::task::spawn_blocking;
 use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 
-use crate::models::state::AppState;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum PermitAcquire {
-    Acquire,
-    TryAcquire,
-}
-
 #[derive(Debug)]
 pub(crate) enum PoolJobError {
-    NoPermit,
-    SemaphoreClosed,
     TimedOut,
     Cancelled,
     JoinFailed(tokio::task::JoinError),
 }
 
 pub(crate) async fn run_blocking_pool_job<T, F>(
-    state: &AppState,
-    pool_protocol: &str,
+    permit: OwnedSemaphorePermit,
     pool_timeout: Duration,
-    acquire_mode: PermitAcquire,
     cancel_token: Option<CancellationToken>,
     job: F,
 ) -> Result<T, PoolJobError>
@@ -34,13 +22,6 @@ where
     T: Send + 'static,
     F: FnOnce(Instant) -> T + Send + 'static,
 {
-    let permit = match acquire_mode {
-        PermitAcquire::Acquire => {
-            acquire_permit(state, pool_protocol, cancel_token.as_ref()).await?
-        }
-        PermitAcquire::TryAcquire => try_acquire_permit(state, pool_protocol)?,
-    };
-
     let (started_tx, started_rx) = tokio::sync::oneshot::channel();
     let handle = spawn_blocking(move || {
         let _permit = permit;
@@ -77,53 +58,6 @@ where
                 Err(PoolJobError::TimedOut)
             }
         }
-    }
-}
-
-async fn acquire_permit(
-    state: &AppState,
-    pool_protocol: &str,
-    cancel_token: Option<&CancellationToken>,
-) -> Result<tokio::sync::OwnedSemaphorePermit, PoolJobError> {
-    let semaphore = semaphore_for_protocol(state, pool_protocol);
-    if let Some(cancel_token) = cancel_token {
-        tokio::select! {
-            permit = semaphore.acquire_owned() => permit.map_err(map_acquire_error),
-            _ = cancel_token.cancelled() => Err(PoolJobError::Cancelled),
-        }
-    } else {
-        semaphore.acquire_owned().await.map_err(map_acquire_error)
-    }
-}
-
-fn try_acquire_permit(
-    state: &AppState,
-    pool_protocol: &str,
-) -> Result<tokio::sync::OwnedSemaphorePermit, PoolJobError> {
-    semaphore_for_protocol(state, pool_protocol)
-        .try_acquire_owned()
-        .map_err(map_try_acquire_error)
-}
-
-fn semaphore_for_protocol(
-    state: &AppState,
-    pool_protocol: &str,
-) -> std::sync::Arc<tokio::sync::Semaphore> {
-    if pool_protocol.starts_with("vm:") {
-        state.vm_sim_semaphore()
-    } else {
-        state.native_sim_semaphore()
-    }
-}
-
-fn map_acquire_error(_: AcquireError) -> PoolJobError {
-    PoolJobError::SemaphoreClosed
-}
-
-fn map_try_acquire_error(error: TryAcquireError) -> PoolJobError {
-    match error {
-        TryAcquireError::NoPermits => PoolJobError::NoPermit,
-        TryAcquireError::Closed => PoolJobError::SemaphoreClosed,
     }
 }
 
@@ -170,52 +104,13 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
     use std::time::Duration;
 
-    use tokio::sync::{RwLock, Semaphore};
-    use tycho_simulation::tycho_common::models::Chain;
+    use tokio::sync::Semaphore;
 
-    use super::{run_blocking_pool_job, PermitAcquire, PoolJobError};
-    use crate::models::state::{AppState, StateStore, VmStreamStatus};
-    use crate::models::stream_health::StreamHealth;
-    use crate::models::tokens::TokenStore;
-
-    fn test_app_state(native_permits: usize, vm_permits: usize) -> AppState {
-        let token_store = Arc::new(TokenStore::new(
-            HashMap::new(),
-            "http://localhost".to_string(),
-            "test".to_string(),
-            Chain::Ethereum,
-            Duration::from_secs(1),
-        ));
-        let native_state_store = Arc::new(StateStore::new(Arc::clone(&token_store)));
-        let vm_state_store = Arc::new(StateStore::new(Arc::clone(&token_store)));
-
-        AppState {
-            tokens: token_store,
-            native_state_store,
-            vm_state_store,
-            native_stream_health: Arc::new(StreamHealth::new()),
-            vm_stream_health: Arc::new(StreamHealth::new()),
-            vm_stream: Arc::new(RwLock::new(VmStreamStatus::default())),
-            latest_native_gas_price_wei: Arc::new(RwLock::new(None)),
-            native_gas_price_reporting_enabled: Arc::new(RwLock::new(false)),
-            enable_vm_pools: true,
-            readiness_stale: Duration::from_secs(120),
-            quote_timeout: Duration::from_secs(1),
-            pool_timeout_native: Duration::from_millis(50),
-            pool_timeout_vm: Duration::from_millis(50),
-            request_timeout: Duration::from_secs(1),
-            native_sim_semaphore: Arc::new(Semaphore::new(native_permits)),
-            vm_sim_semaphore: Arc::new(Semaphore::new(vm_permits)),
-            reset_allowance_tokens: Arc::new(HashMap::new()),
-            native_sim_concurrency: native_permits,
-            vm_sim_concurrency: vm_permits,
-        }
-    }
+    use super::run_blocking_pool_job;
 
     #[test]
     fn timeout_starts_after_blocking_work_really_begins() {
@@ -226,7 +121,6 @@ mod tests {
             .expect("runtime");
 
         runtime.block_on(async {
-            let state = test_app_state(1, 1);
             let (occupier_started_tx, occupier_started_rx) = tokio::sync::oneshot::channel();
             let occupier = tokio::task::spawn_blocking(move || {
                 let _ = occupier_started_tx.send(());
@@ -234,22 +128,20 @@ mod tests {
             });
             occupier_started_rx.await.expect("occupier should start");
 
+            let permit = Arc::new(Semaphore::new(1))
+                .acquire_owned()
+                .await
+                .expect("permit should be available");
             let started = Arc::new(AtomicBool::new(false));
             let started_flag = Arc::clone(&started);
             let started_at = std::time::Instant::now();
-            let result = run_blocking_pool_job(
-                &state,
-                "uniswap_v2",
-                Duration::from_millis(20),
-                PermitAcquire::TryAcquire,
-                None,
-                move |_| {
+            let result =
+                run_blocking_pool_job(permit, Duration::from_millis(20), None, move |_| {
                     started_flag.store(true, Ordering::SeqCst);
                     std::thread::sleep(Duration::from_millis(5));
                     7usize
-                },
-            )
-            .await;
+                })
+                .await;
 
             occupier.await.expect("occupier should finish");
 
@@ -257,81 +149,5 @@ mod tests {
             assert!(started.load(Ordering::SeqCst));
             assert!(started_at.elapsed() >= Duration::from_millis(60));
         });
-    }
-
-    #[tokio::test]
-    async fn try_acquire_reports_no_permit() {
-        let state = test_app_state(0, 1);
-        let result = run_blocking_pool_job(
-            &state,
-            "uniswap_v2",
-            Duration::from_millis(10),
-            PermitAcquire::TryAcquire,
-            None,
-            |_| 1usize,
-        )
-        .await;
-
-        assert!(matches!(result, Err(PoolJobError::NoPermit)));
-    }
-
-    #[tokio::test]
-    async fn helper_uses_protocol_specific_semaphore() {
-        let state = test_app_state(0, 1);
-        let vm_runs = Arc::new(AtomicUsize::new(0));
-        let vm_runs_clone = Arc::clone(&vm_runs);
-        let vm_result = run_blocking_pool_job(
-            &state,
-            "vm:curve",
-            Duration::from_millis(10),
-            PermitAcquire::TryAcquire,
-            None,
-            move |_| {
-                vm_runs_clone.fetch_add(1, Ordering::SeqCst);
-            },
-        )
-        .await;
-
-        assert!(vm_result.is_ok());
-        assert_eq!(vm_runs.load(Ordering::SeqCst), 1);
-
-        let native_result = run_blocking_pool_job(
-            &state,
-            "uniswap_v2",
-            Duration::from_millis(10),
-            PermitAcquire::TryAcquire,
-            None,
-            |_| (),
-        )
-        .await;
-
-        assert!(matches!(native_result, Err(PoolJobError::NoPermit)));
-    }
-
-    #[tokio::test]
-    async fn acquire_mode_waits_for_permit_before_starting_timeout() {
-        let state = test_app_state(0, 1);
-        let semaphore = state.native_sim_semaphore();
-        tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(40)).await;
-            semaphore.add_permits(1);
-        });
-
-        let started_at = std::time::Instant::now();
-        let result = run_blocking_pool_job(
-            &state,
-            "uniswap_v2",
-            Duration::from_millis(10),
-            PermitAcquire::Acquire,
-            None,
-            |_| {
-                std::thread::sleep(Duration::from_millis(5));
-                11usize
-            },
-        )
-        .await;
-
-        assert_eq!(result.expect("job should succeed after permit release"), 11);
-        assert!(started_at.elapsed() >= Duration::from_millis(40));
     }
 }

--- a/src/services/pool_runtime.rs
+++ b/src/services/pool_runtime.rs
@@ -1,0 +1,337 @@
+use std::time::{Duration, Instant};
+
+use tokio::sync::{AcquireError, TryAcquireError};
+use tokio::task::spawn_blocking;
+use tokio::time::sleep;
+use tokio_util::sync::CancellationToken;
+
+use crate::models::state::AppState;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PermitAcquire {
+    Acquire,
+    TryAcquire,
+}
+
+#[derive(Debug)]
+pub(crate) enum PoolJobError {
+    NoPermit,
+    SemaphoreClosed,
+    TimedOut,
+    Cancelled,
+    JoinFailed(tokio::task::JoinError),
+}
+
+pub(crate) async fn run_blocking_pool_job<T, F>(
+    state: &AppState,
+    pool_protocol: &str,
+    pool_timeout: Duration,
+    acquire_mode: PermitAcquire,
+    cancel_token: Option<CancellationToken>,
+    job: F,
+) -> Result<T, PoolJobError>
+where
+    T: Send + 'static,
+    F: FnOnce(Instant) -> T + Send + 'static,
+{
+    let permit = match acquire_mode {
+        PermitAcquire::Acquire => {
+            acquire_permit(state, pool_protocol, cancel_token.as_ref()).await?
+        }
+        PermitAcquire::TryAcquire => try_acquire_permit(state, pool_protocol)?,
+    };
+
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+    let handle = spawn_blocking(move || {
+        let _permit = permit;
+        let started_at = Instant::now();
+        let _ = started_tx.send(started_at);
+        job(started_at)
+    });
+    tokio::pin!(handle);
+
+    wait_for_start(&mut handle, started_rx, cancel_token.as_ref()).await?;
+    let timeout_sleep = sleep(pool_timeout);
+    tokio::pin!(timeout_sleep);
+
+    if let Some(cancel_token) = cancel_token.as_ref() {
+        tokio::select! {
+            result = handle.as_mut() => result.map_err(PoolJobError::JoinFailed),
+            _ = &mut timeout_sleep => {
+                // Best-effort only: started `spawn_blocking` work can keep running after timeout.
+                handle.as_mut().abort();
+                Err(PoolJobError::TimedOut)
+            }
+            _ = cancel_token.cancelled() => {
+                // Started blocking jobs can keep running after this future stops waiting on them.
+                handle.as_mut().abort();
+                Err(PoolJobError::Cancelled)
+            }
+        }
+    } else {
+        tokio::select! {
+            result = handle.as_mut() => result.map_err(PoolJobError::JoinFailed),
+            _ = &mut timeout_sleep => {
+                // Best-effort only: started `spawn_blocking` work can keep running after timeout.
+                handle.as_mut().abort();
+                Err(PoolJobError::TimedOut)
+            }
+        }
+    }
+}
+
+async fn acquire_permit(
+    state: &AppState,
+    pool_protocol: &str,
+    cancel_token: Option<&CancellationToken>,
+) -> Result<tokio::sync::OwnedSemaphorePermit, PoolJobError> {
+    let semaphore = semaphore_for_protocol(state, pool_protocol);
+    if let Some(cancel_token) = cancel_token {
+        tokio::select! {
+            permit = semaphore.acquire_owned() => permit.map_err(map_acquire_error),
+            _ = cancel_token.cancelled() => Err(PoolJobError::Cancelled),
+        }
+    } else {
+        semaphore.acquire_owned().await.map_err(map_acquire_error)
+    }
+}
+
+fn try_acquire_permit(
+    state: &AppState,
+    pool_protocol: &str,
+) -> Result<tokio::sync::OwnedSemaphorePermit, PoolJobError> {
+    semaphore_for_protocol(state, pool_protocol)
+        .try_acquire_owned()
+        .map_err(map_try_acquire_error)
+}
+
+fn semaphore_for_protocol(
+    state: &AppState,
+    pool_protocol: &str,
+) -> std::sync::Arc<tokio::sync::Semaphore> {
+    if pool_protocol.starts_with("vm:") {
+        state.vm_sim_semaphore()
+    } else {
+        state.native_sim_semaphore()
+    }
+}
+
+fn map_acquire_error(_: AcquireError) -> PoolJobError {
+    PoolJobError::SemaphoreClosed
+}
+
+fn map_try_acquire_error(error: TryAcquireError) -> PoolJobError {
+    match error {
+        TryAcquireError::NoPermits => PoolJobError::NoPermit,
+        TryAcquireError::Closed => PoolJobError::SemaphoreClosed,
+    }
+}
+
+async fn wait_for_start<T>(
+    handle: &mut std::pin::Pin<&mut tokio::task::JoinHandle<T>>,
+    started_rx: tokio::sync::oneshot::Receiver<Instant>,
+    cancel_token: Option<&CancellationToken>,
+) -> Result<(), PoolJobError>
+where
+    T: Send + 'static,
+{
+    if let Some(cancel_token) = cancel_token {
+        tokio::select! {
+            biased;
+            started = started_rx => started
+                .map(|_| ())
+                .map_err(|_| panic!("blocking job ended before sending a start signal")),
+            result = handle.as_mut() => {
+                match result {
+                    Ok(_) => panic!("blocking job completed before sending a start signal"),
+                    Err(join_err) => Err(PoolJobError::JoinFailed(join_err)),
+                }
+            }
+            _ = cancel_token.cancelled() => {
+                handle.as_mut().abort();
+                Err(PoolJobError::Cancelled)
+            }
+        }
+    } else {
+        tokio::select! {
+            biased;
+            started = started_rx => started
+                .map(|_| ())
+                .map_err(|_| panic!("blocking job ended before sending a start signal")),
+            result = handle.as_mut() => {
+                match result {
+                    Ok(_) => panic!("blocking job completed before sending a start signal"),
+                    Err(join_err) => Err(PoolJobError::JoinFailed(join_err)),
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio::sync::{RwLock, Semaphore};
+    use tycho_simulation::tycho_common::models::Chain;
+
+    use super::{run_blocking_pool_job, PermitAcquire, PoolJobError};
+    use crate::models::state::{AppState, StateStore, VmStreamStatus};
+    use crate::models::stream_health::StreamHealth;
+    use crate::models::tokens::TokenStore;
+
+    fn test_app_state(native_permits: usize, vm_permits: usize) -> AppState {
+        let token_store = Arc::new(TokenStore::new(
+            HashMap::new(),
+            "http://localhost".to_string(),
+            "test".to_string(),
+            Chain::Ethereum,
+            Duration::from_secs(1),
+        ));
+        let native_state_store = Arc::new(StateStore::new(Arc::clone(&token_store)));
+        let vm_state_store = Arc::new(StateStore::new(Arc::clone(&token_store)));
+
+        AppState {
+            tokens: token_store,
+            native_state_store,
+            vm_state_store,
+            native_stream_health: Arc::new(StreamHealth::new()),
+            vm_stream_health: Arc::new(StreamHealth::new()),
+            vm_stream: Arc::new(RwLock::new(VmStreamStatus::default())),
+            latest_native_gas_price_wei: Arc::new(RwLock::new(None)),
+            native_gas_price_reporting_enabled: Arc::new(RwLock::new(false)),
+            enable_vm_pools: true,
+            readiness_stale: Duration::from_secs(120),
+            quote_timeout: Duration::from_secs(1),
+            pool_timeout_native: Duration::from_millis(50),
+            pool_timeout_vm: Duration::from_millis(50),
+            request_timeout: Duration::from_secs(1),
+            native_sim_semaphore: Arc::new(Semaphore::new(native_permits)),
+            vm_sim_semaphore: Arc::new(Semaphore::new(vm_permits)),
+            reset_allowance_tokens: Arc::new(HashMap::new()),
+            native_sim_concurrency: native_permits,
+            vm_sim_concurrency: vm_permits,
+        }
+    }
+
+    #[test]
+    fn timeout_starts_after_blocking_work_really_begins() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .max_blocking_threads(1)
+            .build()
+            .expect("runtime");
+
+        runtime.block_on(async {
+            let state = test_app_state(1, 1);
+            let (occupier_started_tx, occupier_started_rx) = tokio::sync::oneshot::channel();
+            let occupier = tokio::task::spawn_blocking(move || {
+                let _ = occupier_started_tx.send(());
+                std::thread::sleep(Duration::from_millis(60));
+            });
+            occupier_started_rx.await.expect("occupier should start");
+
+            let started = Arc::new(AtomicBool::new(false));
+            let started_flag = Arc::clone(&started);
+            let started_at = std::time::Instant::now();
+            let result = run_blocking_pool_job(
+                &state,
+                "uniswap_v2",
+                Duration::from_millis(20),
+                PermitAcquire::TryAcquire,
+                None,
+                move |_| {
+                    started_flag.store(true, Ordering::SeqCst);
+                    std::thread::sleep(Duration::from_millis(5));
+                    7usize
+                },
+            )
+            .await;
+
+            occupier.await.expect("occupier should finish");
+
+            assert_eq!(result.expect("queued job should succeed"), 7);
+            assert!(started.load(Ordering::SeqCst));
+            assert!(started_at.elapsed() >= Duration::from_millis(60));
+        });
+    }
+
+    #[tokio::test]
+    async fn try_acquire_reports_no_permit() {
+        let state = test_app_state(0, 1);
+        let result = run_blocking_pool_job(
+            &state,
+            "uniswap_v2",
+            Duration::from_millis(10),
+            PermitAcquire::TryAcquire,
+            None,
+            |_| 1usize,
+        )
+        .await;
+
+        assert!(matches!(result, Err(PoolJobError::NoPermit)));
+    }
+
+    #[tokio::test]
+    async fn helper_uses_protocol_specific_semaphore() {
+        let state = test_app_state(0, 1);
+        let vm_runs = Arc::new(AtomicUsize::new(0));
+        let vm_runs_clone = Arc::clone(&vm_runs);
+        let vm_result = run_blocking_pool_job(
+            &state,
+            "vm:curve",
+            Duration::from_millis(10),
+            PermitAcquire::TryAcquire,
+            None,
+            move |_| {
+                vm_runs_clone.fetch_add(1, Ordering::SeqCst);
+            },
+        )
+        .await;
+
+        assert!(vm_result.is_ok());
+        assert_eq!(vm_runs.load(Ordering::SeqCst), 1);
+
+        let native_result = run_blocking_pool_job(
+            &state,
+            "uniswap_v2",
+            Duration::from_millis(10),
+            PermitAcquire::TryAcquire,
+            None,
+            |_| (),
+        )
+        .await;
+
+        assert!(matches!(native_result, Err(PoolJobError::NoPermit)));
+    }
+
+    #[tokio::test]
+    async fn acquire_mode_waits_for_permit_before_starting_timeout() {
+        let state = test_app_state(0, 1);
+        let semaphore = state.native_sim_semaphore();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(40)).await;
+            semaphore.add_permits(1);
+        });
+
+        let started_at = std::time::Instant::now();
+        let result = run_blocking_pool_job(
+            &state,
+            "uniswap_v2",
+            Duration::from_millis(10),
+            PermitAcquire::Acquire,
+            None,
+            |_| {
+                std::thread::sleep(Duration::from_millis(5));
+                11usize
+            },
+        )
+        .await;
+
+        assert_eq!(result.expect("job should succeed after permit release"), 11);
+        assert!(started_at.elapsed() >= Duration::from_millis(40));
+    }
+}

--- a/src/services/pool_runtime.rs
+++ b/src/services/pool_runtime.rs
@@ -22,12 +22,29 @@ where
     T: Send + 'static,
     F: FnOnce(Instant) -> T + Send + 'static,
 {
+    if cancel_token
+        .as_ref()
+        .is_some_and(CancellationToken::is_cancelled)
+    {
+        return Err(PoolJobError::Cancelled);
+    }
+
     let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+    let cancel_token_for_job = cancel_token.clone();
     let handle = spawn_blocking(move || {
         let _permit = permit;
+        // Re-check after entering the blocking pool so queued work does not start after cancel.
+        if cancel_token_for_job
+            .as_ref()
+            .is_some_and(CancellationToken::is_cancelled)
+        {
+            let _ = started_tx.send(None);
+            return None;
+        }
+
         let started_at = Instant::now();
-        let _ = started_tx.send(started_at);
-        job(started_at)
+        let _ = started_tx.send(Some(started_at));
+        Some(job(started_at))
     });
     tokio::pin!(handle);
 
@@ -37,7 +54,7 @@ where
 
     if let Some(cancel_token) = cancel_token.as_ref() {
         tokio::select! {
-            result = handle.as_mut() => result.map_err(PoolJobError::JoinFailed),
+            result = handle.as_mut() => map_pool_job_result(result),
             _ = &mut timeout_sleep => {
                 // Best-effort only: started `spawn_blocking` work can keep running after timeout.
                 handle.as_mut().abort();
@@ -51,7 +68,7 @@ where
         }
     } else {
         tokio::select! {
-            result = handle.as_mut() => result.map_err(PoolJobError::JoinFailed),
+            result = handle.as_mut() => map_pool_job_result(result),
             _ = &mut timeout_sleep => {
                 // Best-effort only: started `spawn_blocking` work can keep running after timeout.
                 handle.as_mut().abort();
@@ -62,8 +79,8 @@ where
 }
 
 async fn wait_for_start<T>(
-    handle: &mut std::pin::Pin<&mut tokio::task::JoinHandle<T>>,
-    started_rx: tokio::sync::oneshot::Receiver<Instant>,
+    handle: &mut std::pin::Pin<&mut tokio::task::JoinHandle<Option<T>>>,
+    started_rx: tokio::sync::oneshot::Receiver<Option<Instant>>,
     cancel_token: Option<&CancellationToken>,
 ) -> Result<(), PoolJobError>
 where
@@ -72,33 +89,49 @@ where
     if let Some(cancel_token) = cancel_token {
         tokio::select! {
             biased;
-            started = started_rx => started
-                .map(|_| ())
-                .map_err(|_| panic!("blocking job ended before sending a start signal")),
-            result = handle.as_mut() => {
-                match result {
-                    Ok(_) => panic!("blocking job completed before sending a start signal"),
-                    Err(join_err) => Err(PoolJobError::JoinFailed(join_err)),
-                }
-            }
             _ = cancel_token.cancelled() => {
                 handle.as_mut().abort();
                 Err(PoolJobError::Cancelled)
+            }
+            started = started_rx => match started {
+                Ok(Some(_)) => Ok(()),
+                Ok(None) => Err(PoolJobError::Cancelled),
+                Err(_) => panic!("blocking job ended before sending a start signal"),
+            },
+            result = handle.as_mut() => {
+                match result {
+                    Ok(Some(_)) => panic!("blocking job completed before sending a start signal"),
+                    Ok(None) => Err(PoolJobError::Cancelled),
+                    Err(join_err) => Err(PoolJobError::JoinFailed(join_err)),
+                }
             }
         }
     } else {
         tokio::select! {
             biased;
-            started = started_rx => started
-                .map(|_| ())
-                .map_err(|_| panic!("blocking job ended before sending a start signal")),
+            started = started_rx => match started {
+                Ok(Some(_)) => Ok(()),
+                Ok(None) => Err(PoolJobError::Cancelled),
+                Err(_) => panic!("blocking job ended before sending a start signal"),
+            },
             result = handle.as_mut() => {
                 match result {
-                    Ok(_) => panic!("blocking job completed before sending a start signal"),
+                    Ok(Some(_)) => panic!("blocking job completed before sending a start signal"),
+                    Ok(None) => Err(PoolJobError::Cancelled),
                     Err(join_err) => Err(PoolJobError::JoinFailed(join_err)),
                 }
             }
         }
+    }
+}
+
+fn map_pool_job_result<T>(
+    result: Result<Option<T>, tokio::task::JoinError>,
+) -> Result<T, PoolJobError> {
+    match result {
+        Ok(Some(result)) => Ok(result),
+        Ok(None) => Err(PoolJobError::Cancelled),
+        Err(join_err) => Err(PoolJobError::JoinFailed(join_err)),
     }
 }
 
@@ -109,8 +142,9 @@ mod tests {
     use std::time::Duration;
 
     use tokio::sync::Semaphore;
+    use tokio_util::sync::CancellationToken;
 
-    use super::run_blocking_pool_job;
+    use super::{run_blocking_pool_job, PoolJobError};
 
     #[test]
     fn timeout_starts_after_blocking_work_really_begins() {
@@ -148,6 +182,81 @@ mod tests {
             assert_eq!(result.expect("queued job should succeed"), 7);
             assert!(started.load(Ordering::SeqCst));
             assert!(started_at.elapsed() >= Duration::from_millis(60));
+        });
+    }
+
+    #[test]
+    fn cancelled_job_does_not_launch_blocking_work() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .max_blocking_threads(1)
+            .build()
+            .expect("runtime");
+
+        runtime.block_on(async {
+            let permit = Arc::new(Semaphore::new(1))
+                .acquire_owned()
+                .await
+                .expect("permit should be available");
+            let cancel = CancellationToken::new();
+            cancel.cancel();
+            let started = Arc::new(AtomicBool::new(false));
+            let started_flag = Arc::clone(&started);
+
+            let result =
+                run_blocking_pool_job(permit, Duration::from_millis(20), Some(cancel), move |_| {
+                    started_flag.store(true, Ordering::SeqCst);
+                    7usize
+                })
+                .await;
+
+            assert!(matches!(result, Err(PoolJobError::Cancelled)));
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            assert!(!started.load(Ordering::SeqCst));
+        });
+    }
+
+    #[test]
+    fn cancelled_queued_job_does_not_start_after_blocking_thread_frees() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .max_blocking_threads(1)
+            .build()
+            .expect("runtime");
+
+        runtime.block_on(async {
+            let (occupier_started_tx, occupier_started_rx) = tokio::sync::oneshot::channel();
+            let occupier = tokio::task::spawn_blocking(move || {
+                let _ = occupier_started_tx.send(());
+                std::thread::sleep(Duration::from_millis(80));
+            });
+            occupier_started_rx.await.expect("occupier should start");
+
+            let permit = Arc::new(Semaphore::new(1))
+                .acquire_owned()
+                .await
+                .expect("permit should be available");
+            let cancel = CancellationToken::new();
+            let cancel_for_task = cancel.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                cancel_for_task.cancel();
+            });
+            let started = Arc::new(AtomicBool::new(false));
+            let started_flag = Arc::clone(&started);
+
+            let result =
+                run_blocking_pool_job(permit, Duration::from_secs(1), Some(cancel), move |_| {
+                    started_flag.store(true, Ordering::SeqCst);
+                    7usize
+                })
+                .await;
+
+            occupier.await.expect("occupier should finish");
+            tokio::time::sleep(Duration::from_millis(20)).await;
+
+            assert!(matches!(result, Err(PoolJobError::Cancelled)));
+            assert!(!started.load(Ordering::SeqCst));
         });
     }
 }

--- a/src/services/quotes.rs
+++ b/src/services/quotes.rs
@@ -919,11 +919,9 @@ async fn simulate_pool(
     let token_out_clone = Arc::clone(&token_out);
     let amounts_clone = Arc::clone(&amounts);
     let cancel_token_clone = cancel_token.clone();
+
     let permit = match semaphore.try_acquire_owned() {
-        Ok(permit) => {
-            scheduled_pool_count.fetch_add(1, Ordering::Relaxed);
-            permit
-        }
+        Ok(permit) => permit,
         Err(TryAcquireError::NoPermits) => {
             return PoolTaskResult::SkippedDueToConcurrency {
                 pool: pool_id_for_failure,
@@ -953,6 +951,25 @@ async fn simulate_pool(
             };
         }
     };
+
+    if cancel_token.is_cancelled() {
+        drop(permit);
+        let context = FailureContext {
+            pool_id: &pool_id_for_failure,
+            pool_name: Some(pool_name_for_failure.as_str()),
+            pool_address: Some(pool_addr_for_failure.as_str()),
+            protocol: Some(pool_protocol_for_failure.as_str()),
+        };
+        let descriptor = format_pool_descriptor(&context);
+        return PoolTaskResult::Failed {
+            failure: make_failure(
+                QuoteFailureKind::Timeout,
+                format!("{}: Quote computation cancelled", descriptor),
+                Some(context),
+            ),
+        };
+    }
+    scheduled_pool_count.fetch_add(1, Ordering::Relaxed);
     let result = run_blocking_pool_job(
         permit,
         pool_timeout,
@@ -4651,6 +4668,54 @@ mod tests {
                 assert_eq!(result.gas_used, vec![1]);
             }
             _ => panic!("expected queued pool to acquire permit once polled"),
+        }
+    }
+
+    #[tokio::test]
+    async fn simulate_pool_does_not_count_or_keep_a_permit_after_cancellation() {
+        let token_in =
+            Bytes::from_str("0x0000000000000000000000000000000000000001").expect("valid address");
+        let token_out =
+            Bytes::from_str("0x0000000000000000000000000000000000000002").expect("valid address");
+        let semaphore = test_semaphore();
+        let scheduled = test_scheduled_counter();
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        let outcome = simulate_pool(
+            "pool-cancelled".to_string(),
+            Arc::new(SpotPriceCountingSim {
+                spot_price_value: Some(1.0),
+                max_in: 1_000_000,
+                spot_price_calls: Arc::new(AtomicUsize::new(0)),
+            }),
+            "0x0000000000000000000000000000000000000009".to_string(),
+            "uniswap_v2".to_string(),
+            "uniswap_v2".to_string(),
+            Arc::new(make_token(&token_in, "TK1")),
+            Arc::new(make_token(&token_out, "TK2")),
+            Arc::new(vec![BigUint::from(1u8)]),
+            BigUint::from(1u8),
+            1,
+            Instant::now() + Duration::from_secs(1),
+            Duration::from_millis(50),
+            cancel,
+            semaphore.clone(),
+            Arc::clone(&scheduled),
+        )
+        .await;
+
+        assert_eq!(scheduled.load(Ordering::SeqCst), 0);
+        let _ = semaphore
+            .clone()
+            .try_acquire_owned()
+            .expect("cancelled task should not consume the permit");
+        match outcome {
+            PoolTaskResult::Failed { failure } => {
+                assert!(matches!(failure.kind, QuoteFailureKind::Timeout));
+                assert!(failure.message.contains("cancelled"));
+            }
+            _ => panic!("expected cancelled pool to return a timeout-style failure"),
         }
     }
 

--- a/src/services/quotes.rs
+++ b/src/services/quotes.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -28,15 +29,23 @@ use crate::models::messages::{
 };
 use crate::models::state::AppState;
 use crate::models::tokens::TokenStoreError;
-use crate::services::native_wrapped::{
-    is_direct_native_wrapped_pair, is_native_or_wrapped_token, simulation_tokens_for_pool,
-};
+use crate::services::native_wrapped::{is_direct_native_wrapped_pair, simulation_tokens_for_pool};
 use crate::services::pool_runtime::{run_blocking_pool_job, PoolJobError};
 
 const VM_LOW_FIRST_GAS_THRESHOLD: u64 = 600_000;
 const VM_LOW_FIRST_GAS_SAMPLE_CAP: usize = 3;
 const SPOT_PRICE_SCALE: u128 = 1_000_000_000;
 const WEI_PER_ETH: u128 = 1_000_000_000_000_000_000;
+const MIN_REASONABLE_ETH_TO_SELL_SPOT: f64 = 1e-12;
+const MAX_REASONABLE_ETH_TO_SELL_SPOT: f64 = 1e12;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SpotProbeMode {
+    NativeOnly,
+    WrappedOnly,
+    Both,
+    None,
+}
 
 // Per-request scheduling metrics (logged once by the handler).
 #[derive(Debug, Default, Clone)]
@@ -461,12 +470,46 @@ pub async fn get_amounts_out(
     );
 
     let sell_token_decimals = token_in_ref.decimals;
-    let eth_to_sell_spot_price = is_native_or_wrapped_token(&token_in_ref).then_some(1.0);
-    let gas_price_wei = state.effective_native_gas_price_wei_for_quotes().await;
-
-    // Stable ordering keeps scheduling deterministic under contention.
+    // Stable ordering ensures deterministic spot source and scheduling under contention.
     native_candidates.sort_by(|a, b| a.0.cmp(&b.0));
     vm_candidates.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let native = token_in_ref.chain.native_token();
+    let wrapped_native = token_in_ref.chain.wrapped_native_token();
+
+    let mut spot_native_candidates_raw = if token_in_ref.address == native.address
+        || token_in_ref.address == wrapped_native.address
+    {
+        Vec::new()
+    } else {
+        let mut candidates = state
+            .native_state_store
+            .matching_pools_by_addresses(&token_in_bytes, &wrapped_native.address)
+            .await;
+        if native.address != wrapped_native.address {
+            candidates.extend(
+                state
+                    .native_state_store
+                    .matching_pools_by_addresses(&token_in_bytes, &native.address)
+                    .await,
+            );
+        }
+        candidates
+    };
+
+    let mut seen_spot_ids = HashSet::new();
+    let mut spot_native_candidates: Vec<(String, Arc<dyn ProtocolSim>, Arc<ProtocolComponent>)> =
+        Vec::new();
+    for (id, (pool_state, component)) in spot_native_candidates_raw.drain(..) {
+        if seen_spot_ids.insert(id.clone()) {
+            spot_native_candidates.push((id, pool_state, component));
+        }
+    }
+    spot_native_candidates.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let eth_to_sell_spot_price =
+        resolve_request_eth_to_sell_spot_price(&token_in_ref, &spot_native_candidates, &[]);
+    let gas_price_wei = state.effective_native_gas_price_wei_for_quotes().await;
 
     let token_in = Arc::new(token_in_ref);
     let token_out = Arc::new(token_out_ref);
@@ -603,14 +646,14 @@ pub async fn get_amounts_out(
         while !tasks.is_empty() {
             tokio::select! {
                 _ = &mut quote_timeout_sleep => {
-                    cancel_token.cancel();
                     let message = format!(
                         "Quote computation timed out after {}ms",
                         quote_timeout.as_millis()
                     );
                     failures.push(make_failure(QuoteFailureKind::Timeout, message, None));
                     meta.status = QuoteStatus::PartialSuccess;
-                    drain_ready_pool_outcomes(
+                    cancel_and_flush_pool_outcomes(
+                        &cancel_token,
                         &mut tasks,
                         &mut responses,
                         &mut failures,
@@ -628,7 +671,8 @@ pub async fn get_amounts_out(
                 }
                 _ = cancel_token.cancelled() => {
                     meta.status = QuoteStatus::PartialSuccess;
-                    drain_ready_pool_outcomes(
+                    cancel_and_flush_pool_outcomes(
+                        &cancel_token,
                         &mut tasks,
                         &mut responses,
                         &mut failures,
@@ -1409,6 +1453,98 @@ fn handle_pool_task_result(
 }
 
 #[allow(clippy::too_many_arguments)]
+fn cancel_and_flush_pool_outcomes<F>(
+    cancel_token: &CancellationToken,
+    tasks: &mut FuturesUnordered<F>,
+    responses: &mut Vec<AmountOutResponse>,
+    failures: &mut Vec<QuoteFailure>,
+    pool_results: &mut Vec<PoolSimulationOutcome>,
+    metrics: &mut QuoteMetrics,
+    meta: &mut QuoteMeta,
+    vm_first_gases: &mut Vec<u64>,
+    expected_len: usize,
+    gas_price_wei: Option<u128>,
+    eth_to_sell_spot_price: Option<f64>,
+    sell_token_decimals: u32,
+    current_block: u64,
+) where
+    F: std::future::Future<Output = PoolTaskResult>,
+{
+    cancel_token.cancel();
+    poll_queued_pool_tasks_once(
+        tasks,
+        responses,
+        failures,
+        pool_results,
+        metrics,
+        meta,
+        vm_first_gases,
+        expected_len,
+        gas_price_wei,
+        eth_to_sell_spot_price,
+        sell_token_decimals,
+        current_block,
+    );
+    drain_ready_pool_outcomes(
+        tasks,
+        responses,
+        failures,
+        pool_results,
+        metrics,
+        meta,
+        vm_first_gases,
+        expected_len,
+        gas_price_wei,
+        eth_to_sell_spot_price,
+        sell_token_decimals,
+        current_block,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn poll_queued_pool_tasks_once<F>(
+    tasks: &mut FuturesUnordered<F>,
+    responses: &mut Vec<AmountOutResponse>,
+    failures: &mut Vec<QuoteFailure>,
+    pool_results: &mut Vec<PoolSimulationOutcome>,
+    metrics: &mut QuoteMetrics,
+    meta: &mut QuoteMeta,
+    vm_first_gases: &mut Vec<u64>,
+    expected_len: usize,
+    gas_price_wei: Option<u128>,
+    eth_to_sell_spot_price: Option<f64>,
+    sell_token_decimals: u32,
+    current_block: u64,
+) where
+    F: std::future::Future<Output = PoolTaskResult>,
+{
+    // Newly queued FuturesUnordered entries are never polled until the stream gets polled.
+    // Give each currently queued task one chance to run its pre-await path after cancellation
+    // so immediate skipped/cancelled outcomes are surfaced before we stop waiting.
+    let queued_tasks = tasks.len();
+    for _ in 0..queued_tasks {
+        match tasks.next().now_or_never() {
+            Some(Some(outcome)) => handle_pool_task_result(
+                outcome,
+                responses,
+                failures,
+                pool_results,
+                metrics,
+                meta,
+                vm_first_gases,
+                expected_len,
+                gas_price_wei,
+                eth_to_sell_spot_price,
+                sell_token_decimals,
+                current_block,
+            ),
+            Some(None) => break,
+            None => {}
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 fn drain_ready_pool_outcomes<F>(
     tasks: &mut FuturesUnordered<F>,
     responses: &mut Vec<AmountOutResponse>,
@@ -1441,6 +1577,191 @@ fn drain_ready_pool_outcomes<F>(
             current_block,
         );
     }
+}
+
+fn resolve_request_eth_to_sell_spot_price(
+    sell_token: &Token,
+    native_candidates: &[(String, Arc<dyn ProtocolSim>, Arc<ProtocolComponent>)],
+    vm_candidates: &[(String, Arc<dyn ProtocolSim>, Arc<ProtocolComponent>)],
+) -> Option<f64> {
+    let native = sell_token.chain.native_token();
+    let wrapped_native = sell_token.chain.wrapped_native_token();
+
+    // Gas price is denominated in native token units (wei for ETH family).
+    // Wrapped/native are interchangeable for conversion purposes.
+    if sell_token.address == native.address || sell_token.address == wrapped_native.address {
+        return Some(1.0);
+    }
+
+    let mut fallback_pool: Option<(&Arc<dyn ProtocolSim>, &Arc<ProtocolComponent>)> = None;
+    let mut selected_pool: Option<(&Arc<dyn ProtocolSim>, &Arc<ProtocolComponent>)> = None;
+    let mut best_liquidity_score: Option<BigUint> = None;
+
+    for (_, pool_state, component) in native_candidates.iter().chain(vm_candidates.iter()) {
+        if fallback_pool.is_none() {
+            fallback_pool = Some((pool_state, component));
+        }
+
+        let Some(liquidity_score) = spot_liquidity_score_in_sell_token(
+            pool_state.as_ref(),
+            sell_token,
+            &wrapped_native,
+            &native,
+        ) else {
+            continue;
+        };
+
+        let should_replace = best_liquidity_score
+            .as_ref()
+            .map(|current| liquidity_score > *current)
+            .unwrap_or(true);
+
+        if should_replace {
+            best_liquidity_score = Some(liquidity_score);
+            selected_pool = Some((pool_state, component));
+        }
+    }
+
+    let (pool_state, component) = selected_pool.or(fallback_pool)?;
+    let probe_mode = spot_probe_mode(component.as_ref(), sell_token, &wrapped_native, &native);
+    spot_price_eth_to_sell_from_pool(
+        pool_state.as_ref(),
+        sell_token,
+        &wrapped_native,
+        &native,
+        probe_mode,
+    )
+}
+
+fn spot_liquidity_score_in_sell_token(
+    pool_state: &dyn ProtocolSim,
+    sell_token: &Token,
+    wrapped_native: &Token,
+    native: &Token,
+) -> Option<BigUint> {
+    let mut best_score: Option<BigUint> = None;
+
+    let mut consider = |candidate: BigUint| {
+        if candidate.is_zero() {
+            return;
+        }
+        let should_replace = best_score
+            .as_ref()
+            .map(|current| candidate > *current)
+            .unwrap_or(true);
+        if should_replace {
+            best_score = Some(candidate);
+        }
+    };
+
+    if let Ok((max_in, _)) =
+        pool_state.get_limits(sell_token.address.clone(), wrapped_native.address.clone())
+    {
+        consider(max_in);
+    }
+    if native.address != wrapped_native.address {
+        if let Ok((max_in, _)) =
+            pool_state.get_limits(sell_token.address.clone(), native.address.clone())
+        {
+            consider(max_in);
+        }
+    }
+
+    if let Ok((_, max_out)) =
+        pool_state.get_limits(wrapped_native.address.clone(), sell_token.address.clone())
+    {
+        consider(max_out);
+    }
+    if native.address != wrapped_native.address {
+        if let Ok((_, max_out)) =
+            pool_state.get_limits(native.address.clone(), sell_token.address.clone())
+        {
+            consider(max_out);
+        }
+    }
+
+    best_score
+}
+
+fn spot_price_eth_to_sell_from_pool(
+    pool_state: &dyn ProtocolSim,
+    sell_token: &Token,
+    wrapped_native: &Token,
+    native: &Token,
+    probe_mode: SpotProbeMode,
+) -> Option<f64> {
+    match probe_mode {
+        SpotProbeMode::NativeOnly => {
+            spot_price_candidate(pool_state.spot_price(native, sell_token).ok(), false).or_else(
+                || spot_price_candidate(pool_state.spot_price(sell_token, native).ok(), true),
+            )
+        }
+        SpotProbeMode::WrappedOnly => spot_price_candidate(
+            pool_state.spot_price(wrapped_native, sell_token).ok(),
+            false,
+        )
+        .or_else(|| {
+            spot_price_candidate(pool_state.spot_price(sell_token, wrapped_native).ok(), true)
+        }),
+        SpotProbeMode::Both => spot_price_candidate(
+            pool_state.spot_price(wrapped_native, sell_token).ok(),
+            false,
+        )
+        .or_else(|| spot_price_candidate(pool_state.spot_price(native, sell_token).ok(), false))
+        .or_else(|| {
+            spot_price_candidate(pool_state.spot_price(sell_token, wrapped_native).ok(), true)
+        })
+        .or_else(|| spot_price_candidate(pool_state.spot_price(sell_token, native).ok(), true)),
+        SpotProbeMode::None => None,
+    }
+}
+
+fn spot_probe_mode(
+    component: &ProtocolComponent,
+    sell_token: &Token,
+    wrapped_native: &Token,
+    native: &Token,
+) -> SpotProbeMode {
+    let has_sell = component
+        .tokens
+        .iter()
+        .any(|token| token.address == sell_token.address);
+    if !has_sell {
+        return SpotProbeMode::None;
+    }
+
+    let has_wrapped = component
+        .tokens
+        .iter()
+        .any(|token| token.address == wrapped_native.address);
+    let has_native = component
+        .tokens
+        .iter()
+        .any(|token| token.address == native.address);
+    match (has_native, has_wrapped) {
+        (true, true) => SpotProbeMode::Both,
+        (true, false) => SpotProbeMode::NativeOnly,
+        (false, true) => SpotProbeMode::WrappedOnly,
+        (false, false) => SpotProbeMode::None,
+    }
+}
+
+fn spot_price_candidate(raw_price: Option<f64>, inverted: bool) -> Option<f64> {
+    let raw_spot_price = raw_price.filter(|price| price.is_finite() && *price > 0.0)?;
+    let eth_to_sell_spot_price = if inverted {
+        1.0 / raw_spot_price
+    } else {
+        raw_spot_price
+    };
+    if !eth_to_sell_spot_price.is_finite()
+        || eth_to_sell_spot_price <= 0.0
+        || !(MIN_REASONABLE_ETH_TO_SELL_SPOT..=MAX_REASONABLE_ETH_TO_SELL_SPOT)
+            .contains(&eth_to_sell_spot_price)
+    {
+        return None;
+    }
+
+    Some(eth_to_sell_spot_price)
 }
 
 fn compute_gas_in_sell_base_units(
@@ -1805,9 +2126,12 @@ mod tests {
 
     use std::any::Any;
     use std::collections::HashMap;
+    use std::future::Future;
+    use std::pin::Pin;
     use std::str::FromStr;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
+    use std::task::{Context, Poll};
 
     use chrono::NaiveDateTime;
     use num_traits::Zero;
@@ -1835,6 +2159,24 @@ mod tests {
 
     fn test_scheduled_counter() -> Arc<AtomicUsize> {
         Arc::new(AtomicUsize::new(0))
+    }
+
+    struct PendingThenReadyTask {
+        polls: Arc<AtomicUsize>,
+        result: Option<PoolTaskResult>,
+    }
+
+    impl Future for PendingThenReadyTask {
+        type Output = PoolTaskResult;
+
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            if self.polls.fetch_add(1, Ordering::SeqCst) == 0 {
+                cx.waker().wake_by_ref();
+                return Poll::Pending;
+            }
+
+            Poll::Ready(self.result.take().expect("task should only resolve once"))
+        }
     }
 
     #[test]
@@ -4726,6 +5068,90 @@ mod tests {
             .failures
             .iter()
             .any(|failure| matches!(failure.kind, QuoteFailureKind::ConcurrencyLimit)));
+    }
+
+    #[test]
+    fn cancel_and_flush_pool_outcomes_surfaces_never_polled_tasks() {
+        let poll_count = Arc::new(AtomicUsize::new(0));
+        let mut tasks = FuturesUnordered::new();
+        tasks.push(PendingThenReadyTask {
+            polls: Arc::clone(&poll_count),
+            result: Some(PoolTaskResult::SkippedDueToConcurrency {
+                pool: "pool-skipped".to_string(),
+                pool_name: "uniswap_v2::TK1/TK2".to_string(),
+                pool_address: "0x0000000000000000000000000000000000000001".to_string(),
+                protocol: "uniswap_v2".to_string(),
+                reason: Some(
+                    "Pool scheduling skipped because concurrency permits were exhausted"
+                        .to_string(),
+                ),
+            }),
+        });
+        tasks.push(PendingThenReadyTask {
+            polls: Arc::clone(&poll_count),
+            result: Some(PoolTaskResult::Failed {
+                failure: make_failure(
+                    QuoteFailureKind::Timeout,
+                    "pool-timeout: Quote computation cancelled".to_string(),
+                    Some(FailureContext {
+                        pool_id: "pool-timeout",
+                        pool_name: Some("uniswap_v2::TK1/TK2"),
+                        pool_address: Some("0x0000000000000000000000000000000000000002"),
+                        protocol: Some("uniswap_v2"),
+                    }),
+                ),
+            }),
+        });
+
+        let cancel_token = CancellationToken::new();
+        let mut responses = Vec::new();
+        let mut failures = Vec::new();
+        let mut pool_results = Vec::new();
+        let mut metrics = QuoteMetrics::default();
+        let mut meta = QuoteMeta {
+            status: QuoteStatus::Ready,
+            result_quality: QuoteResultQuality::RequestLevelFailure,
+            block_number: 42,
+            vm_block_number: None,
+            matching_pools: 0,
+            candidate_pools: 0,
+            total_pools: None,
+            auction_id: None,
+            pool_results: Vec::new(),
+            vm_unavailable: false,
+            failures: Vec::new(),
+        };
+        let mut vm_first_gases = Vec::new();
+
+        cancel_and_flush_pool_outcomes(
+            &cancel_token,
+            &mut tasks,
+            &mut responses,
+            &mut failures,
+            &mut pool_results,
+            &mut metrics,
+            &mut meta,
+            &mut vm_first_gases,
+            1,
+            None,
+            None,
+            18,
+            42,
+        );
+
+        assert!(cancel_token.is_cancelled());
+        assert!(poll_count.load(Ordering::SeqCst) >= 2);
+        assert!(responses.is_empty());
+        assert_eq!(metrics.skipped_native_concurrency, 1);
+        assert!(failures
+            .iter()
+            .any(|failure| matches!(failure.kind, QuoteFailureKind::Timeout)));
+        assert!(pool_results
+            .iter()
+            .any(|outcome| outcome.outcome == PoolOutcomeKind::SkippedConcurrency));
+        assert!(pool_results
+            .iter()
+            .any(|outcome| outcome.outcome == PoolOutcomeKind::TimedOut));
     }
 
     #[tokio::test]

--- a/src/services/quotes.rs
+++ b/src/services/quotes.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -6,8 +5,6 @@ use std::time::{Duration, Instant};
 use futures::stream::{FuturesUnordered, StreamExt};
 use num_bigint::BigUint;
 use num_traits::{cast::ToPrimitive, Zero};
-use tokio::sync::{OwnedSemaphorePermit, TryAcquireError};
-use tokio::task::spawn_blocking;
 use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
@@ -26,26 +23,15 @@ use crate::models::messages::{
 };
 use crate::models::state::AppState;
 use crate::models::tokens::TokenStoreError;
+use crate::services::native_wrapped::{
+    is_direct_native_wrapped_pair, is_native_or_wrapped_token, simulation_tokens_for_pool,
+};
+use crate::services::pool_runtime::{run_blocking_pool_job, PermitAcquire, PoolJobError};
 
 const VM_LOW_FIRST_GAS_THRESHOLD: u64 = 600_000;
 const VM_LOW_FIRST_GAS_SAMPLE_CAP: usize = 3;
 const SPOT_PRICE_SCALE: u128 = 1_000_000_000;
 const WEI_PER_ETH: u128 = 1_000_000_000_000_000_000;
-const MIN_REASONABLE_ETH_TO_SELL_SPOT: f64 = 1e-12;
-const MAX_REASONABLE_ETH_TO_SELL_SPOT: f64 = 1e12;
-const NATIVE_TOKEN_ADDRESS_BYTES: [u8; 20] = [0u8; 20];
-
-fn native_token_address() -> Bytes {
-    Bytes::from(NATIVE_TOKEN_ADDRESS_BYTES)
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SpotProbeMode {
-    NativeOnly,
-    WrappedOnly,
-    Both,
-    None,
-}
 
 // Per-request scheduling metrics (logged once by the handler).
 #[derive(Debug, Default, Clone)]
@@ -470,46 +456,12 @@ pub async fn get_amounts_out(
     );
 
     let sell_token_decimals = token_in_ref.decimals;
-    // Stable ordering ensures deterministic spot source and scheduling under contention.
+    let eth_to_sell_spot_price = is_native_or_wrapped_token(&token_in_ref).then_some(1.0);
+    let gas_price_wei = state.effective_native_gas_price_wei_for_quotes().await;
+
+    // Stable ordering keeps scheduling deterministic under contention.
     native_candidates.sort_by(|a, b| a.0.cmp(&b.0));
     vm_candidates.sort_by(|a, b| a.0.cmp(&b.0));
-
-    let native = token_in_ref.chain.native_token();
-    let wrapped_native = token_in_ref.chain.wrapped_native_token();
-
-    let mut spot_native_candidates_raw = if token_in_ref.address == native.address
-        || token_in_ref.address == wrapped_native.address
-    {
-        Vec::new()
-    } else {
-        let mut candidates = state
-            .native_state_store
-            .matching_pools_by_addresses(&token_in_bytes, &wrapped_native.address)
-            .await;
-        if native.address != wrapped_native.address {
-            candidates.extend(
-                state
-                    .native_state_store
-                    .matching_pools_by_addresses(&token_in_bytes, &native.address)
-                    .await,
-            );
-        }
-        candidates
-    };
-
-    let mut seen_spot_ids = HashSet::new();
-    let mut spot_native_candidates: Vec<(String, Arc<dyn ProtocolSim>, Arc<ProtocolComponent>)> =
-        Vec::new();
-    for (id, (pool_state, component)) in spot_native_candidates_raw.drain(..) {
-        if seen_spot_ids.insert(id.clone()) {
-            spot_native_candidates.push((id, pool_state, component));
-        }
-    }
-    spot_native_candidates.sort_by(|a, b| a.0.cmp(&b.0));
-
-    let eth_to_sell_spot_price =
-        resolve_request_eth_to_sell_spot_price(&token_in_ref, &spot_native_candidates, &[]);
-    let gas_price_wei = state.effective_native_gas_price_wei_for_quotes().await;
 
     let token_in = Arc::new(token_in_ref);
     let token_out = Arc::new(token_out_ref);
@@ -521,8 +473,6 @@ pub async fn get_amounts_out(
         .unwrap_or_default();
     let mut tasks = FuturesUnordered::new();
     let mut vm_first_gases = Vec::new();
-    let native_semaphore = state.native_sim_semaphore();
-    let vm_semaphore = state.vm_sim_semaphore();
 
     // Native first
     for (id, pool_state, component) in native_candidates.into_iter() {
@@ -533,16 +483,9 @@ pub async fn get_amounts_out(
         let pool_address = component.id.to_string();
         let pool_protocol = component.protocol_system.clone();
         let pool_name = derive_pool_name(&component);
+        let pool_timeout = state.pool_timeout_native();
 
-        let now = Instant::now();
-        let proposed_deadline = now + state.pool_timeout_native();
-        let pool_deadline = if proposed_deadline <= quote_deadline {
-            proposed_deadline
-        } else {
-            quote_deadline
-        };
-
-        if pool_deadline <= now {
+        if Instant::now() >= quote_deadline {
             metrics.skipped_native_deadline += 1;
             pool_results.push(make_pool_outcome(
                 id.clone(),
@@ -557,38 +500,7 @@ pub async fn get_amounts_out(
             continue;
         }
 
-        let permit = match native_semaphore.clone().try_acquire_owned() {
-            Ok(permit) => permit,
-            Err(TryAcquireError::NoPermits) => {
-                metrics.skipped_native_concurrency += 1;
-                pool_results.push(make_pool_outcome(
-                    id.clone(),
-                    pool_name.clone(),
-                    pool_address.clone(),
-                    pool_protocol.clone(),
-                    PoolOutcomeKind::SkippedConcurrency,
-                    0,
-                    expected_len,
-                    Some(
-                        "Pool scheduling skipped because native concurrency permits were exhausted"
-                            .to_string(),
-                    ),
-                ));
-                continue;
-            }
-            Err(TryAcquireError::Closed) => {
-                failures.push(make_failure(
-                    QuoteFailureKind::Internal,
-                    "Native pool semaphore closed".to_string(),
-                    None,
-                ));
-                meta.status = QuoteStatus::InternalError;
-                break;
-            }
-        };
-
         let pool_cancel = cancel_token.child_token();
-        metrics.scheduled_native_pools += 1;
         let (sim_token_in, sim_token_out) = simulation_tokens_for_pool_with_remap_log(
             token_in.as_ref(),
             token_out.as_ref(),
@@ -598,6 +510,7 @@ pub async fn get_amounts_out(
         );
 
         tasks.push(simulate_pool(
+            state.clone(),
             id,
             pool_state,
             pool_address,
@@ -608,9 +521,9 @@ pub async fn get_amounts_out(
             Arc::clone(&amounts_in),
             requested_max_in.clone(),
             expected_len,
-            pool_deadline,
+            quote_deadline,
+            pool_timeout,
             pool_cancel,
-            permit,
         ));
     }
 
@@ -623,16 +536,9 @@ pub async fn get_amounts_out(
         let pool_address = component.id.to_string();
         let pool_protocol = component.protocol_system.clone();
         let pool_name = derive_pool_name(&component);
+        let pool_timeout = state.pool_timeout_vm();
 
-        let now = Instant::now();
-        let proposed_deadline = now + state.pool_timeout_vm();
-        let pool_deadline = if proposed_deadline <= quote_deadline {
-            proposed_deadline
-        } else {
-            quote_deadline
-        };
-
-        if pool_deadline <= now {
+        if Instant::now() >= quote_deadline {
             metrics.skipped_vm_deadline += 1;
             pool_results.push(make_pool_outcome(
                 id.clone(),
@@ -647,38 +553,7 @@ pub async fn get_amounts_out(
             continue;
         }
 
-        let permit = match vm_semaphore.clone().try_acquire_owned() {
-            Ok(permit) => permit,
-            Err(TryAcquireError::NoPermits) => {
-                metrics.skipped_vm_concurrency += 1;
-                pool_results.push(make_pool_outcome(
-                    id.clone(),
-                    pool_name.clone(),
-                    pool_address.clone(),
-                    pool_protocol.clone(),
-                    PoolOutcomeKind::SkippedConcurrency,
-                    0,
-                    expected_len,
-                    Some(
-                        "Pool scheduling skipped because VM concurrency permits were exhausted"
-                            .to_string(),
-                    ),
-                ));
-                continue;
-            }
-            Err(TryAcquireError::Closed) => {
-                failures.push(make_failure(
-                    QuoteFailureKind::Internal,
-                    "VM pool semaphore closed".to_string(),
-                    None,
-                ));
-                meta.status = QuoteStatus::InternalError;
-                break;
-            }
-        };
-
         let pool_cancel = cancel_token.child_token();
-        metrics.scheduled_vm_pools += 1;
         let (sim_token_in, sim_token_out) = simulation_tokens_for_pool_with_remap_log(
             token_in.as_ref(),
             token_out.as_ref(),
@@ -688,6 +563,7 @@ pub async fn get_amounts_out(
         );
 
         tasks.push(simulate_pool(
+            state.clone(),
             id,
             pool_state,
             pool_address,
@@ -698,9 +574,9 @@ pub async fn get_amounts_out(
             Arc::clone(&amounts_in),
             requested_max_in.clone(),
             expected_len,
-            pool_deadline,
+            quote_deadline,
+            pool_timeout,
             pool_cancel,
-            permit,
         ));
     }
 
@@ -730,8 +606,11 @@ pub async fn get_amounts_out(
                 maybe_outcome = tasks.next() => {
                     match maybe_outcome {
                         Some(outcome) => {
+                            if outcome.scheduled() {
+                                record_scheduled_pool_metrics(&mut metrics, outcome.protocol());
+                            }
                             match outcome {
-                                Ok(outcome) => match outcome {
+                                PoolTaskResult::Completed(outcome) => match outcome {
                                     PoolSimOutcome::Simulated(result) => {
                                         let had_timeout = is_timeout_like_outcome(&result);
                                         let is_partial = result.amounts_out.len() < expected_len;
@@ -840,7 +719,30 @@ pub async fn get_amounts_out(
                                         ));
                                     }
                                 },
-                                Err(failure) => {
+                                PoolTaskResult::SkippedDueToConcurrency {
+                                    pool,
+                                    pool_name,
+                                    pool_address,
+                                    protocol,
+                                    reason,
+                                } => {
+                                    if protocol.starts_with("vm:") {
+                                        metrics.skipped_vm_concurrency += 1;
+                                    } else {
+                                        metrics.skipped_native_concurrency += 1;
+                                    }
+                                    pool_results.push(make_pool_outcome(
+                                        pool,
+                                        pool_name,
+                                        pool_address,
+                                        protocol,
+                                        PoolOutcomeKind::SkippedConcurrency,
+                                        0,
+                                        expected_len,
+                                        reason,
+                                    ));
+                                }
+                                PoolTaskResult::Failed { failure, .. } => {
                                     if let Some(pool_outcome) =
                                         pool_outcome_from_failure(&failure, expected_len)
                                     {
@@ -968,17 +870,6 @@ pub async fn get_amounts_out(
     }
 }
 
-fn simulation_tokens_for_pool(
-    request_token_in: &Token,
-    request_token_out: &Token,
-    component: &ProtocolComponent,
-) -> (Token, Token) {
-    (
-        remap_request_token_for_pool(request_token_in, component),
-        remap_request_token_for_pool(request_token_out, component),
-    )
-}
-
 fn simulation_tokens_for_pool_with_remap_log(
     request_token_in: &Token,
     request_token_out: &Token,
@@ -1004,48 +895,6 @@ fn simulation_tokens_for_pool_with_remap_log(
     }
 
     (Arc::new(sim_token_in), Arc::new(sim_token_out))
-}
-
-fn remap_request_token_for_pool(request_token: &Token, component: &ProtocolComponent) -> Token {
-    let native = request_token.chain.native_token();
-    let wrapped_native = request_token.chain.wrapped_native_token();
-
-    if native.address == wrapped_native.address {
-        return request_token.clone();
-    }
-
-    let pool_has_native = component
-        .tokens
-        .iter()
-        .any(|token| token.address == native.address);
-    let pool_has_wrapped = component
-        .tokens
-        .iter()
-        .any(|token| token.address == wrapped_native.address);
-
-    if request_token.address == wrapped_native.address && pool_has_native && !pool_has_wrapped {
-        return native;
-    }
-
-    if request_token.address == native.address && pool_has_wrapped && !pool_has_native {
-        return wrapped_native;
-    }
-
-    request_token.clone()
-}
-
-fn is_direct_native_wrapped_pair(
-    token_in: &Bytes,
-    token_out: &Bytes,
-    wrapped_native: Option<&Bytes>,
-) -> bool {
-    let native_address = native_token_address();
-    let Some(wrapped_native) = wrapped_native else {
-        return false;
-    };
-
-    (token_in == &native_address && token_out == wrapped_native)
-        || (token_in == wrapped_native && token_out == &native_address)
 }
 
 struct PoolQuoteResult {
@@ -1077,8 +926,55 @@ struct FailureContext<'a> {
     protocol: Option<&'a str>,
 }
 
+enum PoolTaskResult {
+    Completed(PoolSimOutcome),
+    SkippedDueToConcurrency {
+        pool: String,
+        pool_name: String,
+        pool_address: String,
+        protocol: String,
+        reason: Option<String>,
+    },
+    Failed {
+        failure: QuoteFailure,
+        scheduled: bool,
+    },
+}
+
+impl PoolTaskResult {
+    fn protocol(&self) -> Option<&str> {
+        match self {
+            PoolTaskResult::Completed(PoolSimOutcome::Simulated(result)) => {
+                Some(result.protocol.as_str())
+            }
+            PoolTaskResult::Completed(PoolSimOutcome::SkippedDueToLimits { protocol, .. }) => {
+                Some(protocol.as_str())
+            }
+            PoolTaskResult::SkippedDueToConcurrency { protocol, .. } => Some(protocol.as_str()),
+            PoolTaskResult::Failed { failure, .. } => failure.protocol.as_deref(),
+        }
+    }
+
+    fn scheduled(&self) -> bool {
+        match self {
+            PoolTaskResult::Completed(_) => true,
+            PoolTaskResult::SkippedDueToConcurrency { .. } => false,
+            PoolTaskResult::Failed { scheduled, .. } => *scheduled,
+        }
+    }
+}
+
+fn record_scheduled_pool_metrics(metrics: &mut QuoteMetrics, protocol: Option<&str>) {
+    match protocol {
+        Some(protocol) if protocol.starts_with("vm:") => metrics.scheduled_vm_pools += 1,
+        Some(_) => metrics.scheduled_native_pools += 1,
+        None => {}
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn simulate_pool(
+    state: AppState,
     pool_id: String,
     pool_state: Arc<dyn ProtocolSim>,
     pool_address: String,
@@ -1089,10 +985,10 @@ async fn simulate_pool(
     amounts: Arc<Vec<BigUint>>,
     requested_max_in: BigUint,
     expected_len: usize,
-    deadline: Instant,
+    quote_deadline: Instant,
+    pool_timeout: Duration,
     cancel_token: CancellationToken,
-    permit: OwnedSemaphorePermit,
-) -> Result<PoolSimOutcome, QuoteFailure> {
+) -> PoolTaskResult {
     let pool_id_for_failure = pool_id.clone();
     let pool_addr_for_failure = pool_address.clone();
     let pool_name_for_failure = pool_name.clone();
@@ -1100,80 +996,70 @@ async fn simulate_pool(
     let token_in_clone = Arc::clone(&token_in);
     let token_out_clone = Arc::clone(&token_out);
     let amounts_clone = Arc::clone(&amounts);
-
     let cancel_token_clone = cancel_token.clone();
-    let sleep_duration = deadline
-        .checked_duration_since(Instant::now())
-        .unwrap_or(Duration::from_millis(0));
-    let handle = spawn_blocking(move || {
-        // Hold the permit until the blocking work exits.
-        let _permit = permit;
+    let pool_protocol_for_runtime = pool_protocol.clone();
+    let result = run_blocking_pool_job(
+        &state,
+        &pool_protocol_for_runtime,
+        pool_timeout,
+        PermitAcquire::TryAcquire,
+        Some(cancel_token.clone()),
+        move |started_at| {
+            let deadline = std::cmp::min(started_at + pool_timeout, quote_deadline);
 
-        // Abort quickly if this task starts after cancellation/deadline.
-        if cancel_token_clone.is_cancelled() {
-            debug!(
-                scope = "pool_timeout",
-                pool_id = %pool_id,
-                protocol = %pool_protocol,
-                pool_name = %pool_name,
-                pool_address = %pool_address,
-                "Pool quote cancelled before completion"
-            );
-            return PoolSimOutcome::Simulated(PoolQuoteResult {
-                pool: pool_id,
-                pool_name,
-                pool_address,
-                protocol: pool_protocol,
-                amounts_out: Vec::new(),
-                gas_used: Vec::new(),
-                errors: vec!["Cancelled".to_string()],
-                timed_out: false,
-            });
-        }
-        if Instant::now() >= deadline {
-            debug!(
-                scope = "pool_timeout",
-                pool_id = %pool_id,
-                protocol = %pool_protocol,
-                pool_name = %pool_name,
-                pool_address = %pool_address,
-                "Pool quote exceeded deadline before completion"
-            );
-            return PoolSimOutcome::Simulated(PoolQuoteResult {
-                pool: pool_id,
-                pool_name,
-                pool_address,
-                protocol: pool_protocol,
-                amounts_out: Vec::new(),
-                gas_used: Vec::new(),
-                errors: vec!["Timed out".to_string()],
-                timed_out: true,
-            });
-        }
+            if cancel_token_clone.is_cancelled() {
+                debug!(
+                    scope = "pool_timeout",
+                    pool_id = %pool_id,
+                    protocol = %pool_protocol,
+                    pool_name = %pool_name,
+                    pool_address = %pool_address,
+                    "Pool quote cancelled before completion"
+                );
+                return PoolSimOutcome::Simulated(PoolQuoteResult {
+                    pool: pool_id,
+                    pool_name,
+                    pool_address,
+                    protocol: pool_protocol,
+                    amounts_out: Vec::new(),
+                    gas_used: Vec::new(),
+                    errors: vec!["Cancelled".to_string()],
+                    timed_out: false,
+                });
+            }
+            if Instant::now() >= deadline {
+                debug!(
+                    scope = "pool_timeout",
+                    pool_id = %pool_id,
+                    protocol = %pool_protocol,
+                    pool_name = %pool_name,
+                    pool_address = %pool_address,
+                    "Pool quote exceeded deadline before completion"
+                );
+                return PoolSimOutcome::Simulated(PoolQuoteResult {
+                    pool: pool_id,
+                    pool_name,
+                    pool_address,
+                    protocol: pool_protocol,
+                    amounts_out: Vec::new(),
+                    gas_used: Vec::new(),
+                    errors: vec!["Timed out".to_string()],
+                    timed_out: true,
+                });
+            }
 
-        // Short-circuit when the request exceeds pool limits to avoid wasted compute.
-        //
-        // Note: `get_limits` can be a "soft" limit (advisory). When the request exceeds the
-        // reported limit, we do a single probe before quoting the whole ladder:
-        // - If some requested amounts are within the reported max, probe the max requested amount
-        //   to avoid wasted compute for the largest step.
-        // - If every requested amount exceeds the reported max, probe the smallest requested
-        //   amount and only skip the whole pool if that also fails with a clear limits signal.
-        let mut probed_amount_in: Option<BigUint> = None;
-        let mut probed_amount: Option<(String, u64)> = None;
-        let mut probed_amount_error: Option<String> = None;
-        if !requested_max_in.is_zero() {
-            match pool_state.get_limits(
-                token_in_clone.address.clone(),
-                token_out_clone.address.clone(),
-            ) {
-                Ok((max_in, _max_out)) => {
+            let mut probed_amount_in: Option<BigUint> = None;
+            let mut probed_amount: Option<(String, u64)> = None;
+            let mut probed_amount_error: Option<String> = None;
+            if !requested_max_in.is_zero() {
+                if let Ok((max_in, _max_out)) = pool_state.get_limits(
+                    token_in_clone.address.clone(),
+                    token_out_clone.address.clone(),
+                ) {
                     if requested_max_in > max_in {
                         let all_amounts_exceed_limit =
                             amounts_clone.iter().all(|amount| amount > &max_in);
                         let probe_amount_in = if all_amounts_exceed_limit {
-                            // Prefer probing the smallest requested amount when every request is
-                            // above the reported limit: `max_in` can be conservative.
                             amounts_clone
                                 .iter()
                                 .min()
@@ -1182,6 +1068,7 @@ async fn simulate_pool(
                         } else {
                             requested_max_in.clone()
                         };
+
                         match pool_state.get_amount_out(
                             probe_amount_in.clone(),
                             &token_in_clone,
@@ -1212,10 +1099,8 @@ async fn simulate_pool(
                                     "Probe quote failed (amount_in={}, max_in={}): Invalid input: {}",
                                     probe_amount_in, max_in, message,
                                 );
-                                if is_limits_exhaustion_probe_error(
-                                    &message,
-                                    maybe_result.is_some(),
-                                ) {
+                                if is_limits_exhaustion_probe_error(&message, maybe_result.is_some())
+                                {
                                     if all_amounts_exceed_limit {
                                         debug!(
                                             scope = "limits_precheck",
@@ -1286,65 +1171,79 @@ async fn simulate_pool(
                         }
                     }
                 }
-                Err(_) => {
-                    // Best-effort: if limits are unavailable, proceed with the normal ladder.
+            }
+
+            let mut amounts_out = Vec::with_capacity(expected_len);
+            let mut gas_used = Vec::with_capacity(expected_len);
+            let mut errors = Vec::new();
+            let mut timed_out = false;
+
+            for amount_in in amounts_clone.iter() {
+                if cancel_token_clone.is_cancelled() {
+                    debug!(
+                        scope = "pool_timeout",
+                        pool_id = %pool_id,
+                        protocol = %pool_protocol,
+                        pool_name = %pool_name,
+                        pool_address = %pool_address,
+                        "Pool quote cancelled before completion"
+                    );
+                    errors.push("Cancelled".to_string());
+                    break;
                 }
-            }
-        }
+                if Instant::now() >= deadline {
+                    debug!(
+                        scope = "pool_timeout",
+                        pool_id = %pool_id,
+                        protocol = %pool_protocol,
+                        pool_name = %pool_name,
+                        pool_address = %pool_address,
+                        "Pool quote exceeded deadline before completion"
+                    );
+                    errors.push("Timed out".to_string());
+                    timed_out = true;
+                    break;
+                }
 
-        let mut amounts_out = Vec::with_capacity(expected_len);
-        let mut gas_used = Vec::with_capacity(expected_len);
-        let mut errors = Vec::new();
-        let mut timed_out = false;
-
-        for amount_in in amounts_clone.iter() {
-            if cancel_token_clone.is_cancelled() {
-                debug!(
-                    scope = "pool_timeout",
-                    pool_id = %pool_id,
-                    protocol = %pool_protocol,
-                    pool_name = %pool_name,
-                    pool_address = %pool_address,
-                    "Pool quote cancelled before completion"
-                );
-                errors.push("Cancelled".to_string());
-                break;
-            }
-            if Instant::now() >= deadline {
-                debug!(
-                    scope = "pool_timeout",
-                    pool_id = %pool_id,
-                    protocol = %pool_protocol,
-                    pool_name = %pool_name,
-                    pool_address = %pool_address,
-                    "Pool quote exceeded deadline before completion"
-                );
-                errors.push("Timed out".to_string());
-                timed_out = true;
-                break;
-            }
-
-            if let Some(probed_amount_in_value) = probed_amount_in.as_ref() {
-                if amount_in == probed_amount_in_value {
-                    if let Some((amount_out, gas_u64)) = &probed_amount {
-                        amounts_out.push(amount_out.clone());
-                        gas_used.push(*gas_u64);
-                        continue;
-                    }
-                    if let Some(probe_error) = &probed_amount_error {
-                        errors.push(probe_error.clone());
-                        continue;
+                if let Some(probed_amount_in_value) = probed_amount_in.as_ref() {
+                    if amount_in == probed_amount_in_value {
+                        if let Some((amount_out, gas_u64)) = &probed_amount {
+                            amounts_out.push(amount_out.clone());
+                            gas_used.push(*gas_u64);
+                            continue;
+                        }
+                        if let Some(probe_error) = &probed_amount_error {
+                            errors.push(probe_error.clone());
+                            continue;
+                        }
                     }
                 }
-            }
 
-            match pool_state.get_amount_out(amount_in.clone(), &token_in_clone, &token_out_clone) {
-                Ok(result) => {
-                    if let Some(gas_u64) = result.gas.to_u64() {
-                        amounts_out.push(result.amount.to_string());
-                        gas_used.push(gas_u64);
-                    } else {
-                        let msg = "no gas reported".to_string();
+                match pool_state.get_amount_out(amount_in.clone(), &token_in_clone, &token_out_clone)
+                {
+                    Ok(result) => {
+                        if let Some(gas_u64) = result.gas.to_u64() {
+                            amounts_out.push(result.amount.to_string());
+                            gas_used.push(gas_u64);
+                        } else {
+                            let msg = "no gas reported".to_string();
+                            debug!(
+                                scope = "pool_timeout",
+                                pool_id = %pool_id,
+                                protocol = %pool_protocol,
+                                pool_name = %pool_name,
+                                pool_address = %pool_address,
+                                "Pool quote error: {}",
+                                msg
+                            );
+                            errors.push(msg);
+                            amounts_out.clear();
+                            gas_used.clear();
+                            break;
+                        }
+                    }
+                    Err(error) => {
+                        let msg = error.to_string();
                         debug!(
                             scope = "pool_timeout",
                             pool_id = %pool_id,
@@ -1354,290 +1253,121 @@ async fn simulate_pool(
                             "Pool quote error: {}",
                             msg
                         );
-                        // Do not return results with no gas: mark as error and discard
                         errors.push(msg);
-                        amounts_out.clear();
-                        gas_used.clear();
-                        break;
                     }
                 }
-                Err(e) => {
-                    let msg = e.to_string();
+
+                if Instant::now() >= deadline {
                     debug!(
                         scope = "pool_timeout",
                         pool_id = %pool_id,
                         protocol = %pool_protocol,
                         pool_name = %pool_name,
                         pool_address = %pool_address,
-                        "Pool quote error: {}",
-                        msg
+                        "Pool quote deadline reached after ladder step"
                     );
-                    errors.push(msg);
+                    if errors.is_empty() {
+                        errors.push("Timed out".to_string());
+                    }
+                    timed_out = true;
+                    break;
                 }
             }
 
-            if Instant::now() >= deadline {
-                debug!(
-                    scope = "pool_timeout",
-                    pool_id = %pool_id,
-                    protocol = %pool_protocol,
-                    pool_name = %pool_name,
-                    pool_address = %pool_address,
-                    "Pool quote deadline reached after ladder step"
-                );
-                if errors.is_empty() {
-                    errors.push("Timed out".to_string());
-                }
-                timed_out = true;
-                break;
-            }
-        }
-
-        PoolSimOutcome::Simulated(PoolQuoteResult {
-            pool: pool_id,
-            pool_name,
-            pool_address,
-            protocol: pool_protocol,
-            amounts_out,
-            gas_used,
-            errors,
-            timed_out,
-        })
-    });
-    tokio::pin!(handle);
-
-    tokio::select! {
-        res = handle.as_mut() => {
-            match res {
-                Ok(result) => Ok(result),
-                Err(join_err) => {
-                    let context = FailureContext {
-                        pool_id: &pool_id_for_failure,
-                        pool_name: Some(pool_name_for_failure.as_str()),
-                        pool_address: Some(pool_addr_for_failure.as_str()),
-                        protocol: Some(pool_protocol_for_failure.as_str()),
-                    };
-                    let descriptor = format_pool_descriptor(&context);
-                    let message = format!(
-                        "{}: Quote computation panicked: {}",
-                        descriptor, join_err
-                    );
-                    Err(make_failure(QuoteFailureKind::Internal, message, Some(context)))
-                }
-            }
-        }
-        _ = cancel_token.cancelled() => {
-            cancel_token.cancel();
-            handle.as_mut().abort();
-            let context = FailureContext {
-                pool_id: &pool_id_for_failure,
-                pool_name: Some(pool_name_for_failure.as_str()),
-                pool_address: Some(pool_addr_for_failure.as_str()),
-                protocol: Some(pool_protocol_for_failure.as_str()),
-            };
-            let descriptor = format_pool_descriptor(&context);
-            let message = format!("{}: Quote computation cancelled", descriptor);
-            Err(make_failure(QuoteFailureKind::Timeout, message, Some(context)))
-        }
-        _ = sleep(sleep_duration) => {
-            cancel_token.cancel();
-            handle.as_mut().abort();
-            let context = FailureContext {
-                pool_id: &pool_id_for_failure,
-                pool_name: Some(pool_name_for_failure.as_str()),
-                pool_address: Some(pool_addr_for_failure.as_str()),
-                protocol: Some(pool_protocol_for_failure.as_str()),
-            };
-            let descriptor = format_pool_descriptor(&context);
-            let message = format!("{}: Quote computation timed out", descriptor);
-            Err(make_failure(QuoteFailureKind::Timeout, message, Some(context)))
-        }
-    }
-}
-
-fn resolve_request_eth_to_sell_spot_price(
-    sell_token: &Token,
-    native_candidates: &[(String, Arc<dyn ProtocolSim>, Arc<ProtocolComponent>)],
-    vm_candidates: &[(String, Arc<dyn ProtocolSim>, Arc<ProtocolComponent>)],
-) -> Option<f64> {
-    let native = sell_token.chain.native_token();
-    let wrapped_native = sell_token.chain.wrapped_native_token();
-
-    // Gas price is denominated in native token units (wei for ETH family).
-    // Wrapped/native are interchangeable for conversion purposes.
-    if sell_token.address == native.address || sell_token.address == wrapped_native.address {
-        return Some(1.0);
-    }
-
-    let mut fallback_pool: Option<(&Arc<dyn ProtocolSim>, &Arc<ProtocolComponent>)> = None;
-    let mut selected_pool: Option<(&Arc<dyn ProtocolSim>, &Arc<ProtocolComponent>)> = None;
-    let mut best_liquidity_score: Option<BigUint> = None;
-
-    for (_, pool_state, component) in native_candidates.iter().chain(vm_candidates.iter()) {
-        if fallback_pool.is_none() {
-            fallback_pool = Some((pool_state, component));
-        }
-
-        let Some(liquidity_score) = spot_liquidity_score_in_sell_token(
-            pool_state.as_ref(),
-            sell_token,
-            &wrapped_native,
-            &native,
-        ) else {
-            continue;
-        };
-
-        let should_replace = best_liquidity_score
-            .as_ref()
-            .map(|current| liquidity_score > *current)
-            .unwrap_or(true);
-
-        if should_replace {
-            best_liquidity_score = Some(liquidity_score);
-            selected_pool = Some((pool_state, component));
-        }
-    }
-
-    let (pool_state, component) = selected_pool.or(fallback_pool)?;
-    let probe_mode = spot_probe_mode(component.as_ref(), sell_token, &wrapped_native, &native);
-    spot_price_eth_to_sell_from_pool(
-        pool_state.as_ref(),
-        sell_token,
-        &wrapped_native,
-        &native,
-        probe_mode,
+            PoolSimOutcome::Simulated(PoolQuoteResult {
+                pool: pool_id,
+                pool_name,
+                pool_address,
+                protocol: pool_protocol,
+                amounts_out,
+                gas_used,
+                errors,
+                timed_out,
+            })
+        },
     )
-}
+    .await;
 
-fn spot_liquidity_score_in_sell_token(
-    pool_state: &dyn ProtocolSim,
-    sell_token: &Token,
-    wrapped_native: &Token,
-    native: &Token,
-) -> Option<BigUint> {
-    let mut best_score: Option<BigUint> = None;
-
-    let mut consider = |candidate: BigUint| {
-        if candidate.is_zero() {
-            return;
+    match result {
+        Ok(outcome) => PoolTaskResult::Completed(outcome),
+        Err(PoolJobError::NoPermit) => PoolTaskResult::SkippedDueToConcurrency {
+            pool: pool_id_for_failure,
+            pool_name: pool_name_for_failure,
+            pool_address: pool_addr_for_failure,
+            protocol: pool_protocol_for_failure,
+            reason: Some(
+                "Pool scheduling skipped because concurrency permits were exhausted".to_string(),
+            ),
+        },
+        Err(PoolJobError::SemaphoreClosed) => {
+            let context = FailureContext {
+                pool_id: &pool_id_for_failure,
+                pool_name: Some(pool_name_for_failure.as_str()),
+                pool_address: Some(pool_addr_for_failure.as_str()),
+                protocol: Some(pool_protocol_for_failure.as_str()),
+            };
+            let descriptor = format_pool_descriptor(&context);
+            PoolTaskResult::Failed {
+                failure: make_failure(
+                    QuoteFailureKind::Internal,
+                    format!("{}: Pool semaphore closed", descriptor),
+                    Some(context),
+                ),
+                scheduled: false,
+            }
         }
-        let should_replace = best_score
-            .as_ref()
-            .map(|current| candidate > *current)
-            .unwrap_or(true);
-        if should_replace {
-            best_score = Some(candidate);
+        Err(PoolJobError::TimedOut) => {
+            let context = FailureContext {
+                pool_id: &pool_id_for_failure,
+                pool_name: Some(pool_name_for_failure.as_str()),
+                pool_address: Some(pool_addr_for_failure.as_str()),
+                protocol: Some(pool_protocol_for_failure.as_str()),
+            };
+            let descriptor = format_pool_descriptor(&context);
+            PoolTaskResult::Failed {
+                failure: make_failure(
+                    QuoteFailureKind::Timeout,
+                    format!("{}: Quote computation timed out", descriptor),
+                    Some(context),
+                ),
+                scheduled: true,
+            }
         }
-    };
-
-    if let Ok((max_in, _)) =
-        pool_state.get_limits(sell_token.address.clone(), wrapped_native.address.clone())
-    {
-        consider(max_in);
-    }
-    if native.address != wrapped_native.address {
-        if let Ok((max_in, _)) =
-            pool_state.get_limits(sell_token.address.clone(), native.address.clone())
-        {
-            consider(max_in);
+        Err(PoolJobError::Cancelled) => {
+            let context = FailureContext {
+                pool_id: &pool_id_for_failure,
+                pool_name: Some(pool_name_for_failure.as_str()),
+                pool_address: Some(pool_addr_for_failure.as_str()),
+                protocol: Some(pool_protocol_for_failure.as_str()),
+            };
+            let descriptor = format_pool_descriptor(&context);
+            PoolTaskResult::Failed {
+                failure: make_failure(
+                    QuoteFailureKind::Timeout,
+                    format!("{}: Quote computation cancelled", descriptor),
+                    Some(context),
+                ),
+                scheduled: true,
+            }
+        }
+        Err(PoolJobError::JoinFailed(join_err)) => {
+            let context = FailureContext {
+                pool_id: &pool_id_for_failure,
+                pool_name: Some(pool_name_for_failure.as_str()),
+                pool_address: Some(pool_addr_for_failure.as_str()),
+                protocol: Some(pool_protocol_for_failure.as_str()),
+            };
+            let descriptor = format_pool_descriptor(&context);
+            PoolTaskResult::Failed {
+                failure: make_failure(
+                    QuoteFailureKind::Internal,
+                    format!("{}: Quote computation panicked: {}", descriptor, join_err),
+                    Some(context),
+                ),
+                scheduled: true,
+            }
         }
     }
-
-    if let Ok((_, max_out)) =
-        pool_state.get_limits(wrapped_native.address.clone(), sell_token.address.clone())
-    {
-        consider(max_out);
-    }
-    if native.address != wrapped_native.address {
-        if let Ok((_, max_out)) =
-            pool_state.get_limits(native.address.clone(), sell_token.address.clone())
-        {
-            consider(max_out);
-        }
-    }
-
-    best_score
-}
-
-fn spot_price_eth_to_sell_from_pool(
-    pool_state: &dyn ProtocolSim,
-    sell_token: &Token,
-    wrapped_native: &Token,
-    native: &Token,
-    probe_mode: SpotProbeMode,
-) -> Option<f64> {
-    match probe_mode {
-        SpotProbeMode::NativeOnly => {
-            spot_price_candidate(pool_state.spot_price(native, sell_token).ok(), false).or_else(
-                || spot_price_candidate(pool_state.spot_price(sell_token, native).ok(), true),
-            )
-        }
-        SpotProbeMode::WrappedOnly => spot_price_candidate(
-            pool_state.spot_price(wrapped_native, sell_token).ok(),
-            false,
-        )
-        .or_else(|| {
-            spot_price_candidate(pool_state.spot_price(sell_token, wrapped_native).ok(), true)
-        }),
-        SpotProbeMode::Both => spot_price_candidate(
-            pool_state.spot_price(wrapped_native, sell_token).ok(),
-            false,
-        )
-        .or_else(|| spot_price_candidate(pool_state.spot_price(native, sell_token).ok(), false))
-        .or_else(|| {
-            spot_price_candidate(pool_state.spot_price(sell_token, wrapped_native).ok(), true)
-        })
-        .or_else(|| spot_price_candidate(pool_state.spot_price(sell_token, native).ok(), true)),
-        SpotProbeMode::None => None,
-    }
-}
-
-fn spot_probe_mode(
-    component: &ProtocolComponent,
-    sell_token: &Token,
-    wrapped_native: &Token,
-    native: &Token,
-) -> SpotProbeMode {
-    let has_sell = component
-        .tokens
-        .iter()
-        .any(|token| token.address == sell_token.address);
-    if !has_sell {
-        return SpotProbeMode::None;
-    }
-
-    let has_wrapped = component
-        .tokens
-        .iter()
-        .any(|token| token.address == wrapped_native.address);
-    let has_native = component
-        .tokens
-        .iter()
-        .any(|token| token.address == native.address);
-    match (has_native, has_wrapped) {
-        (true, true) => SpotProbeMode::Both,
-        (true, false) => SpotProbeMode::NativeOnly,
-        (false, true) => SpotProbeMode::WrappedOnly,
-        (false, false) => SpotProbeMode::None,
-    }
-}
-
-fn spot_price_candidate(raw_price: Option<f64>, inverted: bool) -> Option<f64> {
-    let raw_spot_price = raw_price.filter(|price| price.is_finite() && *price > 0.0)?;
-    let eth_to_sell_spot_price = if inverted {
-        1.0 / raw_spot_price
-    } else {
-        raw_spot_price
-    };
-    if !eth_to_sell_spot_price.is_finite()
-        || eth_to_sell_spot_price <= 0.0
-        || !(MIN_REASONABLE_ETH_TO_SELL_SPOT..=MAX_REASONABLE_ETH_TO_SELL_SPOT)
-            .contains(&eth_to_sell_spot_price)
-    {
-        return None;
-    }
-
-    Some(eth_to_sell_spot_price)
 }
 
 fn compute_gas_in_sell_base_units(
@@ -1998,9 +1728,10 @@ fn make_failure(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::services::native_wrapped::remap_request_token_for_pool;
 
     use std::any::Any;
-    use std::collections::{HashMap, HashSet};
+    use std::collections::HashMap;
     use std::str::FromStr;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
@@ -2484,6 +2215,25 @@ mod tests {
         }
     }
 
+    fn make_runtime_only_app_state(
+        native_sim_concurrency: usize,
+        vm_sim_concurrency: usize,
+    ) -> AppState {
+        let token_store = make_token_store(Vec::new());
+        let native_state_store = Arc::new(StateStore::new(Arc::clone(&token_store)));
+        let vm_state_store = Arc::new(StateStore::new(Arc::clone(&token_store)));
+        make_test_app_state(
+            token_store,
+            native_state_store,
+            vm_state_store,
+            TestAppStateConfig {
+                native_sim_concurrency,
+                vm_sim_concurrency,
+                ..TestAppStateConfig::default()
+            },
+        )
+    }
+
     #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
     struct SpotPriceCountingSim {
         spot_price_value: Option<f64>,
@@ -2523,176 +2273,6 @@ mod tests {
             _buy_token: Bytes,
         ) -> Result<(BigUint, BigUint), SimulationError> {
             Ok((BigUint::from(self.max_in), BigUint::zero()))
-        }
-
-        fn delta_transition(
-            &mut self,
-            _delta: ProtocolStateDelta,
-            _tokens: &HashMap<Bytes, Token>,
-            _balances: &Balances,
-        ) -> Result<(), TransitionError<String>> {
-            Ok(())
-        }
-
-        fn clone_box(&self) -> Box<dyn ProtocolSim> {
-            Box::new(self.clone())
-        }
-
-        fn as_any(&self) -> &dyn Any {
-            self
-        }
-
-        fn as_any_mut(&mut self) -> &mut dyn Any {
-            self
-        }
-
-        fn eq(&self, other: &dyn ProtocolSim) -> bool {
-            other.as_any().is::<Self>()
-        }
-    }
-
-    #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-    struct PairAwareSpotPriceSim {
-        sell_token: Bytes,
-        wrapped_native: Bytes,
-        native_token: Bytes,
-        wrapped_price: f64,
-        native_price: f64,
-    }
-
-    #[typetag::serde]
-    impl ProtocolSim for PairAwareSpotPriceSim {
-        fn fee(&self) -> f64 {
-            0.0
-        }
-
-        fn spot_price(&self, base: &Token, quote: &Token) -> Result<f64, SimulationError> {
-            if quote.address == self.sell_token && base.address == self.wrapped_native {
-                return Ok(self.wrapped_price);
-            }
-            if quote.address == self.sell_token && base.address == self.native_token {
-                return Ok(self.native_price);
-            }
-            Err(SimulationError::FatalError(
-                "pair not supported".to_string(),
-            ))
-        }
-
-        fn get_amount_out(
-            &self,
-            amount_in: BigUint,
-            _token_in: &Token,
-            _token_out: &Token,
-        ) -> Result<GetAmountOutResult, SimulationError> {
-            Ok(GetAmountOutResult::new(
-                amount_in.clone(),
-                amount_in,
-                self.clone_box(),
-            ))
-        }
-
-        fn get_limits(
-            &self,
-            _sell_token: Bytes,
-            _buy_token: Bytes,
-        ) -> Result<(BigUint, BigUint), SimulationError> {
-            Ok((BigUint::from(1_000_000u64), BigUint::zero()))
-        }
-
-        fn delta_transition(
-            &mut self,
-            _delta: ProtocolStateDelta,
-            _tokens: &HashMap<Bytes, Token>,
-            _balances: &Balances,
-        ) -> Result<(), TransitionError<String>> {
-            Ok(())
-        }
-
-        fn clone_box(&self) -> Box<dyn ProtocolSim> {
-            Box::new(self.clone())
-        }
-
-        fn as_any(&self) -> &dyn Any {
-            self
-        }
-
-        fn as_any_mut(&mut self) -> &mut dyn Any {
-            self
-        }
-
-        fn eq(&self, other: &dyn ProtocolSim) -> bool {
-            other.as_any().is::<Self>()
-        }
-    }
-
-    #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-    struct ProbeModeGuardSpotPriceSim {
-        sell_token: Bytes,
-        wrapped_native: Bytes,
-        native_token: Bytes,
-        native_price: f64,
-        wrapped_price: f64,
-        #[serde(skip, default = "default_calls")]
-        native_calls: Arc<AtomicUsize>,
-        #[serde(skip, default = "default_calls")]
-        wrapped_calls: Arc<AtomicUsize>,
-    }
-
-    #[typetag::serde]
-    impl ProtocolSim for ProbeModeGuardSpotPriceSim {
-        fn fee(&self) -> f64 {
-            0.0
-        }
-
-        fn spot_price(&self, base: &Token, quote: &Token) -> Result<f64, SimulationError> {
-            let is_native_pair = (base.address == self.native_token
-                && quote.address == self.sell_token)
-                || (base.address == self.sell_token && quote.address == self.native_token);
-            if is_native_pair {
-                self.native_calls.fetch_add(1, Ordering::SeqCst);
-                return if base.address == self.sell_token {
-                    Ok(1.0 / self.native_price)
-                } else {
-                    Ok(self.native_price)
-                };
-            }
-
-            let is_wrapped_pair = (base.address == self.wrapped_native
-                && quote.address == self.sell_token)
-                || (base.address == self.sell_token && quote.address == self.wrapped_native);
-            if is_wrapped_pair {
-                self.wrapped_calls.fetch_add(1, Ordering::SeqCst);
-                return if base.address == self.sell_token {
-                    Ok(1.0 / self.wrapped_price)
-                } else {
-                    Ok(self.wrapped_price)
-                };
-            }
-
-            Err(SimulationError::FatalError(
-                "pair not supported".to_string(),
-            ))
-        }
-
-        fn get_amount_out(
-            &self,
-            amount_in: BigUint,
-            _token_in: &Token,
-            _token_out: &Token,
-        ) -> Result<GetAmountOutResult, SimulationError> {
-            Ok(GetAmountOutResult::new(
-                amount_in.clone(),
-                amount_in,
-                self.clone_box(),
-            ))
-        }
-
-        fn get_limits(
-            &self,
-            _sell_token: Bytes,
-            _buy_token: Bytes,
-        ) -> Result<(BigUint, BigUint), SimulationError> {
-            Ok((BigUint::from(1_000_000u64), BigUint::zero()))
         }
 
         fn delta_transition(
@@ -2810,313 +2390,19 @@ mod tests {
         }
     }
 
-    #[test]
-    fn resolve_request_eth_to_sell_spot_price_returns_one_for_wrapped_native_sell() {
-        let sell_token = Chain::Ethereum.wrapped_native_token();
-        let native_candidates: Vec<(String, Arc<dyn ProtocolSim>, Arc<ProtocolComponent>)> =
-            Vec::new();
-        let vm_candidates: Vec<(String, Arc<dyn ProtocolSim>, Arc<ProtocolComponent>)> = Vec::new();
-
-        let price =
-            resolve_request_eth_to_sell_spot_price(&sell_token, &native_candidates, &vm_candidates);
-
-        assert_eq!(price, Some(1.0));
-    }
-
-    #[test]
-    fn resolve_request_eth_to_sell_spot_price_prefers_wrapped_native_source() {
-        let sell_token = make_token_with_decimals(
-            &Bytes::from_str("0x00000000000000000000000000000000000000a1").expect("valid address"),
-            "USDT",
-            6,
-        );
-        let wrapped_native = Chain::Ethereum.wrapped_native_token();
-        let native_token = Chain::Ethereum.native_token();
-
-        let component = ProtocolComponent::new(
-            Bytes::from_str("0x00000000000000000000000000000000000000b1")
-                .expect("valid pool address"),
-            "uniswap_v2".to_string(),
-            "uniswap_v2".to_string(),
-            Chain::Ethereum,
-            vec![wrapped_native.clone(), sell_token.clone()],
-            Vec::new(),
-            HashMap::new(),
-            Bytes::default(),
-            NaiveDateTime::default(),
-        );
-        let sim = PairAwareSpotPriceSim {
-            sell_token: sell_token.address.clone(),
-            wrapped_native: wrapped_native.address.clone(),
-            native_token: native_token.address.clone(),
-            wrapped_price: 2_500.0,
-            native_price: 552_709_307.0,
-        };
-
-        let native_candidates: Vec<(String, Arc<dyn ProtocolSim>, Arc<ProtocolComponent>)> =
-            vec![(
-                "pool-a".to_string(),
-                Arc::new(sim) as Arc<dyn ProtocolSim>,
-                Arc::new(component),
-            )];
-        let vm_candidates: Vec<(String, Arc<dyn ProtocolSim>, Arc<ProtocolComponent>)> = Vec::new();
-
-        let price =
-            resolve_request_eth_to_sell_spot_price(&sell_token, &native_candidates, &vm_candidates)
-                .expect("spot price should resolve");
-
-        assert!((price - 2_500.0).abs() < f64::EPSILON);
-    }
-
-    #[test]
-    fn resolve_request_eth_to_sell_spot_price_native_only_pool_ignores_wrapped_path() {
-        let sell_token = make_token_with_decimals(
-            &Bytes::from_str("0x00000000000000000000000000000000000000a1").expect("valid address"),
-            "USDT",
-            6,
-        );
-        let wrapped_native = Chain::Ethereum.wrapped_native_token();
-        let native_token = Chain::Ethereum.native_token();
-        let native_calls = Arc::new(AtomicUsize::new(0));
-        let wrapped_calls = Arc::new(AtomicUsize::new(0));
-
-        let component = ProtocolComponent::new(
-            Bytes::from_str("0x00000000000000000000000000000000000000b1")
-                .expect("valid pool address"),
-            "uniswap_v2".to_string(),
-            "uniswap_v2".to_string(),
-            Chain::Ethereum,
-            vec![native_token.clone(), sell_token.clone()],
-            Vec::new(),
-            HashMap::new(),
-            Bytes::default(),
-            NaiveDateTime::default(),
-        );
-        let sim = ProbeModeGuardSpotPriceSim {
-            sell_token: sell_token.address.clone(),
-            wrapped_native: wrapped_native.address.clone(),
-            native_token: native_token.address.clone(),
-            native_price: 2_500.0,
-            wrapped_price: 552_709_307.0,
-            native_calls: Arc::clone(&native_calls),
-            wrapped_calls: Arc::clone(&wrapped_calls),
-        };
-
-        let native_candidates: Vec<(String, Arc<dyn ProtocolSim>, Arc<ProtocolComponent>)> =
-            vec![(
-                "pool-a".to_string(),
-                Arc::new(sim) as Arc<dyn ProtocolSim>,
-                Arc::new(component),
-            )];
-        let vm_candidates: Vec<(String, Arc<dyn ProtocolSim>, Arc<ProtocolComponent>)> = Vec::new();
-
-        let price =
-            resolve_request_eth_to_sell_spot_price(&sell_token, &native_candidates, &vm_candidates)
-                .expect("spot price should resolve");
-
-        assert!((price - 2_500.0).abs() < f64::EPSILON);
-        assert_eq!(native_calls.load(Ordering::SeqCst), 1);
-        assert_eq!(wrapped_calls.load(Ordering::SeqCst), 0);
-    }
-
-    #[test]
-    fn resolve_request_eth_to_sell_spot_price_wrapped_only_pool_ignores_native_path() {
-        let sell_token = make_token_with_decimals(
-            &Bytes::from_str("0x00000000000000000000000000000000000000a1").expect("valid address"),
-            "USDT",
-            6,
-        );
-        let wrapped_native = Chain::Ethereum.wrapped_native_token();
-        let native_token = Chain::Ethereum.native_token();
-        let native_calls = Arc::new(AtomicUsize::new(0));
-        let wrapped_calls = Arc::new(AtomicUsize::new(0));
-
-        let component = ProtocolComponent::new(
-            Bytes::from_str("0x00000000000000000000000000000000000000b2")
-                .expect("valid pool address"),
-            "uniswap_v2".to_string(),
-            "uniswap_v2".to_string(),
-            Chain::Ethereum,
-            vec![wrapped_native.clone(), sell_token.clone()],
-            Vec::new(),
-            HashMap::new(),
-            Bytes::default(),
-            NaiveDateTime::default(),
-        );
-        let sim = ProbeModeGuardSpotPriceSim {
-            sell_token: sell_token.address.clone(),
-            wrapped_native: wrapped_native.address.clone(),
-            native_token: native_token.address.clone(),
-            native_price: 552_709_307.0,
-            wrapped_price: 2_500.0,
-            native_calls: Arc::clone(&native_calls),
-            wrapped_calls: Arc::clone(&wrapped_calls),
-        };
-
-        let native_candidates: Vec<(String, Arc<dyn ProtocolSim>, Arc<ProtocolComponent>)> =
-            vec![(
-                "pool-a".to_string(),
-                Arc::new(sim) as Arc<dyn ProtocolSim>,
-                Arc::new(component),
-            )];
-        let vm_candidates: Vec<(String, Arc<dyn ProtocolSim>, Arc<ProtocolComponent>)> = Vec::new();
-
-        let price =
-            resolve_request_eth_to_sell_spot_price(&sell_token, &native_candidates, &vm_candidates)
-                .expect("spot price should resolve");
-
-        assert!((price - 2_500.0).abs() < f64::EPSILON);
-        assert_eq!(native_calls.load(Ordering::SeqCst), 0);
-        assert_eq!(wrapped_calls.load(Ordering::SeqCst), 1);
-    }
-
-    #[test]
-    fn resolve_request_eth_to_sell_spot_price_returns_none_when_probe_mode_is_none() {
-        let sell_token = make_token_with_decimals(
-            &Bytes::from_str("0x00000000000000000000000000000000000000a1").expect("valid address"),
-            "USDT",
-            6,
-        );
-        let unrelated_a = make_token_with_decimals(
-            &Bytes::from_str("0x00000000000000000000000000000000000000d1").expect("valid address"),
-            "AAA",
-            18,
-        );
-        let unrelated_b = make_token_with_decimals(
-            &Bytes::from_str("0x00000000000000000000000000000000000000d2").expect("valid address"),
-            "BBB",
-            18,
-        );
-        let spot_price_calls = Arc::new(AtomicUsize::new(0));
-
-        let component = ProtocolComponent::new(
-            Bytes::from_str("0x00000000000000000000000000000000000000b3")
-                .expect("valid pool address"),
-            "uniswap_v2".to_string(),
-            "uniswap_v2".to_string(),
-            Chain::Ethereum,
-            vec![unrelated_a, unrelated_b],
-            Vec::new(),
-            HashMap::new(),
-            Bytes::default(),
-            NaiveDateTime::default(),
-        );
-        let sim = SpotPriceCountingSim {
-            spot_price_value: Some(2_500.0),
-            max_in: 1_000_000,
-            spot_price_calls: Arc::clone(&spot_price_calls),
-        };
-
-        let native_candidates: Vec<(String, Arc<dyn ProtocolSim>, Arc<ProtocolComponent>)> =
-            vec![(
-                "pool-a".to_string(),
-                Arc::new(sim) as Arc<dyn ProtocolSim>,
-                Arc::new(component),
-            )];
-        let vm_candidates: Vec<(String, Arc<dyn ProtocolSim>, Arc<ProtocolComponent>)> = Vec::new();
-
-        let spot_price =
-            resolve_request_eth_to_sell_spot_price(&sell_token, &native_candidates, &vm_candidates);
-        assert_eq!(spot_price, None);
-        assert_eq!(spot_price_calls.load(Ordering::SeqCst), 0);
-        assert_eq!(
-            compute_gas_in_sell_base_units(
-                Some(1_000_000_000_000_000_000),
-                Some(21_000),
-                spot_price,
-                sell_token.decimals,
-            ),
-            "0"
-        );
-    }
-
-    #[test]
-    fn resolve_request_eth_to_sell_spot_price_uses_most_liquid_pool() {
-        let sell_token = make_token_with_decimals(
-            &Bytes::from_str("0x00000000000000000000000000000000000000b2").expect("valid address"),
-            "WBTC",
-            8,
-        );
-        let wrapped_native = Chain::Ethereum.wrapped_native_token();
-        let low_liquidity_calls = Arc::new(AtomicUsize::new(0));
-        let high_liquidity_calls = Arc::new(AtomicUsize::new(0));
-
-        let component_a = ProtocolComponent::new(
-            Bytes::from_str("0x00000000000000000000000000000000000000c1")
-                .expect("valid pool address"),
-            "uniswap_v4".to_string(),
-            "uniswap_v4".to_string(),
-            Chain::Ethereum,
-            vec![wrapped_native.clone(), sell_token.clone()],
-            Vec::new(),
-            HashMap::new(),
-            Bytes::default(),
-            NaiveDateTime::default(),
-        );
-        let component_b = ProtocolComponent::new(
-            Bytes::from_str("0x00000000000000000000000000000000000000c2")
-                .expect("valid pool address"),
-            "uniswap_v3".to_string(),
-            "uniswap_v3".to_string(),
-            Chain::Ethereum,
-            vec![wrapped_native.clone(), sell_token.clone()],
-            Vec::new(),
-            HashMap::new(),
-            Bytes::default(),
-            NaiveDateTime::default(),
-        );
-
-        let outlier = SpotPriceCountingSim {
-            spot_price_value: Some(1.0e18),
-            max_in: 10,
-            spot_price_calls: Arc::clone(&low_liquidity_calls),
-        };
-        let consensus = SpotPriceCountingSim {
-            spot_price_value: Some(0.03125),
-            max_in: 1_000_000_000,
-            spot_price_calls: Arc::clone(&high_liquidity_calls),
-        };
-
-        // Keep ids ordered so the low-liquidity outlier candidate is visited first.
-        let native_candidates: Vec<(String, Arc<dyn ProtocolSim>, Arc<ProtocolComponent>)> = vec![
-            (
-                "a-outlier".to_string(),
-                Arc::new(outlier) as Arc<dyn ProtocolSim>,
-                Arc::new(component_a),
-            ),
-            (
-                "b-liquid".to_string(),
-                Arc::new(consensus) as Arc<dyn ProtocolSim>,
-                Arc::new(component_b),
-            ),
-        ];
-        let vm_candidates: Vec<(String, Arc<dyn ProtocolSim>, Arc<ProtocolComponent>)> = Vec::new();
-
-        let price =
-            resolve_request_eth_to_sell_spot_price(&sell_token, &native_candidates, &vm_candidates)
-                .expect("spot price should resolve");
-
-        assert!((price - 0.03125).abs() < f64::EPSILON);
-        assert_eq!(low_liquidity_calls.load(Ordering::SeqCst), 0);
-        assert_eq!(high_liquidity_calls.load(Ordering::SeqCst), 1);
-    }
-
     #[tokio::test]
-    async fn get_amounts_out_uses_request_scoped_gas_snapshot_across_all_pools() {
-        let token_in_hex = "0x0000000000000000000000000000000000000001";
+    async fn get_amounts_out_uses_direct_gas_conversion_for_wrapped_native_sell_token() {
+        let token_in = Chain::Ethereum.wrapped_native_token().address;
         let token_out_hex = "0x0000000000000000000000000000000000000002";
-        let token_in = Bytes::from_str(token_in_hex).expect("valid address");
         let token_out = Bytes::from_str(token_out_hex).expect("valid address");
-        let wrapped_native = Chain::Ethereum.wrapped_native_token().address;
+        let token_in_hex = token_in.to_string();
 
-        let token_in_meta = make_token_with_decimals(&token_in, "TK1", 2);
+        let token_in_meta = make_token_with_decimals(&token_in, "WETH", 18);
         let token_out_meta = make_token_with_decimals(&token_out, "TK2", 6);
-        let wrapped_native_meta = make_token_with_decimals(&wrapped_native, "WETH", 18);
 
         let mut initial_tokens = HashMap::new();
         initial_tokens.insert(token_in.clone(), token_in_meta.clone());
         initial_tokens.insert(token_out.clone(), token_out_meta.clone());
-        initial_tokens.insert(wrapped_native.clone(), wrapped_native_meta.clone());
 
         let token_store = Arc::new(TokenStore::new(
             initial_tokens,
@@ -3129,52 +2415,26 @@ mod tests {
         let native_state_store = Arc::new(StateStore::new(Arc::clone(&token_store)));
         let vm_state_store = Arc::new(StateStore::new(Arc::clone(&token_store)));
 
-        let pair_spot_price_calls = Arc::new(AtomicUsize::new(0));
-        let spot_source_calls = Arc::new(AtomicUsize::new(0));
+        let spot_price_calls = Arc::new(AtomicUsize::new(0));
         let mut states = HashMap::new();
         let mut new_pairs = HashMap::new();
-        for (pool_id, pool_address_hex) in [
-            ("pool-a", "0x0000000000000000000000000000000000000011"),
-            ("pool-b", "0x0000000000000000000000000000000000000012"),
-        ] {
-            let component = ProtocolComponent::new(
-                Bytes::from_str(pool_address_hex).expect("valid pool address"),
-                "uniswap_v2".to_string(),
-                "uniswap_v2".to_string(),
-                Chain::Ethereum,
-                vec![token_in_meta.clone(), token_out_meta.clone()],
-                Vec::new(),
-                HashMap::new(),
-                Bytes::default(),
-                NaiveDateTime::default(),
-            );
-            states.insert(
-                pool_id.to_string(),
-                Box::new(SpotPriceCountingSim {
-                    spot_price_value: Some(1.5),
-                    max_in: 1_000_000,
-                    spot_price_calls: Arc::clone(&pair_spot_price_calls),
-                }) as Box<dyn ProtocolSim>,
-            );
-            new_pairs.insert(pool_id.to_string(), component);
-        }
         states.insert(
-            "pool-spot".to_string(),
+            "pool-a".to_string(),
             Box::new(SpotPriceCountingSim {
-                spot_price_value: Some(1.5),
-                max_in: 10_000_000,
-                spot_price_calls: Arc::clone(&spot_source_calls),
+                spot_price_value: Some(1234.0),
+                max_in: 1_000_000,
+                spot_price_calls: Arc::clone(&spot_price_calls),
             }) as Box<dyn ProtocolSim>,
         );
         new_pairs.insert(
-            "pool-spot".to_string(),
+            "pool-a".to_string(),
             ProtocolComponent::new(
-                Bytes::from_str("0x0000000000000000000000000000000000000013")
+                Bytes::from_str("0x0000000000000000000000000000000000000011")
                     .expect("valid pool address"),
                 "uniswap_v2".to_string(),
                 "uniswap_v2".to_string(),
                 Chain::Ethereum,
-                vec![token_in_meta.clone(), wrapped_native_meta.clone()],
+                vec![token_in_meta.clone(), token_out_meta.clone()],
                 Vec::new(),
                 HashMap::new(),
                 Bytes::default(),
@@ -3193,9 +2453,7 @@ mod tests {
             native_stream_health: Arc::new(StreamHealth::new()),
             vm_stream_health: Arc::new(StreamHealth::new()),
             vm_stream: Arc::new(RwLock::new(VmStreamStatus::default())),
-            latest_native_gas_price_wei: Arc::new(tokio::sync::RwLock::new(Some(
-                5_000_000_000_000_000_000,
-            ))),
+            latest_native_gas_price_wei: Arc::new(tokio::sync::RwLock::new(Some(1))),
             native_gas_price_reporting_enabled: Arc::new(tokio::sync::RwLock::new(true)),
             enable_vm_pools: false,
             readiness_stale: Duration::from_secs(120),
@@ -3211,28 +2469,92 @@ mod tests {
         };
 
         let request = AmountOutRequest {
-            request_id: "req-spot-reuse".to_string(),
+            request_id: "req-direct-weth-gas".to_string(),
             auction_id: None,
-            token_in: token_in_hex.to_string(),
+            token_in: token_in_hex,
             token_out: token_out_hex.to_string(),
             amounts: vec!["2".to_string(), "5".to_string()],
         };
 
         let computation = get_amounts_out(app_state, request, None).await;
 
-        assert_eq!(pair_spot_price_calls.load(Ordering::SeqCst), 0);
-        assert_eq!(spot_source_calls.load(Ordering::SeqCst), 1);
-        assert_eq!(computation.responses.len(), 2);
-        let unique_gas_in_sell: HashSet<&str> = computation
-            .responses
-            .iter()
-            .map(|response| response.gas_in_sell.as_str())
-            .collect();
-        assert_eq!(unique_gas_in_sell.len(), 1);
-        for response in &computation.responses {
-            assert_eq!(response.gas_used, vec![2, 5]);
-            assert_eq!(response.gas_in_sell, "3750");
-        }
+        assert_eq!(spot_price_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(computation.responses.len(), 1);
+        assert_eq!(computation.responses[0].gas_used, vec![2, 5]);
+        assert_eq!(computation.responses[0].gas_in_sell, "5");
+    }
+
+    #[tokio::test]
+    async fn get_amounts_out_uses_direct_gas_conversion_for_native_sell_token() {
+        let native = Chain::Ethereum.native_token().address;
+        let wrapped_native = Chain::Ethereum.wrapped_native_token().address;
+        let token_out =
+            Bytes::from_str("0x0000000000000000000000000000000000000003").expect("valid address");
+
+        let native_meta = make_token_with_decimals(&native, "ETH", 18);
+        let wrapped_meta = make_token_with_decimals(&wrapped_native, "WETH", 18);
+        let token_out_meta = make_token_with_decimals(&token_out, "TK3", 6);
+        let token_store = make_token_store(vec![
+            native_meta.clone(),
+            wrapped_meta.clone(),
+            token_out_meta.clone(),
+        ]);
+
+        let native_state_store = Arc::new(StateStore::new(Arc::clone(&token_store)));
+        let vm_state_store = Arc::new(StateStore::new(Arc::clone(&token_store)));
+
+        let limit_calls = Arc::new(AtomicUsize::new(0));
+        let quote_calls = Arc::new(AtomicUsize::new(0));
+        let mut states = HashMap::new();
+        let mut new_pairs = HashMap::new();
+        states.insert(
+            "pool-wrapped".to_string(),
+            Box::new(StrictPairTokenSim {
+                expected_sell: wrapped_native.clone(),
+                expected_buy: token_out.clone(),
+                limit_calls: Arc::clone(&limit_calls),
+                quote_calls: Arc::clone(&quote_calls),
+            }) as Box<dyn ProtocolSim>,
+        );
+        new_pairs.insert(
+            "pool-wrapped".to_string(),
+            make_pair_component(
+                "0x0000000000000000000000000000000000000012",
+                "uniswap_v2",
+                "uniswap_v2",
+                vec![wrapped_meta, token_out_meta],
+            ),
+        );
+
+        native_state_store
+            .apply_update(Update::new(1, states, new_pairs))
+            .await;
+
+        let app_state = make_test_app_state(
+            token_store,
+            native_state_store,
+            vm_state_store,
+            TestAppStateConfig {
+                gas_price_wei: Some(1),
+                gas_reporting_enabled: true,
+                ..TestAppStateConfig::default()
+            },
+        );
+
+        let request = AmountOutRequest {
+            request_id: "req-direct-eth-gas".to_string(),
+            auction_id: None,
+            token_in: native.to_string(),
+            token_out: token_out.to_string(),
+            amounts: vec!["2".to_string()],
+        };
+
+        let computation = get_amounts_out(app_state, request, None).await;
+
+        assert_eq!(quote_calls.load(Ordering::SeqCst), 1);
+        assert!(limit_calls.load(Ordering::SeqCst) >= 1);
+        assert_eq!(computation.responses.len(), 1);
+        assert_eq!(computation.responses[0].gas_in_sell, "21000");
     }
 
     #[tokio::test]
@@ -3733,16 +3055,13 @@ mod tests {
         let token_out_hex = "0x0000000000000000000000000000000000000002";
         let token_in = Bytes::from_str(token_in_hex).expect("valid address");
         let token_out = Bytes::from_str(token_out_hex).expect("valid address");
-        let wrapped_native = Chain::Ethereum.wrapped_native_token().address;
 
         let token_in_meta = make_token_with_decimals(&token_in, "TK1", 6);
         let token_out_meta = make_token_with_decimals(&token_out, "TK2", 6);
-        let wrapped_native_meta = make_token_with_decimals(&wrapped_native, "WETH", 18);
 
         let mut initial_tokens = HashMap::new();
         initial_tokens.insert(token_in.clone(), token_in_meta.clone());
         initial_tokens.insert(token_out.clone(), token_out_meta.clone());
-        initial_tokens.insert(wrapped_native.clone(), wrapped_native_meta.clone());
 
         let token_store = Arc::new(TokenStore::new(
             initial_tokens,
@@ -3774,29 +3093,6 @@ mod tests {
                 "uniswap_v2".to_string(),
                 Chain::Ethereum,
                 vec![token_in_meta.clone(), token_out_meta.clone()],
-                Vec::new(),
-                HashMap::new(),
-                Bytes::default(),
-                NaiveDateTime::default(),
-            ),
-        );
-        states.insert(
-            "pool-spot".to_string(),
-            Box::new(SpotPriceCountingSim {
-                spot_price_value: Some(1.5),
-                max_in: 10_000_000,
-                spot_price_calls: Arc::new(AtomicUsize::new(0)),
-            }) as Box<dyn ProtocolSim>,
-        );
-        new_pairs.insert(
-            "pool-spot".to_string(),
-            ProtocolComponent::new(
-                Bytes::from_str("0x0000000000000000000000000000000000000013")
-                    .expect("valid pool address"),
-                "uniswap_v2".to_string(),
-                "uniswap_v2".to_string(),
-                Chain::Ethereum,
-                vec![token_in_meta.clone(), wrapped_native_meta.clone()],
                 Vec::new(),
                 HashMap::new(),
                 Bytes::default(),
@@ -3848,7 +3144,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_amounts_out_sets_gas_in_sell_to_zero_when_spot_price_fails() {
+    async fn get_amounts_out_sets_gas_in_sell_to_zero_for_non_native_sell_without_probe() {
         let token_in_hex = "0x0000000000000000000000000000000000000001";
         let token_out_hex = "0x0000000000000000000000000000000000000002";
         let token_in = Bytes::from_str(token_in_hex).expect("valid address");
@@ -4242,12 +3538,8 @@ mod tests {
             calls: Arc::clone(&calls),
         };
 
-        let permit = Arc::new(Semaphore::new(1))
-            .acquire_owned()
-            .await
-            .expect("permit");
-
         let outcome = simulate_pool(
+            make_runtime_only_app_state(1, 1),
             "pool-1".to_string(),
             Arc::new(sim),
             "0x0000000000000000000000000000000000000009".to_string(),
@@ -4259,23 +3551,23 @@ mod tests {
             BigUint::from(11u8),
             2,
             Instant::now() + Duration::from_secs(1),
+            Duration::from_millis(50),
             CancellationToken::new(),
-            permit,
         )
-        .await
-        .expect("simulate_pool should return outcome");
+        .await;
 
         assert_eq!(calls.load(Ordering::SeqCst), 2, "probe + lower amount");
         match outcome {
-            PoolSimOutcome::Simulated(result) => {
+            PoolTaskResult::Completed(PoolSimOutcome::Simulated(result)) => {
                 assert_eq!(result.amounts_out.len(), 1);
                 assert_eq!(result.gas_used.len(), 1);
                 assert_eq!(result.errors.len(), 1);
                 assert!(result.errors[0].contains("Probe quote failed"));
             }
-            PoolSimOutcome::SkippedDueToLimits { .. } => {
+            PoolTaskResult::Completed(PoolSimOutcome::SkippedDueToLimits { .. }) => {
                 panic!("mixed ladder should still quote lower amounts")
             }
+            _ => panic!("expected simulated pool outcome"),
         }
     }
 
@@ -4293,12 +3585,8 @@ mod tests {
             calls: Arc::clone(&calls),
         };
 
-        let permit = Arc::new(Semaphore::new(1))
-            .acquire_owned()
-            .await
-            .expect("permit");
-
         let outcome = simulate_pool(
+            make_runtime_only_app_state(1, 1),
             "pool-1".to_string(),
             Arc::new(sim),
             "0x0000000000000000000000000000000000000009".to_string(),
@@ -4310,15 +3598,14 @@ mod tests {
             BigUint::from(20u8),
             2,
             Instant::now() + Duration::from_secs(1),
+            Duration::from_millis(50),
             CancellationToken::new(),
-            permit,
         )
-        .await
-        .expect("simulate_pool should return outcome");
+        .await;
 
         assert_eq!(calls.load(Ordering::SeqCst), 2, "probe + remaining amount");
         match outcome {
-            PoolSimOutcome::Simulated(result) => {
+            PoolTaskResult::Completed(PoolSimOutcome::Simulated(result)) => {
                 assert_eq!(result.amounts_out.len(), 1);
                 assert_eq!(result.gas_used.len(), 1);
                 assert_eq!(result.errors.len(), 1);
@@ -4326,9 +3613,10 @@ mod tests {
                     .to_ascii_lowercase()
                     .contains("sell amount exceeds limit"));
             }
-            PoolSimOutcome::SkippedDueToLimits { .. } => {
+            PoolTaskResult::Completed(PoolSimOutcome::SkippedDueToLimits { .. }) => {
                 panic!("min-amount probe should prevent conservative get_limits skip")
             }
+            _ => panic!("expected simulated pool outcome"),
         }
     }
 
@@ -4755,12 +4043,8 @@ mod tests {
             calls: Arc::clone(&calls),
         };
 
-        let permit = Arc::new(Semaphore::new(1))
-            .acquire_owned()
-            .await
-            .expect("permit");
-
         let outcome = simulate_pool(
+            make_runtime_only_app_state(1, 1),
             "pool-1".to_string(),
             Arc::new(sim),
             "0x0000000000000000000000000000000000000009".to_string(),
@@ -4772,15 +4056,14 @@ mod tests {
             BigUint::from(11u8),
             2,
             Instant::now() + Duration::from_secs(1),
+            Duration::from_millis(50),
             CancellationToken::new(),
-            permit,
         )
-        .await
-        .expect("simulate_pool should return outcome");
+        .await;
 
         assert_eq!(calls.load(Ordering::SeqCst), 2, "probe + lower amount");
         match outcome {
-            PoolSimOutcome::Simulated(result) => {
+            PoolTaskResult::Completed(PoolSimOutcome::Simulated(result)) => {
                 assert_eq!(result.amounts_out.len(), 1);
                 assert_eq!(result.gas_used.len(), 1);
                 assert!(!result.timed_out);
@@ -4788,10 +4071,66 @@ mod tests {
                 assert!(result.errors[0].contains("Probe quote failed"));
                 assert!(result.errors[0].contains("Invalid input"));
             }
-            PoolSimOutcome::SkippedDueToLimits { .. } => {
+            PoolTaskResult::Completed(PoolSimOutcome::SkippedDueToLimits { .. }) => {
                 panic!("non-limit invalid input should not be treated as limits skip")
             }
+            _ => panic!("expected simulated pool outcome"),
         }
+    }
+
+    #[test]
+    fn simulate_pool_starts_timeout_when_blocking_work_actually_begins() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .max_blocking_threads(1)
+            .build()
+            .expect("runtime");
+
+        runtime.block_on(async {
+            let token_in = Bytes::from_str("0x0000000000000000000000000000000000000001")
+                .expect("valid address");
+            let token_out = Bytes::from_str("0x0000000000000000000000000000000000000002")
+                .expect("valid address");
+            let (occupier_started_tx, occupier_started_rx) = tokio::sync::oneshot::channel();
+            let occupier = tokio::task::spawn_blocking(move || {
+                let _ = occupier_started_tx.send(());
+                std::thread::sleep(Duration::from_millis(60));
+            });
+            occupier_started_rx.await.expect("occupier should start");
+
+            let outcome = simulate_pool(
+                make_runtime_only_app_state(1, 1),
+                "pool-delayed".to_string(),
+                Arc::new(SpotPriceCountingSim {
+                    spot_price_value: Some(1.0),
+                    max_in: 1_000_000,
+                    spot_price_calls: Arc::new(AtomicUsize::new(0)),
+                }),
+                "0x0000000000000000000000000000000000000009".to_string(),
+                "uniswap_v2".to_string(),
+                "uniswap_v2".to_string(),
+                Arc::new(make_token(&token_in, "TK1")),
+                Arc::new(make_token(&token_out, "TK2")),
+                Arc::new(vec![BigUint::from(1u8)]),
+                BigUint::from(1u8),
+                1,
+                Instant::now() + Duration::from_secs(1),
+                Duration::from_millis(20),
+                CancellationToken::new(),
+            )
+            .await;
+
+            occupier.await.expect("occupier should finish");
+
+            match outcome {
+                PoolTaskResult::Completed(PoolSimOutcome::Simulated(result)) => {
+                    assert_eq!(result.amounts_out, vec!["1".to_string()]);
+                    assert_eq!(result.gas_used, vec![1]);
+                    assert!(!result.timed_out);
+                }
+                _ => panic!("expected queued pool to complete after blocking thread became free"),
+            }
+        });
     }
 
     #[tokio::test]

--- a/src/services/quotes.rs
+++ b/src/services/quotes.rs
@@ -1,10 +1,15 @@
 use std::str::FromStr;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use futures::stream::{FuturesUnordered, StreamExt};
+use futures::{
+    future::FutureExt,
+    stream::{FuturesUnordered, StreamExt},
+};
 use num_bigint::BigUint;
 use num_traits::{cast::ToPrimitive, Zero};
+use tokio::sync::TryAcquireError;
 use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
@@ -26,7 +31,7 @@ use crate::models::tokens::TokenStoreError;
 use crate::services::native_wrapped::{
     is_direct_native_wrapped_pair, is_native_or_wrapped_token, simulation_tokens_for_pool,
 };
-use crate::services::pool_runtime::{run_blocking_pool_job, PermitAcquire, PoolJobError};
+use crate::services::pool_runtime::{run_blocking_pool_job, PoolJobError};
 
 const VM_LOW_FIRST_GAS_THRESHOLD: u64 = 600_000;
 const VM_LOW_FIRST_GAS_SAMPLE_CAP: usize = 3;
@@ -473,6 +478,12 @@ pub async fn get_amounts_out(
         .unwrap_or_default();
     let mut tasks = FuturesUnordered::new();
     let mut vm_first_gases = Vec::new();
+    let native_semaphore = state.native_sim_semaphore();
+    let vm_semaphore = state.vm_sim_semaphore();
+    // Count pools that actually acquired a permit so timeout metrics stay accurate
+    // without reserving capacity during the enqueue pass.
+    let scheduled_native_pools = Arc::new(AtomicUsize::new(0));
+    let scheduled_vm_pools = Arc::new(AtomicUsize::new(0));
 
     // Native first
     for (id, pool_state, component) in native_candidates.into_iter() {
@@ -510,7 +521,6 @@ pub async fn get_amounts_out(
         );
 
         tasks.push(simulate_pool(
-            state.clone(),
             id,
             pool_state,
             pool_address,
@@ -524,6 +534,8 @@ pub async fn get_amounts_out(
             quote_deadline,
             pool_timeout,
             pool_cancel,
+            native_semaphore.clone(),
+            Arc::clone(&scheduled_native_pools),
         ));
     }
 
@@ -563,7 +575,6 @@ pub async fn get_amounts_out(
         );
 
         tasks.push(simulate_pool(
-            state.clone(),
             id,
             pool_state,
             pool_address,
@@ -577,6 +588,8 @@ pub async fn get_amounts_out(
             quote_deadline,
             pool_timeout,
             pool_cancel,
+            vm_semaphore.clone(),
+            Arc::clone(&scheduled_vm_pools),
         ));
     }
 
@@ -597,163 +610,57 @@ pub async fn get_amounts_out(
                     );
                     failures.push(make_failure(QuoteFailureKind::Timeout, message, None));
                     meta.status = QuoteStatus::PartialSuccess;
+                    drain_ready_pool_outcomes(
+                        &mut tasks,
+                        &mut responses,
+                        &mut failures,
+                        &mut pool_results,
+                        &mut metrics,
+                        &mut meta,
+                        &mut vm_first_gases,
+                        expected_len,
+                        gas_price_wei,
+                        eth_to_sell_spot_price,
+                        sell_token_decimals,
+                        current_block,
+                    );
                     break;
                 }
                 _ = cancel_token.cancelled() => {
                     meta.status = QuoteStatus::PartialSuccess;
+                    drain_ready_pool_outcomes(
+                        &mut tasks,
+                        &mut responses,
+                        &mut failures,
+                        &mut pool_results,
+                        &mut metrics,
+                        &mut meta,
+                        &mut vm_first_gases,
+                        expected_len,
+                        gas_price_wei,
+                        eth_to_sell_spot_price,
+                        sell_token_decimals,
+                        current_block,
+                    );
                     break;
                 }
                 maybe_outcome = tasks.next() => {
                     match maybe_outcome {
                         Some(outcome) => {
-                            if outcome.scheduled() {
-                                record_scheduled_pool_metrics(&mut metrics, outcome.protocol());
-                            }
-                            match outcome {
-                                PoolTaskResult::Completed(outcome) => match outcome {
-                                    PoolSimOutcome::Simulated(result) => {
-                                        let had_timeout = is_timeout_like_outcome(&result);
-                                        let is_partial = result.amounts_out.len() < expected_len;
-                                        record_vm_first_gas_metrics(
-                                            &mut metrics,
-                                            &mut vm_first_gases,
-                                            result.protocol.as_str(),
-                                            result.pool.as_str(),
-                                            result.gas_used.first().copied(),
-                                        );
-
-                                        if let Some((outcome_kind, reason)) =
-                                            classify_pool_outcome(&result, expected_len)
-                                        {
-                                            pool_results.push(make_pool_outcome(
-                                                result.pool.clone(),
-                                                result.pool_name.clone(),
-                                                result.pool_address.clone(),
-                                                result.protocol.clone(),
-                                                outcome_kind,
-                                                result.amounts_out.len(),
-                                                expected_len,
-                                                reason,
-                                            ));
-                                        }
-
-                                        if !result.errors.is_empty() || is_partial {
-                                            let context = FailureContext {
-                                                pool_id: &result.pool,
-                                                pool_name: Some(&result.pool_name),
-                                                pool_address: Some(&result.pool_address),
-                                                protocol: Some(&result.protocol),
-                                            };
-                                            let descriptor = format_pool_descriptor(&context);
-                                            let message = if had_timeout {
-                                                format!(
-                                                    "{}: Quote computation timed out (partial ladder {} of {} steps)",
-                                                    descriptor,
-                                                    result.amounts_out.len(),
-                                                    expected_len
-                                                )
-                                            } else if result.amounts_out.is_empty() {
-                                                let base_error = result
-                                                    .errors
-                                                    .first()
-                                                    .cloned()
-                                                    .unwrap_or_else(|| "Pool returned no quotes".to_string());
-                                                format!("{}: {}", descriptor, base_error)
-                                            } else {
-                                                format!(
-                                                    "{} produced partial ladder ({} of {} steps)",
-                                                    descriptor,
-                                                    result.amounts_out.len(),
-                                                    expected_len
-                                                )
-                                            };
-                                            let kind = if had_timeout {
-                                                QuoteFailureKind::Timeout
-                                            } else if result.amounts_out.is_empty() {
-                                                classify_failure(&message, true)
-                                            } else {
-                                                QuoteFailureKind::InconsistentResult
-                                            };
-                                            failures.push(make_failure(kind, message, Some(context)));
-                                        }
-
-                                        if !result.amounts_out.is_empty() {
-                                            let gas_in_sell = compute_gas_in_sell_base_units(
-                                                gas_price_wei,
-                                                result.gas_used.last().copied(),
-                                                eth_to_sell_spot_price,
-                                                sell_token_decimals,
-                                            );
-                                            responses.push(AmountOutResponse {
-                                                pool: result.pool,
-                                                pool_name: result.pool_name,
-                                                pool_address: result.pool_address,
-                                                amounts_out: result.amounts_out,
-                                                gas_used: result.gas_used,
-                                                gas_in_sell,
-                                                block_number: current_block,
-                                            });
-                                        }
-                                    }
-                                    PoolSimOutcome::SkippedDueToLimits {
-                                        pool,
-                                        pool_name,
-                                        pool_address,
-                                        protocol,
-                                        reason,
-                                    } => {
-                                        if protocol.starts_with("vm:") {
-                                            metrics.skipped_vm_limits += 1;
-                                        } else {
-                                            metrics.skipped_native_limits += 1;
-                                        }
-                                        pool_results.push(make_pool_outcome(
-                                            pool,
-                                            pool_name,
-                                            pool_address,
-                                            protocol,
-                                            PoolOutcomeKind::SkippedPrecheck,
-                                            0,
-                                            expected_len,
-                                            reason,
-                                        ));
-                                    }
-                                },
-                                PoolTaskResult::SkippedDueToConcurrency {
-                                    pool,
-                                    pool_name,
-                                    pool_address,
-                                    protocol,
-                                    reason,
-                                } => {
-                                    if protocol.starts_with("vm:") {
-                                        metrics.skipped_vm_concurrency += 1;
-                                    } else {
-                                        metrics.skipped_native_concurrency += 1;
-                                    }
-                                    pool_results.push(make_pool_outcome(
-                                        pool,
-                                        pool_name,
-                                        pool_address,
-                                        protocol,
-                                        PoolOutcomeKind::SkippedConcurrency,
-                                        0,
-                                        expected_len,
-                                        reason,
-                                    ));
-                                }
-                                PoolTaskResult::Failed { failure, .. } => {
-                                    if let Some(pool_outcome) =
-                                        pool_outcome_from_failure(&failure, expected_len)
-                                    {
-                                        pool_results.push(pool_outcome);
-                                    }
-                                    if matches!(failure.kind, QuoteFailureKind::Internal) {
-                                        meta.status = QuoteStatus::InternalError;
-                                    }
-                                    failures.push(failure);
-                                }
-                            }
+                            handle_pool_task_result(
+                                outcome,
+                                &mut responses,
+                                &mut failures,
+                                &mut pool_results,
+                                &mut metrics,
+                                &mut meta,
+                                &mut vm_first_gases,
+                                expected_len,
+                                gas_price_wei,
+                                eth_to_sell_spot_price,
+                                sell_token_decimals,
+                                current_block,
+                            );
                         }
                         None => break,
                     }
@@ -763,6 +670,8 @@ pub async fn get_amounts_out(
     }
 
     drop(tasks);
+    metrics.scheduled_native_pools = scheduled_native_pools.load(Ordering::Relaxed);
+    metrics.scheduled_vm_pools = scheduled_vm_pools.load(Ordering::Relaxed);
     finalize_vm_first_gas_metrics(&mut metrics, &mut vm_first_gases);
 
     // Record scheduling skips as a single aggregated failure to avoid bloating responses
@@ -937,44 +846,11 @@ enum PoolTaskResult {
     },
     Failed {
         failure: QuoteFailure,
-        scheduled: bool,
     },
-}
-
-impl PoolTaskResult {
-    fn protocol(&self) -> Option<&str> {
-        match self {
-            PoolTaskResult::Completed(PoolSimOutcome::Simulated(result)) => {
-                Some(result.protocol.as_str())
-            }
-            PoolTaskResult::Completed(PoolSimOutcome::SkippedDueToLimits { protocol, .. }) => {
-                Some(protocol.as_str())
-            }
-            PoolTaskResult::SkippedDueToConcurrency { protocol, .. } => Some(protocol.as_str()),
-            PoolTaskResult::Failed { failure, .. } => failure.protocol.as_deref(),
-        }
-    }
-
-    fn scheduled(&self) -> bool {
-        match self {
-            PoolTaskResult::Completed(_) => true,
-            PoolTaskResult::SkippedDueToConcurrency { .. } => false,
-            PoolTaskResult::Failed { scheduled, .. } => *scheduled,
-        }
-    }
-}
-
-fn record_scheduled_pool_metrics(metrics: &mut QuoteMetrics, protocol: Option<&str>) {
-    match protocol {
-        Some(protocol) if protocol.starts_with("vm:") => metrics.scheduled_vm_pools += 1,
-        Some(_) => metrics.scheduled_native_pools += 1,
-        None => {}
-    }
 }
 
 #[allow(clippy::too_many_arguments)]
 async fn simulate_pool(
-    state: AppState,
     pool_id: String,
     pool_state: Arc<dyn ProtocolSim>,
     pool_address: String,
@@ -988,6 +864,8 @@ async fn simulate_pool(
     quote_deadline: Instant,
     pool_timeout: Duration,
     cancel_token: CancellationToken,
+    semaphore: Arc<tokio::sync::Semaphore>,
+    scheduled_pool_count: Arc<AtomicUsize>,
 ) -> PoolTaskResult {
     let pool_id_for_failure = pool_id.clone();
     let pool_addr_for_failure = pool_address.clone();
@@ -997,12 +875,43 @@ async fn simulate_pool(
     let token_out_clone = Arc::clone(&token_out);
     let amounts_clone = Arc::clone(&amounts);
     let cancel_token_clone = cancel_token.clone();
-    let pool_protocol_for_runtime = pool_protocol.clone();
+    let permit = match semaphore.try_acquire_owned() {
+        Ok(permit) => {
+            scheduled_pool_count.fetch_add(1, Ordering::Relaxed);
+            permit
+        }
+        Err(TryAcquireError::NoPermits) => {
+            return PoolTaskResult::SkippedDueToConcurrency {
+                pool: pool_id_for_failure,
+                pool_name: pool_name_for_failure,
+                pool_address: pool_addr_for_failure,
+                protocol: pool_protocol_for_failure,
+                reason: Some(
+                    "Pool scheduling skipped because concurrency permits were exhausted"
+                        .to_string(),
+                ),
+            };
+        }
+        Err(TryAcquireError::Closed) => {
+            let context = FailureContext {
+                pool_id: &pool_id_for_failure,
+                pool_name: Some(pool_name_for_failure.as_str()),
+                pool_address: Some(pool_addr_for_failure.as_str()),
+                protocol: Some(pool_protocol_for_failure.as_str()),
+            };
+            let descriptor = format_pool_descriptor(&context);
+            return PoolTaskResult::Failed {
+                failure: make_failure(
+                    QuoteFailureKind::Internal,
+                    format!("{}: Pool semaphore closed", descriptor),
+                    Some(context),
+                ),
+            };
+        }
+    };
     let result = run_blocking_pool_job(
-        &state,
-        &pool_protocol_for_runtime,
+        permit,
         pool_timeout,
-        PermitAcquire::TryAcquire,
         Some(cancel_token.clone()),
         move |started_at| {
             let deadline = std::cmp::min(started_at + pool_timeout, quote_deadline);
@@ -1290,32 +1199,6 @@ async fn simulate_pool(
 
     match result {
         Ok(outcome) => PoolTaskResult::Completed(outcome),
-        Err(PoolJobError::NoPermit) => PoolTaskResult::SkippedDueToConcurrency {
-            pool: pool_id_for_failure,
-            pool_name: pool_name_for_failure,
-            pool_address: pool_addr_for_failure,
-            protocol: pool_protocol_for_failure,
-            reason: Some(
-                "Pool scheduling skipped because concurrency permits were exhausted".to_string(),
-            ),
-        },
-        Err(PoolJobError::SemaphoreClosed) => {
-            let context = FailureContext {
-                pool_id: &pool_id_for_failure,
-                pool_name: Some(pool_name_for_failure.as_str()),
-                pool_address: Some(pool_addr_for_failure.as_str()),
-                protocol: Some(pool_protocol_for_failure.as_str()),
-            };
-            let descriptor = format_pool_descriptor(&context);
-            PoolTaskResult::Failed {
-                failure: make_failure(
-                    QuoteFailureKind::Internal,
-                    format!("{}: Pool semaphore closed", descriptor),
-                    Some(context),
-                ),
-                scheduled: false,
-            }
-        }
         Err(PoolJobError::TimedOut) => {
             let context = FailureContext {
                 pool_id: &pool_id_for_failure,
@@ -1330,7 +1213,6 @@ async fn simulate_pool(
                     format!("{}: Quote computation timed out", descriptor),
                     Some(context),
                 ),
-                scheduled: true,
             }
         }
         Err(PoolJobError::Cancelled) => {
@@ -1347,7 +1229,6 @@ async fn simulate_pool(
                     format!("{}: Quote computation cancelled", descriptor),
                     Some(context),
                 ),
-                scheduled: true,
             }
         }
         Err(PoolJobError::JoinFailed(join_err)) => {
@@ -1364,9 +1245,201 @@ async fn simulate_pool(
                     format!("{}: Quote computation panicked: {}", descriptor, join_err),
                     Some(context),
                 ),
-                scheduled: true,
             }
         }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn handle_pool_task_result(
+    outcome: PoolTaskResult,
+    responses: &mut Vec<AmountOutResponse>,
+    failures: &mut Vec<QuoteFailure>,
+    pool_results: &mut Vec<PoolSimulationOutcome>,
+    metrics: &mut QuoteMetrics,
+    meta: &mut QuoteMeta,
+    vm_first_gases: &mut Vec<u64>,
+    expected_len: usize,
+    gas_price_wei: Option<u128>,
+    eth_to_sell_spot_price: Option<f64>,
+    sell_token_decimals: u32,
+    current_block: u64,
+) {
+    match outcome {
+        PoolTaskResult::Completed(outcome) => match outcome {
+            PoolSimOutcome::Simulated(result) => {
+                let had_timeout = is_timeout_like_outcome(&result);
+                let is_partial = result.amounts_out.len() < expected_len;
+                record_vm_first_gas_metrics(
+                    metrics,
+                    vm_first_gases,
+                    result.protocol.as_str(),
+                    result.pool.as_str(),
+                    result.gas_used.first().copied(),
+                );
+
+                if let Some((outcome_kind, reason)) = classify_pool_outcome(&result, expected_len) {
+                    pool_results.push(make_pool_outcome(
+                        result.pool.clone(),
+                        result.pool_name.clone(),
+                        result.pool_address.clone(),
+                        result.protocol.clone(),
+                        outcome_kind,
+                        result.amounts_out.len(),
+                        expected_len,
+                        reason,
+                    ));
+                }
+
+                if !result.errors.is_empty() || is_partial {
+                    let context = FailureContext {
+                        pool_id: &result.pool,
+                        pool_name: Some(&result.pool_name),
+                        pool_address: Some(&result.pool_address),
+                        protocol: Some(&result.protocol),
+                    };
+                    let descriptor = format_pool_descriptor(&context);
+                    let message = if had_timeout {
+                        format!(
+                            "{}: Quote computation timed out (partial ladder {} of {} steps)",
+                            descriptor,
+                            result.amounts_out.len(),
+                            expected_len
+                        )
+                    } else if result.amounts_out.is_empty() {
+                        let base_error = result
+                            .errors
+                            .first()
+                            .cloned()
+                            .unwrap_or_else(|| "Pool returned no quotes".to_string());
+                        format!("{}: {}", descriptor, base_error)
+                    } else {
+                        format!(
+                            "{} produced partial ladder ({} of {} steps)",
+                            descriptor,
+                            result.amounts_out.len(),
+                            expected_len
+                        )
+                    };
+                    let kind = if had_timeout {
+                        QuoteFailureKind::Timeout
+                    } else if result.amounts_out.is_empty() {
+                        classify_failure(&message, true)
+                    } else {
+                        QuoteFailureKind::InconsistentResult
+                    };
+                    failures.push(make_failure(kind, message, Some(context)));
+                }
+
+                if !result.amounts_out.is_empty() {
+                    let gas_in_sell = compute_gas_in_sell_base_units(
+                        gas_price_wei,
+                        result.gas_used.last().copied(),
+                        eth_to_sell_spot_price,
+                        sell_token_decimals,
+                    );
+                    responses.push(AmountOutResponse {
+                        pool: result.pool,
+                        pool_name: result.pool_name,
+                        pool_address: result.pool_address,
+                        amounts_out: result.amounts_out,
+                        gas_used: result.gas_used,
+                        gas_in_sell,
+                        block_number: current_block,
+                    });
+                }
+            }
+            PoolSimOutcome::SkippedDueToLimits {
+                pool,
+                pool_name,
+                pool_address,
+                protocol,
+                reason,
+            } => {
+                if protocol.starts_with("vm:") {
+                    metrics.skipped_vm_limits += 1;
+                } else {
+                    metrics.skipped_native_limits += 1;
+                }
+                pool_results.push(make_pool_outcome(
+                    pool,
+                    pool_name,
+                    pool_address,
+                    protocol,
+                    PoolOutcomeKind::SkippedPrecheck,
+                    0,
+                    expected_len,
+                    reason,
+                ));
+            }
+        },
+        PoolTaskResult::SkippedDueToConcurrency {
+            pool,
+            pool_name,
+            pool_address,
+            protocol,
+            reason,
+        } => {
+            if protocol.starts_with("vm:") {
+                metrics.skipped_vm_concurrency += 1;
+            } else {
+                metrics.skipped_native_concurrency += 1;
+            }
+            pool_results.push(make_pool_outcome(
+                pool,
+                pool_name,
+                pool_address,
+                protocol,
+                PoolOutcomeKind::SkippedConcurrency,
+                0,
+                expected_len,
+                reason,
+            ));
+        }
+        PoolTaskResult::Failed { failure } => {
+            if let Some(pool_outcome) = pool_outcome_from_failure(&failure, expected_len) {
+                pool_results.push(pool_outcome);
+            }
+            if matches!(failure.kind, QuoteFailureKind::Internal) {
+                meta.status = QuoteStatus::InternalError;
+            }
+            failures.push(failure);
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn drain_ready_pool_outcomes<F>(
+    tasks: &mut FuturesUnordered<F>,
+    responses: &mut Vec<AmountOutResponse>,
+    failures: &mut Vec<QuoteFailure>,
+    pool_results: &mut Vec<PoolSimulationOutcome>,
+    metrics: &mut QuoteMetrics,
+    meta: &mut QuoteMeta,
+    vm_first_gases: &mut Vec<u64>,
+    expected_len: usize,
+    gas_price_wei: Option<u128>,
+    eth_to_sell_spot_price: Option<f64>,
+    sell_token_decimals: u32,
+    current_block: u64,
+) where
+    F: std::future::Future<Output = PoolTaskResult>,
+{
+    while let Some(Some(outcome)) = tasks.next().now_or_never() {
+        handle_pool_task_result(
+            outcome,
+            responses,
+            failures,
+            pool_results,
+            metrics,
+            meta,
+            vm_first_gases,
+            expected_len,
+            gas_price_wei,
+            eth_to_sell_spot_price,
+            sell_token_decimals,
+            current_block,
+        );
     }
 }
 
@@ -1753,6 +1826,14 @@ mod tests {
     use crate::models::tokens::TokenStore;
 
     fn default_calls() -> Arc<AtomicUsize> {
+        Arc::new(AtomicUsize::new(0))
+    }
+
+    fn test_semaphore() -> Arc<Semaphore> {
+        Arc::new(Semaphore::new(1))
+    }
+
+    fn test_scheduled_counter() -> Arc<AtomicUsize> {
         Arc::new(AtomicUsize::new(0))
     }
 
@@ -2215,25 +2296,6 @@ mod tests {
         }
     }
 
-    fn make_runtime_only_app_state(
-        native_sim_concurrency: usize,
-        vm_sim_concurrency: usize,
-    ) -> AppState {
-        let token_store = make_token_store(Vec::new());
-        let native_state_store = Arc::new(StateStore::new(Arc::clone(&token_store)));
-        let vm_state_store = Arc::new(StateStore::new(Arc::clone(&token_store)));
-        make_test_app_state(
-            token_store,
-            native_state_store,
-            vm_state_store,
-            TestAppStateConfig {
-                native_sim_concurrency,
-                vm_sim_concurrency,
-                ..TestAppStateConfig::default()
-            },
-        )
-    }
-
     #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
     struct SpotPriceCountingSim {
         spot_price_value: Option<f64>,
@@ -2273,6 +2335,69 @@ mod tests {
             _buy_token: Bytes,
         ) -> Result<(BigUint, BigUint), SimulationError> {
             Ok((BigUint::from(self.max_in), BigUint::zero()))
+        }
+
+        fn delta_transition(
+            &mut self,
+            _delta: ProtocolStateDelta,
+            _tokens: &HashMap<Bytes, Token>,
+            _balances: &Balances,
+        ) -> Result<(), TransitionError<String>> {
+            Ok(())
+        }
+
+        fn clone_box(&self) -> Box<dyn ProtocolSim> {
+            Box::new(self.clone())
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn as_any_mut(&mut self) -> &mut dyn Any {
+            self
+        }
+
+        fn eq(&self, other: &dyn ProtocolSim) -> bool {
+            other.as_any().is::<Self>()
+        }
+    }
+
+    #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+    struct SlowQuoteSim {
+        delay_ms: u64,
+    }
+
+    #[typetag::serde]
+    impl ProtocolSim for SlowQuoteSim {
+        fn fee(&self) -> f64 {
+            0.0
+        }
+
+        fn spot_price(&self, _base: &Token, _quote: &Token) -> Result<f64, SimulationError> {
+            Err(SimulationError::FatalError("spot unavailable".to_string()))
+        }
+
+        fn get_amount_out(
+            &self,
+            amount_in: BigUint,
+            _token_in: &Token,
+            _token_out: &Token,
+        ) -> Result<GetAmountOutResult, SimulationError> {
+            std::thread::sleep(Duration::from_millis(self.delay_ms));
+            Ok(GetAmountOutResult::new(
+                amount_in.clone(),
+                BigUint::from(21_000u64),
+                self.clone_box(),
+            ))
+        }
+
+        fn get_limits(
+            &self,
+            _sell_token: Bytes,
+            _buy_token: Bytes,
+        ) -> Result<(BigUint, BigUint), SimulationError> {
+            Ok((BigUint::from(1_000_000u64), BigUint::zero()))
         }
 
         fn delta_transition(
@@ -3539,7 +3664,6 @@ mod tests {
         };
 
         let outcome = simulate_pool(
-            make_runtime_only_app_state(1, 1),
             "pool-1".to_string(),
             Arc::new(sim),
             "0x0000000000000000000000000000000000000009".to_string(),
@@ -3553,6 +3677,8 @@ mod tests {
             Instant::now() + Duration::from_secs(1),
             Duration::from_millis(50),
             CancellationToken::new(),
+            test_semaphore(),
+            test_scheduled_counter(),
         )
         .await;
 
@@ -3586,7 +3712,6 @@ mod tests {
         };
 
         let outcome = simulate_pool(
-            make_runtime_only_app_state(1, 1),
             "pool-1".to_string(),
             Arc::new(sim),
             "0x0000000000000000000000000000000000000009".to_string(),
@@ -3600,6 +3725,8 @@ mod tests {
             Instant::now() + Duration::from_secs(1),
             Duration::from_millis(50),
             CancellationToken::new(),
+            test_semaphore(),
+            test_scheduled_counter(),
         )
         .await;
 
@@ -4044,7 +4171,6 @@ mod tests {
         };
 
         let outcome = simulate_pool(
-            make_runtime_only_app_state(1, 1),
             "pool-1".to_string(),
             Arc::new(sim),
             "0x0000000000000000000000000000000000000009".to_string(),
@@ -4058,6 +4184,8 @@ mod tests {
             Instant::now() + Duration::from_secs(1),
             Duration::from_millis(50),
             CancellationToken::new(),
+            test_semaphore(),
+            test_scheduled_counter(),
         )
         .await;
 
@@ -4099,7 +4227,6 @@ mod tests {
             occupier_started_rx.await.expect("occupier should start");
 
             let outcome = simulate_pool(
-                make_runtime_only_app_state(1, 1),
                 "pool-delayed".to_string(),
                 Arc::new(SpotPriceCountingSim {
                     spot_price_value: Some(1.0),
@@ -4117,6 +4244,8 @@ mod tests {
                 Instant::now() + Duration::from_secs(1),
                 Duration::from_millis(20),
                 CancellationToken::new(),
+                test_semaphore(),
+                test_scheduled_counter(),
             )
             .await;
 
@@ -4131,6 +4260,56 @@ mod tests {
                 _ => panic!("expected queued pool to complete after blocking thread became free"),
             }
         });
+    }
+
+    #[tokio::test]
+    async fn simulate_pool_does_not_reserve_permit_before_poll() {
+        let token_in =
+            Bytes::from_str("0x0000000000000000000000000000000000000001").expect("valid address");
+        let token_out =
+            Bytes::from_str("0x0000000000000000000000000000000000000002").expect("valid address");
+        let semaphore = test_semaphore();
+        let scheduled = test_scheduled_counter();
+
+        let future = simulate_pool(
+            "pool-queued".to_string(),
+            Arc::new(SpotPriceCountingSim {
+                spot_price_value: Some(1.0),
+                max_in: 1_000_000,
+                spot_price_calls: Arc::new(AtomicUsize::new(0)),
+            }),
+            "0x0000000000000000000000000000000000000009".to_string(),
+            "uniswap_v2".to_string(),
+            "uniswap_v2".to_string(),
+            Arc::new(make_token(&token_in, "TK1")),
+            Arc::new(make_token(&token_out, "TK2")),
+            Arc::new(vec![BigUint::from(1u8)]),
+            BigUint::from(1u8),
+            1,
+            Instant::now() + Duration::from_secs(1),
+            Duration::from_millis(50),
+            CancellationToken::new(),
+            semaphore.clone(),
+            Arc::clone(&scheduled),
+        );
+
+        let extra_permit = semaphore
+            .clone()
+            .try_acquire_owned()
+            .expect("queued future should not reserve the only permit");
+        assert_eq!(scheduled.load(Ordering::SeqCst), 0);
+        drop(extra_permit);
+
+        let outcome = future.await;
+
+        assert_eq!(scheduled.load(Ordering::SeqCst), 1);
+        match outcome {
+            PoolTaskResult::Completed(PoolSimOutcome::Simulated(result)) => {
+                assert_eq!(result.amounts_out, vec!["1".to_string()]);
+                assert_eq!(result.gas_used, vec![1]);
+            }
+            _ => panic!("expected queued pool to acquire permit once polled"),
+        }
     }
 
     #[tokio::test]
@@ -4452,6 +4631,96 @@ mod tests {
             .pool_results
             .iter()
             .any(|outcome| outcome.outcome == PoolOutcomeKind::SkippedConcurrency));
+        assert!(computation
+            .meta
+            .failures
+            .iter()
+            .any(|failure| matches!(failure.kind, QuoteFailureKind::ConcurrencyLimit)));
+    }
+
+    #[tokio::test]
+    async fn request_timeout_keeps_scheduling_metrics_and_skip_outcomes() {
+        let token_in_hex = "0x0000000000000000000000000000000000000001";
+        let token_out_hex = "0x0000000000000000000000000000000000000002";
+        let token_in = Bytes::from_str(token_in_hex).expect("valid address");
+        let token_out = Bytes::from_str(token_out_hex).expect("valid address");
+
+        let token_in_meta = make_token(&token_in, "TK1");
+        let token_out_meta = make_token(&token_out, "TK2");
+
+        let token_store = make_token_store(vec![token_in_meta.clone(), token_out_meta.clone()]);
+        let native_state_store = Arc::new(StateStore::new(Arc::clone(&token_store)));
+        let vm_state_store = Arc::new(StateStore::new(Arc::clone(&token_store)));
+
+        let mut states = HashMap::new();
+        let mut new_pairs = HashMap::new();
+        for (pool_id, address) in [
+            ("pool-1", "0x0000000000000000000000000000000000000031"),
+            ("pool-2", "0x0000000000000000000000000000000000000032"),
+            ("pool-3", "0x0000000000000000000000000000000000000033"),
+        ] {
+            states.insert(
+                pool_id.to_string(),
+                Box::new(SlowQuoteSim { delay_ms: 50 }) as Box<dyn ProtocolSim>,
+            );
+            new_pairs.insert(
+                pool_id.to_string(),
+                make_pair_component(
+                    address,
+                    "uniswap_v2",
+                    "uniswap_v2",
+                    vec![token_in_meta.clone(), token_out_meta.clone()],
+                ),
+            );
+        }
+
+        native_state_store
+            .apply_update(Update::new(1, states, new_pairs))
+            .await;
+
+        let mut app_state = make_test_app_state(
+            token_store,
+            Arc::clone(&native_state_store),
+            Arc::clone(&vm_state_store),
+            TestAppStateConfig {
+                native_sim_concurrency: 1,
+                ..TestAppStateConfig::default()
+            },
+        );
+        app_state.quote_timeout = Duration::from_millis(10);
+        app_state.pool_timeout_native = Duration::from_millis(100);
+
+        let request = AmountOutRequest {
+            request_id: "req-timeout-accounting".to_string(),
+            auction_id: None,
+            token_in: token_in_hex.to_string(),
+            token_out: token_out_hex.to_string(),
+            amounts: vec!["1".to_string()],
+        };
+
+        let computation = get_amounts_out(app_state, request, None).await;
+
+        assert!(computation.responses.is_empty());
+        assert_eq!(computation.metrics.scheduled_native_pools, 1);
+        assert_eq!(computation.metrics.skipped_native_concurrency, 2);
+        assert_eq!(
+            computation
+                .meta
+                .pool_results
+                .iter()
+                .filter(|outcome| outcome.outcome == PoolOutcomeKind::SkippedConcurrency)
+                .count(),
+            2
+        );
+        assert!(matches!(
+            computation.meta.status,
+            QuoteStatus::PartialSuccess
+        ));
+        assert!(computation
+            .meta
+            .failures
+            .iter()
+            .any(|failure| matches!(failure.kind, QuoteFailureKind::Timeout)));
         assert!(computation
             .meta
             .failures

--- a/tests/integration/simulate_gas_in_sell.rs
+++ b/tests/integration/simulate_gas_in_sell.rs
@@ -1,5 +1,5 @@
 use std::any::Any;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -9,8 +9,8 @@ use axum::body::{to_bytes, Body};
 use axum::http::{Request, StatusCode};
 use chrono::NaiveDateTime;
 use num_bigint::BigUint;
-use num_traits::{ToPrimitive, Zero};
-use tokio::sync::Semaphore;
+use num_traits::Zero;
+use tokio::sync::{RwLock, Semaphore};
 use tower::ServiceExt;
 use tycho_simulation::protocol::models::{ProtocolComponent, Update};
 use tycho_simulation::tycho_common::dto::ProtocolStateDelta;
@@ -21,21 +21,13 @@ use tycho_simulation::tycho_common::simulation::protocol_sim::{
 };
 use tycho_simulation::tycho_common::Bytes;
 use tycho_simulation_server::api::create_router;
-use tycho_simulation_server::models::messages::AmountOutRequest;
 use tycho_simulation_server::models::state::{AppState, StateStore, VmStreamStatus};
 use tycho_simulation_server::models::stream_health::StreamHealth;
 use tycho_simulation_server::models::tokens::TokenStore;
 
-const ETH_USD_PRICE: u128 = 2_000;
-const GAS_PRICE_WEI: u128 = 50_000_000_000; // 50 gwei
-const WEI_PER_ETH: u128 = 1_000_000_000_000_000_000;
-const USD_MICROS: u128 = 1_000_000;
-const SPOT_PRICE_SCALE: u128 = 1_000_000_000;
-
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 struct SimPool {
     gas_ladder: Vec<u64>,
-    spot_quotes: Vec<(Bytes, Bytes, f64)>,
     #[serde(skip, default = "default_calls")]
     calls: Arc<AtomicUsize>,
 }
@@ -50,12 +42,7 @@ impl ProtocolSim for SimPool {
         0.0
     }
 
-    fn spot_price(&self, base: &Token, quote: &Token) -> Result<f64, SimulationError> {
-        for (b, q, price) in &self.spot_quotes {
-            if *b == base.address && *q == quote.address {
-                return Ok(*price);
-            }
-        }
+    fn spot_price(&self, _base: &Token, _quote: &Token) -> Result<f64, SimulationError> {
         Err(SimulationError::FatalError(
             "spot price not available".to_string(),
         ))
@@ -140,61 +127,67 @@ fn make_component(
     )
 }
 
-#[derive(Clone, Copy)]
-struct PairCase {
-    request_id: &'static str,
-    pool_id: &'static str,
-    token_in: &'static str,
-    token_out: &'static str,
-    sell_decimals: u32,
-    sell_usd_micros: u128,
-    eth_to_sell_spot: f64,
-    expected_last_gas: u64,
+fn make_app_state(
+    token_store: Arc<TokenStore>,
+    native_state_store: Arc<StateStore>,
+    vm_state_store: Arc<StateStore>,
+    gas_price_wei: Option<u128>,
+    gas_reporting_enabled: bool,
+) -> AppState {
+    AppState {
+        tokens: token_store,
+        native_state_store,
+        vm_state_store,
+        native_stream_health: Arc::new(StreamHealth::new()),
+        vm_stream_health: Arc::new(StreamHealth::new()),
+        vm_stream: Arc::new(RwLock::new(VmStreamStatus::default())),
+        latest_native_gas_price_wei: Arc::new(RwLock::new(gas_price_wei)),
+        native_gas_price_reporting_enabled: Arc::new(RwLock::new(gas_reporting_enabled)),
+        enable_vm_pools: false,
+        readiness_stale: Duration::from_secs(120),
+        quote_timeout: Duration::from_secs(1),
+        pool_timeout_native: Duration::from_millis(200),
+        pool_timeout_vm: Duration::from_millis(200),
+        request_timeout: Duration::from_secs(2),
+        native_sim_semaphore: Arc::new(Semaphore::new(1)),
+        vm_sim_semaphore: Arc::new(Semaphore::new(1)),
+        reset_allowance_tokens: Arc::new(HashMap::new()),
+        native_sim_concurrency: 1,
+        vm_sim_concurrency: 1,
+    }
 }
 
-fn gas_cost_usd_micros(gas_used: u64) -> u128 {
-    (u128::from(gas_used) * GAS_PRICE_WEI * ETH_USD_PRICE * USD_MICROS) / WEI_PER_ETH
-}
+async fn post_simulate(router: axum::Router, payload: serde_json::Value) -> serde_json::Value {
+    let response = router
+        .oneshot(
+            Request::post("/simulate")
+                .header("content-type", "application/json")
+                .body(Body::from(payload.to_string()))
+                .expect("request"),
+        )
+        .await
+        .expect("router response");
 
-fn expected_gas_in_sell_base_units(
-    gas_used: u64,
-    sell_decimals: u32,
-    eth_to_sell_spot: f64,
-) -> u128 {
-    let spot_scaled = (eth_to_sell_spot * SPOT_PRICE_SCALE as f64).floor() as u128;
-    let numerator = BigUint::from(gas_used)
-        * BigUint::from(GAS_PRICE_WEI)
-        * BigUint::from(spot_scaled)
-        * BigUint::from(10u32).pow(sell_decimals);
-    let denominator = BigUint::from(SPOT_PRICE_SCALE) * BigUint::from(WEI_PER_ETH);
-    (numerator / denominator)
-        .to_u128()
-        .expect("expected gas_in_sell to fit into u128")
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("response body");
+    serde_json::from_slice(&body).expect("json body")
 }
 
 #[tokio::test]
-async fn simulate_gas_in_sell_matches_gas_price_cost_in_usd_for_multiple_pairs() {
-    let usdt = Bytes::from_str("0xdAC17F958D2ee523a2206206994597C13D831ec7").unwrap();
-    let usdc = Bytes::from_str("0xA0b86991c6218b36c1d19d4a2e9Eb0cE3606eB48").unwrap();
-    let dai = Bytes::from_str("0x6B175474E89094C44Da98b954EedeAC495271d0F").unwrap();
-    let wbtc = Bytes::from_str("0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599").unwrap();
+async fn simulate_gas_in_sell_uses_direct_conversion_for_wrapped_native_sell_token() {
     let weth = Chain::Ethereum.wrapped_native_token().address;
+    let usdc = Bytes::from_str("0xA0b86991c6218b36c1d19d4a2e9Eb0cE3606eB48").unwrap();
 
-    let usdt_token = make_token(&usdt, "USDT", 6);
-    let usdc_token = make_token(&usdc, "USDC", 6);
-    let dai_token = make_token(&dai, "DAI", 18);
-    let wbtc_token = make_token(&wbtc, "WBTC", 8);
     let weth_token = make_token(&weth, "WETH", 18);
-
-    let mut tokens = HashMap::new();
-    tokens.insert(usdt.clone(), usdt_token.clone());
-    tokens.insert(usdc.clone(), usdc_token.clone());
-    tokens.insert(dai.clone(), dai_token.clone());
-    tokens.insert(wbtc.clone(), wbtc_token.clone());
-    tokens.insert(weth.clone(), weth_token.clone());
+    let usdc_token = make_token(&usdc, "USDC", 6);
 
     let token_store = Arc::new(TokenStore::new(
-        tokens,
+        HashMap::from([
+            (weth.clone(), weth_token.clone()),
+            (usdc.clone(), usdc_token.clone()),
+        ]),
         "http://localhost".to_string(),
         "test".to_string(),
         Chain::Ethereum,
@@ -205,338 +198,65 @@ async fn simulate_gas_in_sell_matches_gas_price_cost_in_usd_for_multiple_pairs()
 
     let mut states: HashMap<String, Box<dyn ProtocolSim>> = HashMap::new();
     let mut new_pairs = HashMap::new();
-
-    // Quote pools used by /simulate requests.
     states.insert(
-        "pool-usdt-usdc".to_string(),
+        "pool-weth-usdc".to_string(),
         Box::new(SimPool {
             gas_ladder: vec![120_000, 150_000],
-            spot_quotes: Vec::new(),
             calls: default_calls(),
         }) as Box<dyn ProtocolSim>,
     );
     new_pairs.insert(
-        "pool-usdt-usdc".to_string(),
+        "pool-weth-usdc".to_string(),
         make_component(
             "0x0000000000000000000000000000000000000101",
-            usdt_token.clone(),
-            usdc_token.clone(),
-            "uniswap_v2",
-            "uniswap_v2",
-        ),
-    );
-
-    states.insert(
-        "pool-usdc-dai".to_string(),
-        Box::new(SimPool {
-            gas_ladder: vec![180_000, 210_000],
-            spot_quotes: Vec::new(),
-            calls: default_calls(),
-        }) as Box<dyn ProtocolSim>,
-    );
-    new_pairs.insert(
-        "pool-usdc-dai".to_string(),
-        make_component(
-            "0x0000000000000000000000000000000000000102",
-            usdc_token.clone(),
-            dai_token.clone(),
-            "uniswap_v2",
-            "uniswap_v2",
-        ),
-    );
-
-    states.insert(
-        "pool-dai-usdt".to_string(),
-        Box::new(SimPool {
-            gas_ladder: vec![160_000, 180_000],
-            spot_quotes: Vec::new(),
-            calls: default_calls(),
-        }) as Box<dyn ProtocolSim>,
-    );
-    new_pairs.insert(
-        "pool-dai-usdt".to_string(),
-        make_component(
-            "0x0000000000000000000000000000000000000103",
-            dai_token.clone(),
-            usdt_token.clone(),
-            "uniswap_v2",
-            "uniswap_v2",
-        ),
-    );
-
-    states.insert(
-        "pool-wbtc-usdc".to_string(),
-        Box::new(SimPool {
-            gas_ladder: vec![170_000, 190_000],
-            spot_quotes: Vec::new(),
-            calls: default_calls(),
-        }) as Box<dyn ProtocolSim>,
-    );
-    new_pairs.insert(
-        "pool-wbtc-usdc".to_string(),
-        make_component(
-            "0x0000000000000000000000000000000000000104",
-            wbtc_token.clone(),
-            usdc_token.clone(),
-            "uniswap_v2",
-            "uniswap_v2",
-        ),
-    );
-
-    // Dedicated spot pools for ETH/sell conversion.
-    states.insert(
-        "pool-spot-usdt-weth".to_string(),
-        Box::new(SimPool {
-            gas_ladder: vec![0],
-            spot_quotes: vec![(weth.clone(), usdt.clone(), ETH_USD_PRICE as f64)],
-            calls: default_calls(),
-        }) as Box<dyn ProtocolSim>,
-    );
-    new_pairs.insert(
-        "pool-spot-usdt-weth".to_string(),
-        make_component(
-            "0x0000000000000000000000000000000000000201",
-            usdt_token.clone(),
-            weth_token.clone(),
-            "uniswap_v2",
-            "uniswap_v2",
-        ),
-    );
-
-    states.insert(
-        "pool-spot-usdc-weth".to_string(),
-        Box::new(SimPool {
-            gas_ladder: vec![0],
-            spot_quotes: vec![(weth.clone(), usdc.clone(), ETH_USD_PRICE as f64)],
-            calls: default_calls(),
-        }) as Box<dyn ProtocolSim>,
-    );
-    new_pairs.insert(
-        "pool-spot-usdc-weth".to_string(),
-        make_component(
-            "0x0000000000000000000000000000000000000202",
-            usdc_token.clone(),
-            weth_token.clone(),
-            "uniswap_v2",
-            "uniswap_v2",
-        ),
-    );
-
-    states.insert(
-        "pool-spot-dai-weth".to_string(),
-        Box::new(SimPool {
-            gas_ladder: vec![0],
-            spot_quotes: vec![(weth.clone(), dai.clone(), ETH_USD_PRICE as f64)],
-            calls: default_calls(),
-        }) as Box<dyn ProtocolSim>,
-    );
-    new_pairs.insert(
-        "pool-spot-dai-weth".to_string(),
-        make_component(
-            "0x0000000000000000000000000000000000000203",
-            dai_token.clone(),
-            weth_token.clone(),
-            "uniswap_v2",
-            "uniswap_v2",
-        ),
-    );
-
-    states.insert(
-        "pool-spot-wbtc-weth".to_string(),
-        Box::new(SimPool {
-            gas_ladder: vec![0],
-            // ETH priced in WBTC (1 ETH = 0.03125 WBTC) for deterministic rounding.
-            spot_quotes: vec![(weth.clone(), wbtc.clone(), 0.03125)],
-            calls: default_calls(),
-        }) as Box<dyn ProtocolSim>,
-    );
-    new_pairs.insert(
-        "pool-spot-wbtc-weth".to_string(),
-        make_component(
-            "0x0000000000000000000000000000000000000204",
-            wbtc_token.clone(),
-            weth_token.clone(),
+            weth_token,
+            usdc_token,
             "uniswap_v2",
             "uniswap_v2",
         ),
     );
 
     native_state_store
-        .apply_update(Update::new(42, states, new_pairs))
+        .apply_update(Update::new(1, states, new_pairs))
         .await;
 
-    let app_state = AppState {
-        tokens: Arc::clone(&token_store),
-        native_state_store: Arc::clone(&native_state_store),
-        vm_state_store: Arc::clone(&vm_state_store),
-        native_stream_health: Arc::new(StreamHealth::new()),
-        vm_stream_health: Arc::new(StreamHealth::new()),
-        vm_stream: Arc::new(tokio::sync::RwLock::new(VmStreamStatus::default())),
-        latest_native_gas_price_wei: Arc::new(tokio::sync::RwLock::new(Some(GAS_PRICE_WEI))),
-        native_gas_price_reporting_enabled: Arc::new(tokio::sync::RwLock::new(true)),
-        enable_vm_pools: false,
-        readiness_stale: Duration::from_secs(120),
-        quote_timeout: Duration::from_secs(1),
-        pool_timeout_native: Duration::from_millis(200),
-        pool_timeout_vm: Duration::from_millis(200),
-        request_timeout: Duration::from_secs(2),
-        native_sim_semaphore: Arc::new(Semaphore::new(8)),
-        vm_sim_semaphore: Arc::new(Semaphore::new(1)),
-        reset_allowance_tokens: Arc::new(HashMap::<u64, HashSet<Bytes>>::new()),
-        native_sim_concurrency: 8,
-        vm_sim_concurrency: 1,
-    };
+    let app_state = make_app_state(
+        Arc::clone(&token_store),
+        native_state_store,
+        vm_state_store,
+        Some(1),
+        true,
+    );
 
-    let app = create_router(app_state);
+    let response = post_simulate(
+        create_router(app_state),
+        serde_json::json!({
+            "request_id": "req-direct-weth-gas",
+            "token_in": weth.to_string(),
+            "token_out": usdc.to_string(),
+            "amounts": ["2", "5"]
+        }),
+    )
+    .await;
 
-    let cases = vec![
-        PairCase {
-            request_id: "case-usdt-usdc",
-            pool_id: "pool-usdt-usdc",
-            token_in: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
-            token_out: "0xA0b86991c6218b36c1d19d4a2e9Eb0cE3606eB48",
-            sell_decimals: 6,
-            sell_usd_micros: 1_000_000,
-            eth_to_sell_spot: 2_000.0,
-            expected_last_gas: 150_000,
-        },
-        PairCase {
-            request_id: "case-usdc-dai",
-            pool_id: "pool-usdc-dai",
-            token_in: "0xA0b86991c6218b36c1d19d4a2e9Eb0cE3606eB48",
-            token_out: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
-            sell_decimals: 6,
-            sell_usd_micros: 1_000_000,
-            eth_to_sell_spot: 2_000.0,
-            expected_last_gas: 210_000,
-        },
-        PairCase {
-            request_id: "case-dai-usdt",
-            pool_id: "pool-dai-usdt",
-            token_in: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
-            token_out: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
-            sell_decimals: 18,
-            sell_usd_micros: 1_000_000,
-            eth_to_sell_spot: 2_000.0,
-            expected_last_gas: 180_000,
-        },
-        PairCase {
-            request_id: "case-wbtc-usdc",
-            pool_id: "pool-wbtc-usdc",
-            token_in: "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
-            token_out: "0xA0b86991c6218b36c1d19d4a2e9Eb0cE3606eB48",
-            sell_decimals: 8,
-            sell_usd_micros: 64_000 * USD_MICROS,
-            eth_to_sell_spot: 0.03125,
-            expected_last_gas: 190_000,
-        },
-    ];
-
-    for case in cases {
-        let request = AmountOutRequest {
-            request_id: case.request_id.to_string(),
-            auction_id: None,
-            token_in: case.token_in.to_string(),
-            token_out: case.token_out.to_string(),
-            amounts: vec!["1000000".to_string(), "2000000".to_string()],
-        };
-
-        let response = app
-            .clone()
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri("/simulate")
-                    .header("content-type", "application/json")
-                    .body(Body::from(
-                        serde_json::to_vec(&request).expect("serialize simulate request"),
-                    ))
-                    .expect("build request"),
-            )
-            .await
-            .expect("simulate response");
-
-        let status = response.status();
-        let body = to_bytes(response.into_body(), usize::MAX)
-            .await
-            .expect("read body");
-        assert_eq!(
-            status,
-            StatusCode::OK,
-            "unexpected status {}: {}",
-            status,
-            String::from_utf8_lossy(&body)
-        );
-
-        let value: serde_json::Value =
-            serde_json::from_slice(&body).expect("simulate response JSON");
-        assert_eq!(value["meta"]["status"], "ready");
-
-        let data = value["data"].as_array().expect("data must be array");
-        let entry = data
-            .iter()
-            .find(|item| item["pool"] == case.pool_id)
-            .unwrap_or_else(|| panic!("pool {} not found in simulate response", case.pool_id));
-
-        let gas_used = entry["gas_used"]
-            .as_array()
-            .expect("gas_used must be array");
-        let last_gas_used = gas_used
-            .last()
-            .and_then(|v| v.as_u64())
-            .expect("last gas_used must be u64");
-        assert_eq!(last_gas_used, case.expected_last_gas);
-
-        let gas_in_sell = entry["gas_in_sell"]
-            .as_str()
-            .and_then(|v| v.parse::<u128>().ok())
-            .expect("gas_in_sell must be u128 string");
-
-        let gas_in_sell_usd_micros =
-            (gas_in_sell * case.sell_usd_micros) / 10u128.pow(case.sell_decimals);
-        let gas_price_cost_usd_micros = gas_cost_usd_micros(last_gas_used);
-        let usd_diff = gas_in_sell_usd_micros.abs_diff(gas_price_cost_usd_micros);
-        let usd_tolerance = (case.sell_usd_micros / 10u128.pow(case.sell_decimals)).max(1);
-        assert!(
-            usd_diff <= usd_tolerance,
-            "USD mismatch for {}: left={} right={} diff={} tol={}",
-            case.request_id,
-            gas_in_sell_usd_micros,
-            gas_price_cost_usd_micros,
-            usd_diff,
-            usd_tolerance
-        );
-
-        let expected_base_units = expected_gas_in_sell_base_units(
-            last_gas_used,
-            case.sell_decimals,
-            case.eth_to_sell_spot,
-        );
-        assert_eq!(
-            gas_in_sell, expected_base_units,
-            "base-unit mismatch for {}",
-            case.request_id
-        );
-    }
+    let entry = &response["data"][0];
+    assert_eq!(entry["gas_used"], serde_json::json!([120000, 150000]));
+    assert_eq!(entry["gas_in_sell"], "150000");
 }
 
 #[tokio::test]
 async fn simulate_gas_in_sell_is_zero_when_reporting_disabled() {
     let usdt = Bytes::from_str("0xdAC17F958D2ee523a2206206994597C13D831ec7").unwrap();
     let usdc = Bytes::from_str("0xA0b86991c6218b36c1d19d4a2e9Eb0cE3606eB48").unwrap();
-    let weth = Chain::Ethereum.wrapped_native_token().address;
 
     let usdt_token = make_token(&usdt, "USDT", 6);
     let usdc_token = make_token(&usdc, "USDC", 6);
-    let weth_token = make_token(&weth, "WETH", 18);
-
-    let mut tokens = HashMap::new();
-    tokens.insert(usdt.clone(), usdt_token.clone());
-    tokens.insert(usdc.clone(), usdc_token.clone());
-    tokens.insert(weth.clone(), weth_token.clone());
 
     let token_store = Arc::new(TokenStore::new(
-        tokens,
+        HashMap::from([
+            (usdt.clone(), usdt_token.clone()),
+            (usdc.clone(), usdc_token.clone()),
+        ]),
         "http://localhost".to_string(),
         "test".to_string(),
         Chain::Ethereum,
@@ -547,111 +267,48 @@ async fn simulate_gas_in_sell_is_zero_when_reporting_disabled() {
 
     let mut states: HashMap<String, Box<dyn ProtocolSim>> = HashMap::new();
     let mut new_pairs = HashMap::new();
-
     states.insert(
         "pool-usdt-usdc".to_string(),
         Box::new(SimPool {
             gas_ladder: vec![120_000, 150_000],
-            spot_quotes: Vec::new(),
             calls: default_calls(),
         }) as Box<dyn ProtocolSim>,
     );
     new_pairs.insert(
         "pool-usdt-usdc".to_string(),
         make_component(
-            "0x0000000000000000000000000000000000000301",
-            usdt_token.clone(),
-            usdc_token.clone(),
-            "uniswap_v2",
-            "uniswap_v2",
-        ),
-    );
-
-    states.insert(
-        "pool-spot-usdt-weth".to_string(),
-        Box::new(SimPool {
-            gas_ladder: vec![0],
-            spot_quotes: vec![(weth.clone(), usdt.clone(), ETH_USD_PRICE as f64)],
-            calls: default_calls(),
-        }) as Box<dyn ProtocolSim>,
-    );
-    new_pairs.insert(
-        "pool-spot-usdt-weth".to_string(),
-        make_component(
-            "0x0000000000000000000000000000000000000302",
-            usdt_token.clone(),
-            weth_token.clone(),
+            "0x0000000000000000000000000000000000000102",
+            usdt_token,
+            usdc_token,
             "uniswap_v2",
             "uniswap_v2",
         ),
     );
 
     native_state_store
-        .apply_update(Update::new(42, states, new_pairs))
+        .apply_update(Update::new(1, states, new_pairs))
         .await;
 
-    let app_state = AppState {
-        tokens: Arc::clone(&token_store),
-        native_state_store: Arc::clone(&native_state_store),
-        vm_state_store: Arc::clone(&vm_state_store),
-        native_stream_health: Arc::new(StreamHealth::new()),
-        vm_stream_health: Arc::new(StreamHealth::new()),
-        vm_stream: Arc::new(tokio::sync::RwLock::new(VmStreamStatus::default())),
-        latest_native_gas_price_wei: Arc::new(tokio::sync::RwLock::new(Some(GAS_PRICE_WEI))),
-        native_gas_price_reporting_enabled: Arc::new(tokio::sync::RwLock::new(false)),
-        enable_vm_pools: false,
-        readiness_stale: Duration::from_secs(120),
-        quote_timeout: Duration::from_secs(1),
-        pool_timeout_native: Duration::from_millis(200),
-        pool_timeout_vm: Duration::from_millis(200),
-        request_timeout: Duration::from_secs(2),
-        native_sim_semaphore: Arc::new(Semaphore::new(2)),
-        vm_sim_semaphore: Arc::new(Semaphore::new(1)),
-        reset_allowance_tokens: Arc::new(HashMap::<u64, HashSet<Bytes>>::new()),
-        native_sim_concurrency: 2,
-        vm_sim_concurrency: 1,
-    };
-
-    let app = create_router(app_state);
-    let request = AmountOutRequest {
-        request_id: "reporting-disabled".to_string(),
-        auction_id: None,
-        token_in: "0xdAC17F958D2ee523a2206206994597C13D831ec7".to_string(),
-        token_out: "0xA0b86991c6218b36c1d19d4a2e9Eb0cE3606eB48".to_string(),
-        amounts: vec!["1000000".to_string(), "2000000".to_string()],
-    };
-
-    let response = app
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/simulate")
-                .header("content-type", "application/json")
-                .body(Body::from(
-                    serde_json::to_vec(&request).expect("serialize simulate request"),
-                ))
-                .expect("build request"),
-        )
-        .await
-        .expect("simulate response");
-
-    let status = response.status();
-    let body = to_bytes(response.into_body(), usize::MAX)
-        .await
-        .expect("read body");
-    assert_eq!(
-        status,
-        StatusCode::OK,
-        "unexpected status {}: {}",
-        status,
-        String::from_utf8_lossy(&body)
+    let app_state = make_app_state(
+        Arc::clone(&token_store),
+        native_state_store,
+        vm_state_store,
+        Some(1),
+        false,
     );
 
-    let value: serde_json::Value = serde_json::from_slice(&body).expect("simulate response JSON");
-    let data = value["data"].as_array().expect("data must be array");
-    let entry = data
-        .iter()
-        .find(|item| item["pool"] == "pool-usdt-usdc")
-        .expect("quote pool not found");
+    let response = post_simulate(
+        create_router(app_state),
+        serde_json::json!({
+            "request_id": "req-reporting-disabled",
+            "token_in": usdt.to_string(),
+            "token_out": usdc.to_string(),
+            "amounts": ["2", "5"]
+        }),
+    )
+    .await;
+
+    let entry = &response["data"][0];
+    assert_eq!(entry["gas_used"], serde_json::json!([120000, 150000]));
     assert_eq!(entry["gas_in_sell"], "0");
 }

--- a/tests/integration/simulate_gas_in_sell.rs
+++ b/tests/integration/simulate_gas_in_sell.rs
@@ -9,7 +9,7 @@ use axum::body::{to_bytes, Body};
 use axum::http::{Request, StatusCode};
 use chrono::NaiveDateTime;
 use num_bigint::BigUint;
-use num_traits::Zero;
+use num_traits::{ToPrimitive, Zero};
 use tokio::sync::{RwLock, Semaphore};
 use tower::ServiceExt;
 use tycho_simulation::protocol::models::{ProtocolComponent, Update};
@@ -25,9 +25,14 @@ use tycho_simulation_server::models::state::{AppState, StateStore, VmStreamStatu
 use tycho_simulation_server::models::stream_health::StreamHealth;
 use tycho_simulation_server::models::tokens::TokenStore;
 
+const GAS_PRICE_WEI: u128 = 50_000_000_000; // 50 gwei
+const WEI_PER_ETH: u128 = 1_000_000_000_000_000_000;
+const SPOT_PRICE_SCALE: u128 = 1_000_000_000;
+
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 struct SimPool {
     gas_ladder: Vec<u64>,
+    spot_quotes: Vec<(Bytes, Bytes, f64)>,
     #[serde(skip, default = "default_calls")]
     calls: Arc<AtomicUsize>,
 }
@@ -42,7 +47,12 @@ impl ProtocolSim for SimPool {
         0.0
     }
 
-    fn spot_price(&self, _base: &Token, _quote: &Token) -> Result<f64, SimulationError> {
+    fn spot_price(&self, base: &Token, quote: &Token) -> Result<f64, SimulationError> {
+        for (base_address, quote_address, price) in &self.spot_quotes {
+            if *base_address == base.address && *quote_address == quote.address {
+                return Ok(*price);
+            }
+        }
         Err(SimulationError::FatalError(
             "spot price not available".to_string(),
         ))
@@ -101,6 +111,22 @@ impl ProtocolSim for SimPool {
     fn eq(&self, other: &dyn ProtocolSim) -> bool {
         other.as_any().is::<SimPool>()
     }
+}
+
+fn expected_gas_in_sell_base_units(
+    gas_used: u64,
+    sell_decimals: u32,
+    eth_to_sell_spot: f64,
+) -> u128 {
+    let spot_scaled = (eth_to_sell_spot * SPOT_PRICE_SCALE as f64).floor() as u128;
+    let numerator = BigUint::from(gas_used)
+        * BigUint::from(GAS_PRICE_WEI)
+        * BigUint::from(spot_scaled)
+        * BigUint::from(10u32).pow(sell_decimals);
+    let denominator = BigUint::from(SPOT_PRICE_SCALE) * BigUint::from(WEI_PER_ETH);
+    (numerator / denominator)
+        .to_u128()
+        .expect("expected gas_in_sell to fit into u128")
 }
 
 fn make_token(address: &Bytes, symbol: &str, decimals: u32) -> Token {
@@ -202,6 +228,7 @@ async fn simulate_gas_in_sell_uses_direct_conversion_for_wrapped_native_sell_tok
         "pool-weth-usdc".to_string(),
         Box::new(SimPool {
             gas_ladder: vec![120_000, 150_000],
+            spot_quotes: Vec::new(),
             calls: default_calls(),
         }) as Box<dyn ProtocolSim>,
     );
@@ -245,6 +272,105 @@ async fn simulate_gas_in_sell_uses_direct_conversion_for_wrapped_native_sell_tok
 }
 
 #[tokio::test]
+async fn simulate_gas_in_sell_uses_sell_token_spot_pool_for_non_native_sell_token() {
+    let usdt = Bytes::from_str("0xdAC17F958D2ee523a2206206994597C13D831ec7").unwrap();
+    let usdc = Bytes::from_str("0xA0b86991c6218b36c1d19d4a2e9Eb0cE3606eB48").unwrap();
+    let weth = Chain::Ethereum.wrapped_native_token().address;
+
+    let usdt_token = make_token(&usdt, "USDT", 6);
+    let usdc_token = make_token(&usdc, "USDC", 6);
+    let weth_token = make_token(&weth, "WETH", 18);
+
+    let token_store = Arc::new(TokenStore::new(
+        HashMap::from([
+            (usdt.clone(), usdt_token.clone()),
+            (usdc.clone(), usdc_token.clone()),
+            (weth.clone(), weth_token.clone()),
+        ]),
+        "http://localhost".to_string(),
+        "test".to_string(),
+        Chain::Ethereum,
+        Duration::from_secs(1),
+    ));
+    let native_state_store = Arc::new(StateStore::new(Arc::clone(&token_store)));
+    let vm_state_store = Arc::new(StateStore::new(Arc::clone(&token_store)));
+
+    let mut states: HashMap<String, Box<dyn ProtocolSim>> = HashMap::new();
+    let mut new_pairs = HashMap::new();
+    states.insert(
+        "pool-usdt-usdc".to_string(),
+        Box::new(SimPool {
+            gas_ladder: vec![120_000, 150_000],
+            spot_quotes: Vec::new(),
+            calls: default_calls(),
+        }) as Box<dyn ProtocolSim>,
+    );
+    new_pairs.insert(
+        "pool-usdt-usdc".to_string(),
+        make_component(
+            "0x0000000000000000000000000000000000000102",
+            usdt_token.clone(),
+            usdc_token,
+            "uniswap_v2",
+            "uniswap_v2",
+        ),
+    );
+    states.insert(
+        "pool-spot-usdt-weth".to_string(),
+        Box::new(SimPool {
+            gas_ladder: vec![0],
+            spot_quotes: vec![(weth.clone(), usdt.clone(), 2_000.0)],
+            calls: default_calls(),
+        }) as Box<dyn ProtocolSim>,
+    );
+    new_pairs.insert(
+        "pool-spot-usdt-weth".to_string(),
+        make_component(
+            "0x0000000000000000000000000000000000000201",
+            usdt_token.clone(),
+            weth_token,
+            "uniswap_v2",
+            "uniswap_v2",
+        ),
+    );
+
+    native_state_store
+        .apply_update(Update::new(1, states, new_pairs))
+        .await;
+
+    let app_state = make_app_state(
+        Arc::clone(&token_store),
+        native_state_store,
+        vm_state_store,
+        Some(GAS_PRICE_WEI),
+        true,
+    );
+
+    let response = post_simulate(
+        create_router(app_state),
+        serde_json::json!({
+            "request_id": "req-usdt-gas",
+            "token_in": usdt.to_string(),
+            "token_out": usdc.to_string(),
+            "amounts": ["2", "5"]
+        }),
+    )
+    .await;
+
+    let entry = &response["data"][0];
+    let gas_in_sell = entry["gas_in_sell"]
+        .as_str()
+        .and_then(|value| value.parse::<u128>().ok())
+        .expect("gas_in_sell must be a u128 string");
+
+    assert_eq!(entry["gas_used"], serde_json::json!([120000, 150000]));
+    assert_eq!(
+        gas_in_sell,
+        expected_gas_in_sell_base_units(150_000, usdt_token.decimals, 2_000.0)
+    );
+}
+
+#[tokio::test]
 async fn simulate_gas_in_sell_is_zero_when_reporting_disabled() {
     let usdt = Bytes::from_str("0xdAC17F958D2ee523a2206206994597C13D831ec7").unwrap();
     let usdc = Bytes::from_str("0xA0b86991c6218b36c1d19d4a2e9Eb0cE3606eB48").unwrap();
@@ -271,6 +397,7 @@ async fn simulate_gas_in_sell_is_zero_when_reporting_disabled() {
         "pool-usdt-usdc".to_string(),
         Box::new(SimPool {
             gas_ladder: vec![120_000, 150_000],
+            spot_quotes: Vec::new(),
             calls: default_calls(),
         }) as Box<dyn ProtocolSim>,
     );


### PR DESCRIPTION
This PR moves quote semaphore acquisition back to poll time so requests only reserve permits when work is about to start, preventing premature locking and reducing unnecessary backpressure. It keeps quote scheduling and timeout accounting behavior intact, with only small quote-path refactors to preserve existing semantics.