### PR TITLE
feat: Centralize simulator chain config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Tycho API settings
 TYCHO_API_KEY=your_api_key_here
-# Runtime chain selection (required): 1 = Ethereum, 8453 = Base
+# Runtime chain selection (required): must match a chain in simulator-manifest.toml
 CHAIN_ID=1
 # Hosted Tycho endpoint is selected automatically from CHAIN_ID.
 # Optional JSON-RPC endpoint matching CHAIN_ID, used for on-chain helpers like ERC4626 deposits
@@ -73,5 +73,4 @@ BEBOP_USER=
 BEBOP_KEY=
 HASHFLOW_USER=
 HASHFLOW_KEY=
-BEBOP_URL=
 HASHFLOW_FILENAME_CSV=

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4386,7 +4386,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.23.10+spec-1.0.0",
 ]
 
 [[package]]
@@ -5179,6 +5179,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "toml",
  "tracing",
  "tracing-subscriber 0.3.22",
  "tycho-common 0.152.4",
@@ -5549,6 +5550,15 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -6201,6 +6211,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6211,12 +6242,26 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow",
 ]
@@ -6229,6 +6274,12 @@ checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }
 tokio-stream = "0.1.18"
 tokio-util = "0.7"
+toml = "0.8"
 tower = { version = "0.5", features = ["timeout", "util"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "time"] }

--- a/Dockerfile.simulator-service
+++ b/Dockerfile.simulator-service
@@ -16,6 +16,7 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 COPY --from=builder /app/target/release/dsolver-simulator-service /usr/local/bin/dsolver-simulator-service
+COPY --from=builder /app/simulator-manifest.toml /app/simulator-manifest.toml
 COPY --from=builder /app/hashflow_supported_tokens.csv /app/hashflow_supported_tokens.csv
 ENV HASHFLOW_FILENAME_CSV=/app/hashflow_supported_tokens.csv
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ DSolver Simulator is a Rust service for DeFi quote simulation and route encoding
 | Runtime | Axum + Tokio |
 | Binary | `dsolver-simulator-service` |
 | Endpoints | `GET /status`, `POST /simulate`, `POST /encode` |
-| Supported chains | Ethereum (`1`), Base (`8453`) |
+| Supported chains | Defined in `simulator-manifest.toml` |
 | Required inputs | `TYCHO_API_KEY`, `CHAIN_ID` |
 | Common optional inputs | `RPC_URL`, `ENABLE_VM_POOLS`, `ENABLE_RFQ_POOLS`, `HOST`, `PORT` |
 | License | MIT |
@@ -80,7 +80,7 @@ workspace binary you're targeting.
 Required runtime inputs:
 
 - `TYCHO_API_KEY` for Tycho access
-- `CHAIN_ID` for chain selection (`1` Ethereum, `8453` Base)
+- `CHAIN_ID` for chain selection from `simulator-manifest.toml`
 
 Common optional inputs:
 

--- a/crates/apps/tests/integration/encode_route.rs
+++ b/crates/apps/tests/integration/encode_route.rs
@@ -13,6 +13,7 @@ use num_bigint::BigUint;
 use num_traits::Zero;
 use rpc::create_router;
 use runtime::config::SlippageConfig;
+use runtime::models::erc4626::Erc4626PairPolicy;
 use runtime::models::state::{AppState, RfqStreamStatus, StateStore, VmStreamStatus};
 use runtime::models::stream_health::StreamHealth;
 use runtime::models::tokens::TokenStore;
@@ -219,6 +220,46 @@ impl ProtocolSim for SlowAmountSim {
 
 fn make_token(address: &Bytes, symbol: &str, chain: Chain) -> Token {
     Token::new(address, symbol, 18, 0, &[], chain, 100)
+}
+
+#[expect(
+    clippy::panic,
+    reason = "integration test fixtures should fail immediately on invalid literal addresses"
+)]
+fn test_address(value: &str) -> Bytes {
+    match Bytes::from_str(value) {
+        Ok(address) => address,
+        Err(err) => panic!("test address must parse: {err}"),
+    }
+}
+
+fn erc4626_pair_policies() -> Vec<Erc4626PairPolicy> {
+    vec![
+        Erc4626PairPolicy {
+            asset_symbol: "USDS".to_string(),
+            share_symbol: "sUSDS".to_string(),
+            asset: test_address("0xdC035D45d973E3EC169d2276DDab16f1e407384F"),
+            share: test_address("0xa3931d71877c0e7a3148cb7eb4463524fec27fbd"),
+            allow_asset_to_share: true,
+            allow_share_to_asset: true,
+        },
+        Erc4626PairPolicy {
+            asset_symbol: "USDC".to_string(),
+            share_symbol: "sUSDC".to_string(),
+            asset: test_address("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
+            share: test_address("0xBc65ad17c5C0a2A4D159fa5a503f4992c7B545FE"),
+            allow_asset_to_share: true,
+            allow_share_to_asset: true,
+        },
+        Erc4626PairPolicy {
+            asset_symbol: "PYUSD".to_string(),
+            share_symbol: "spPYUSD".to_string(),
+            asset: test_address("0x6c3ea9036406852006290770BEdFcAbA0e23A0e8"),
+            share: test_address("0x80128DbB9f07b93DDE62A6daeadb69ED14a7D354"),
+            allow_asset_to_share: true,
+            allow_share_to_asset: true,
+        },
+    ]
 }
 
 fn parse_bytes(value: &str) -> Result<Bytes> {
@@ -556,6 +597,7 @@ async fn build_app_state_and_request(
         rfq_sim_semaphore: Arc::new(Semaphore::new(1)),
         slippage: SlippageConfig::default(),
         erc4626_deposits_enabled: config.erc4626_deposits_enabled,
+        erc4626_pair_policies: Arc::new(erc4626_pair_policies()),
         reset_allowance_tokens: Arc::new(reset_allowance_tokens),
         native_sim_concurrency: 4,
         vm_sim_concurrency: 1,
@@ -657,6 +699,7 @@ async fn setup_timeout_app(
         rfq_sim_semaphore: Arc::new(Semaphore::new(1)),
         slippage: SlippageConfig::default(),
         erc4626_deposits_enabled: false,
+        erc4626_pair_policies: Arc::new(erc4626_pair_policies()),
         reset_allowance_tokens: Arc::new(HashMap::new()),
         native_sim_concurrency: 1,
         vm_sim_concurrency: 1,
@@ -1417,6 +1460,7 @@ async fn encode_route_rejects_mixed_route_with_unsupported_erc4626_hop() -> Resu
         rfq_sim_semaphore: Arc::new(Semaphore::new(1)),
         slippage: SlippageConfig::default(),
         erc4626_deposits_enabled: false,
+        erc4626_pair_policies: Arc::new(erc4626_pair_policies()),
         reset_allowance_tokens: Arc::new(HashMap::new()),
         native_sim_concurrency: 4,
         vm_sim_concurrency: 1,

--- a/crates/apps/tests/integration/protocol_reset_memory.rs
+++ b/crates/apps/tests/integration/protocol_reset_memory.rs
@@ -630,6 +630,7 @@ async fn vm_rebuild_resets_store_and_blocks_quotes() {
         rfq_sim_semaphore: Arc::new(Semaphore::new(4)),
         slippage: SlippageConfig::default(),
         erc4626_deposits_enabled: false,
+        erc4626_pair_policies: Arc::new(Vec::new()),
         reset_allowance_tokens: Arc::new(HashMap::new()),
         native_sim_concurrency: 4,
         vm_sim_concurrency: 4,

--- a/crates/rpc/src/handlers/readiness.rs
+++ b/crates/rpc/src/handlers/readiness.rs
@@ -265,6 +265,7 @@ mod tests {
             rfq_sim_semaphore: Arc::new(tokio::sync::Semaphore::new(1)),
             slippage: SlippageConfig::default(),
             erc4626_deposits_enabled: false,
+            erc4626_pair_policies: Arc::new(Vec::new()),
             reset_allowance_tokens: Arc::new(HashMap::new()),
             native_sim_concurrency: 1,
             vm_sim_concurrency: 1,

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -25,6 +25,7 @@ serde_json.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
 tokio-util.workspace = true
+toml.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 tycho-common.workspace = true

--- a/crates/runtime/src/config/manifest.rs
+++ b/crates/runtime/src/config/manifest.rs
@@ -1,0 +1,465 @@
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::Path;
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde::Deserialize;
+use simulator_core::models::protocol::ProtocolKind;
+use tycho_simulation::tycho_common::{models::Chain, Bytes};
+
+use crate::models::erc4626::Erc4626PairPolicy;
+
+pub(crate) const MANIFEST_VERSION: u32 = 1;
+pub(crate) const MANIFEST_PATH: &str = "simulator-manifest.toml";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum BackendKind {
+    Native,
+    Vm,
+    Rfq,
+}
+
+impl BackendKind {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Native => "native",
+            Self::Vm => "vm",
+            Self::Rfq => "rfq",
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ManifestRegistries {
+    chains: HashMap<u64, ChainRegistryEntry>,
+    route_policies: HashMap<String, RoutePolicyRegistryEntry>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ResolvedChainConfig {
+    pub(crate) chain_profile: ResolvedChainProfile,
+    pub(crate) tycho_url: String,
+    pub(crate) bebop_url: String,
+    pub(crate) hashflow_filename: String,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ResolvedChainProfile {
+    pub(crate) chain: Chain,
+    pub(crate) native_protocols: Vec<String>,
+    pub(crate) vm_protocols: Vec<String>,
+    pub(crate) rfq_protocols: Vec<String>,
+    pub(crate) native_token_protocol_allowlist: Vec<String>,
+    pub(crate) reset_allowance_tokens: HashMap<u64, HashSet<Bytes>>,
+    pub(crate) erc4626_pair_policies: Vec<Erc4626PairPolicy>,
+}
+
+#[derive(Clone, Debug)]
+struct ChainRegistryEntry {
+    chain_id: u64,
+    tycho_url: String,
+    bebop_url: String,
+    hashflow_filename: String,
+    native_protocols: Vec<String>,
+    vm_protocols: Vec<String>,
+    rfq_protocols: Vec<String>,
+    route_policy_id: String,
+}
+
+#[derive(Clone, Debug)]
+struct RoutePolicyRegistryEntry {
+    native_token_protocol_allowlist: Vec<String>,
+    reset_allowance_tokens: HashSet<Bytes>,
+    erc4626_pair_policies: Vec<Erc4626PairPolicy>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawManifest {
+    version: u32,
+    protocols: Vec<RawProtocol>,
+    route_policies: Vec<RawRoutePolicy>,
+    chains: Vec<RawChain>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawProtocol {
+    id: String,
+    backend: BackendKind,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawRoutePolicy {
+    id: String,
+    native_token_protocol_allowlist: Vec<String>,
+    reset_allowance_tokens: Vec<String>,
+    #[serde(default)]
+    erc4626_pairs: Vec<RawErc4626PairPolicy>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawErc4626PairPolicy {
+    asset_symbol: String,
+    share_symbol: String,
+    asset: String,
+    share: String,
+    allow_asset_to_share: bool,
+    allow_share_to_asset: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawChain {
+    chain_id: u64,
+    tycho_url: String,
+    bebop_url: String,
+    hashflow_filename: String,
+    native_protocols: Vec<String>,
+    vm_protocols: Vec<String>,
+    rfq_protocols: Vec<String>,
+    route_policy: String,
+}
+
+pub(crate) fn load_manifest_registries(path: &Path) -> Result<ManifestRegistries> {
+    let contents = fs::read_to_string(path)
+        .with_context(|| format!("failed to read manifest at {}", path.display()))?;
+    parse_manifest_registries(&contents)
+}
+
+pub(crate) fn parse_manifest_registries(contents: &str) -> Result<ManifestRegistries> {
+    let manifest: RawManifest =
+        toml::from_str(contents).context("failed to parse simulator-manifest.toml")?;
+    validate_manifest_version(manifest.version)?;
+
+    // Build the registries in dependency order so validation can stay strict and local.
+    let protocols = validate_protocols(&manifest.protocols)?;
+    let route_policies = validate_route_policies(&manifest.route_policies, &protocols)?;
+    let chains = validate_chains(&manifest.chains, &protocols, &route_policies)?;
+
+    Ok(ManifestRegistries {
+        chains,
+        route_policies,
+    })
+}
+
+pub(crate) fn resolve_chain_config(
+    registries: &ManifestRegistries,
+    chain_id: u64,
+    hashflow_filename_override: Option<String>,
+) -> Result<ResolvedChainConfig> {
+    let chain = registries.chains.get(&chain_id).ok_or_else(|| {
+        anyhow!("Unsupported CHAIN_ID={chain_id}: not defined in simulator-manifest.toml")
+    })?;
+    let route_policy = registries
+        .route_policies
+        .get(&chain.route_policy_id)
+        .ok_or_else(|| {
+            anyhow!(
+                "Chain {} references unknown route policy {}",
+                chain.chain_id,
+                chain.route_policy_id
+            )
+        })?;
+
+    let mut reset_allowance_tokens = HashMap::new();
+    // Route policies are shared in the manifest, but the runtime still consumes reset allowances
+    // keyed by the active chain id.
+    if !route_policy.reset_allowance_tokens.is_empty() {
+        reset_allowance_tokens.insert(chain.chain_id, route_policy.reset_allowance_tokens.clone());
+    }
+
+    Ok(ResolvedChainConfig {
+        chain_profile: ResolvedChainProfile {
+            chain: chain_from_id(chain.chain_id)?,
+            native_protocols: chain.native_protocols.clone(),
+            vm_protocols: chain.vm_protocols.clone(),
+            rfq_protocols: chain.rfq_protocols.clone(),
+            native_token_protocol_allowlist: route_policy.native_token_protocol_allowlist.clone(),
+            reset_allowance_tokens,
+            erc4626_pair_policies: route_policy.erc4626_pair_policies.clone(),
+        },
+        tycho_url: chain.tycho_url.clone(),
+        bebop_url: chain.bebop_url.clone(),
+        hashflow_filename: hashflow_filename_override
+            .unwrap_or_else(|| chain.hashflow_filename.clone()),
+    })
+}
+
+fn chain_from_id(chain_id: u64) -> Result<Chain> {
+    supported_runtime_chains()
+        .into_iter()
+        .find(|chain| chain.id() == chain_id)
+        .ok_or_else(|| anyhow!("chain {chain_id} is not supported by the current runtime"))
+}
+
+fn supported_runtime_chains() -> [Chain; 7] {
+    [
+        Chain::Ethereum,
+        Chain::Starknet,
+        Chain::ZkSync,
+        Chain::Arbitrum,
+        Chain::Base,
+        Chain::Bsc,
+        Chain::Unichain,
+    ]
+}
+
+fn validate_manifest_version(version: u32) -> Result<()> {
+    if version != MANIFEST_VERSION {
+        bail!("unsupported manifest version {version}; expected {MANIFEST_VERSION}");
+    }
+    Ok(())
+}
+
+fn validate_protocols(protocols: &[RawProtocol]) -> Result<HashMap<String, BackendKind>> {
+    let mut protocols_by_id = HashMap::new();
+
+    for protocol in protocols {
+        let protocol_id = required_string("protocol.id", &protocol.id)?;
+        if ProtocolKind::from_sync_state_key(protocol_id).is_none() {
+            bail!("unknown protocol id {protocol_id}");
+        }
+        if protocols_by_id
+            .insert(protocol_id.to_string(), protocol.backend)
+            .is_some()
+        {
+            bail!("duplicate protocol id {protocol_id}");
+        }
+    }
+
+    Ok(protocols_by_id)
+}
+
+fn validate_route_policies(
+    route_policies: &[RawRoutePolicy],
+    protocols: &HashMap<String, BackendKind>,
+) -> Result<HashMap<String, RoutePolicyRegistryEntry>> {
+    let mut registry = HashMap::new();
+
+    for policy in route_policies {
+        let policy_id = required_string("route_policies.id", &policy.id)?;
+        if registry.contains_key(policy_id) {
+            bail!("duplicate route-policy id {policy_id}");
+        }
+
+        for protocol_id in &policy.native_token_protocol_allowlist {
+            let protocol_id = required_string(
+                &format!("route_policies[{policy_id}].native_token_protocol_allowlist"),
+                protocol_id,
+            )?;
+            let backend = protocols.get(protocol_id).ok_or_else(|| {
+                anyhow!("route policy {policy_id} references unknown protocol {protocol_id}")
+            })?;
+            if *backend != BackendKind::Native {
+                bail!("route policy {policy_id} allowlists non-native protocol {protocol_id}");
+            }
+        }
+
+        let mut reset_allowance_tokens = HashSet::new();
+        for token in &policy.reset_allowance_tokens {
+            let address = parse_address(
+                &format!("route_policies[{policy_id}].reset_allowance_tokens"),
+                token,
+            )?;
+            if !reset_allowance_tokens.insert(address) {
+                bail!("duplicate reset-allowance token in route policy {policy_id}");
+            }
+        }
+
+        let mut erc4626_pair_policies = Vec::with_capacity(policy.erc4626_pairs.len());
+        // ERC4626 direction rules live with the route policy because they affect routing behavior,
+        // not whether the protocol exists for a chain at all.
+        for pair in &policy.erc4626_pairs {
+            let asset_symbol = required_string(
+                &format!("route_policies[{policy_id}].erc4626_pairs.asset_symbol"),
+                &pair.asset_symbol,
+            )?;
+            let share_symbol = required_string(
+                &format!("route_policies[{policy_id}].erc4626_pairs.share_symbol"),
+                &pair.share_symbol,
+            )?;
+            let asset = parse_address(
+                &format!("route_policies[{policy_id}].erc4626_pairs.asset"),
+                &pair.asset,
+            )?;
+            let share = parse_address(
+                &format!("route_policies[{policy_id}].erc4626_pairs.share"),
+                &pair.share,
+            )?;
+            if asset == share {
+                bail!("route policy {policy_id} contains an ERC4626 pair with matching asset/share addresses");
+            }
+            if !pair.allow_asset_to_share && !pair.allow_share_to_asset {
+                bail!(
+                    "route policy {policy_id} contains an ERC4626 pair with no enabled directions"
+                );
+            }
+
+            erc4626_pair_policies.push(Erc4626PairPolicy {
+                asset_symbol: asset_symbol.to_string(),
+                share_symbol: share_symbol.to_string(),
+                asset,
+                share,
+                allow_asset_to_share: pair.allow_asset_to_share,
+                allow_share_to_asset: pair.allow_share_to_asset,
+            });
+        }
+
+        registry.insert(
+            policy_id.to_string(),
+            RoutePolicyRegistryEntry {
+                native_token_protocol_allowlist: policy.native_token_protocol_allowlist.clone(),
+                reset_allowance_tokens,
+                erc4626_pair_policies,
+            },
+        );
+    }
+
+    Ok(registry)
+}
+
+fn validate_chains(
+    chains: &[RawChain],
+    protocols: &HashMap<String, BackendKind>,
+    route_policies: &HashMap<String, RoutePolicyRegistryEntry>,
+) -> Result<HashMap<u64, ChainRegistryEntry>> {
+    let mut registry = HashMap::new();
+
+    for chain in chains {
+        if registry.contains_key(&chain.chain_id) {
+            bail!("duplicate chain id {}", chain.chain_id);
+        }
+        let _runtime_chain = chain_from_id(chain.chain_id)?;
+
+        let tycho_url = required_string(
+            &format!("chains[{}].tycho_url", chain.chain_id),
+            &chain.tycho_url,
+        )?;
+        let bebop_url = required_string(
+            &format!("chains[{}].bebop_url", chain.chain_id),
+            &chain.bebop_url,
+        )?;
+        let hashflow_filename = required_string(
+            &format!("chains[{}].hashflow_filename", chain.chain_id),
+            &chain.hashflow_filename,
+        )?;
+        let route_policy_id = required_string(
+            &format!("chains[{}].route_policy", chain.chain_id),
+            &chain.route_policy,
+        )?;
+        if !route_policies.contains_key(route_policy_id) {
+            bail!(
+                "chain {} references unknown route policy {}",
+                chain.chain_id,
+                route_policy_id
+            );
+        }
+
+        validate_backend_protocol_refs(
+            chain.chain_id,
+            BackendKind::Native,
+            &chain.native_protocols,
+            protocols,
+        )?;
+        validate_backend_protocol_refs(
+            chain.chain_id,
+            BackendKind::Vm,
+            &chain.vm_protocols,
+            protocols,
+        )?;
+        validate_backend_protocol_refs(
+            chain.chain_id,
+            BackendKind::Rfq,
+            &chain.rfq_protocols,
+            protocols,
+        )?;
+
+        registry.insert(
+            chain.chain_id,
+            ChainRegistryEntry {
+                chain_id: chain.chain_id,
+                tycho_url: tycho_url.to_string(),
+                bebop_url: bebop_url.to_string(),
+                hashflow_filename: hashflow_filename.to_string(),
+                native_protocols: chain.native_protocols.clone(),
+                vm_protocols: chain.vm_protocols.clone(),
+                rfq_protocols: chain.rfq_protocols.clone(),
+                route_policy_id: route_policy_id.to_string(),
+            },
+        );
+    }
+
+    Ok(registry)
+}
+
+fn validate_backend_protocol_refs(
+    chain_id: u64,
+    backend: BackendKind,
+    protocol_ids: &[String],
+    protocols: &HashMap<String, BackendKind>,
+) -> Result<()> {
+    let mut seen = HashSet::new();
+    // Chains can only point at globally declared protocols for the matching backend. That keeps a
+    // typo or copy/paste mixup from silently turning into a weird runtime config.
+    for protocol_id in protocol_ids {
+        let protocol_id = required_string(
+            &format!("chains[{chain_id}].{}_protocols", backend.label()),
+            protocol_id,
+        )?;
+        if !seen.insert(protocol_id) {
+            bail!(
+                "chain {chain_id} lists protocol {protocol_id} more than once for backend {}",
+                backend.label()
+            );
+        }
+        let declared_backend = protocols
+            .get(protocol_id)
+            .ok_or_else(|| anyhow!("chain {chain_id} references unknown protocol {protocol_id}"))?;
+        if *declared_backend != backend {
+            bail!(
+                "chain {chain_id} assigns protocol {protocol_id} to backend {} but manifest declares {}",
+                backend.label(),
+                declared_backend.label()
+            );
+        }
+    }
+    Ok(())
+}
+
+fn required_string<'a>(field: &str, value: &'a str) -> Result<&'a str> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        bail!("{field} must not be empty");
+    }
+    Ok(trimmed)
+}
+
+fn parse_address(field: &str, value: &str) -> Result<Bytes> {
+    let bytes: Bytes = value
+        .parse()
+        .map_err(|_| anyhow!("invalid address in {field}: {value}"))?;
+    if bytes.len() != 20 {
+        bail!("invalid 20-byte address in {field}: {value}");
+    }
+    Ok(bytes)
+}
+
+impl<'de> Deserialize<'de> for BackendKind {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        match value.as_str() {
+            "native" => Ok(Self::Native),
+            "vm" => Ok(Self::Vm),
+            "rfq" => Ok(Self::Rfq),
+            other => Err(serde::de::Error::custom(format!(
+                "unknown backend kind {other}"
+            ))),
+        }
+    }
+}

--- a/crates/runtime/src/config/mod.rs
+++ b/crates/runtime/src/config/mod.rs
@@ -5,11 +5,13 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use tycho_simulation::tycho_common::{models::Chain, Bytes};
-use tycho_simulation::utils::get_default_url;
 
 mod logging;
+mod manifest;
 mod memory;
+use crate::models::erc4626::Erc4626PairPolicy;
 pub use logging::init_logging;
+pub(crate) use manifest::{load_manifest_registries, resolve_chain_config, MANIFEST_PATH};
 pub use memory::MemoryConfig;
 
 /// Per-chain runtime profile resolved from `CHAIN_ID`.
@@ -22,93 +24,7 @@ pub struct ChainProfile {
     /// Protocols allowed to swap with the native token (e.g. rocketpool on Ethereum).
     pub native_token_protocol_allowlist: Vec<String>,
     pub reset_allowance_tokens: HashMap<u64, HashSet<Bytes>>,
-}
-
-pub(crate) const ETHEREUM_NATIVE_PROTOCOLS: &[&str] = &[
-    "uniswap_v2",
-    "sushiswap_v2",
-    "pancakeswap_v2",
-    "uniswap_v3",
-    "pancakeswap_v3",
-    "uniswap_v4",
-    "ekubo_v2",
-    "fluid_v1",
-    "rocketpool",
-    "ekubo_v3",
-    "erc4626",
-];
-pub(crate) const ETHEREUM_VM_PROTOCOLS: &[&str] = &["vm:curve", "vm:balancer_v2", "vm:maverick_v2"];
-pub(crate) const ETHEREUM_RFQ_PROTOCOLS: &[&str] = &["rfq:bebop", "rfq:hashflow"];
-pub(crate) const BASE_NATIVE_PROTOCOLS: &[&str] = &[
-    "uniswap_v2",
-    "uniswap_v3",
-    "uniswap_v4",
-    "pancakeswap_v3",
-    "aerodrome_slipstreams",
-];
-pub(crate) const BASE_VM_PROTOCOLS: &[&str] = &[];
-pub(crate) const BASE_RFQ_PROTOCOLS: &[&str] = &["rfq:bebop", "rfq:hashflow"];
-
-/// Get the default Bebop URL for the given chain.
-pub fn get_default_bebop_url(chain: &Chain) -> Option<String> {
-    match chain {
-        Chain::Ethereum => Some("https://api.bebop.xyz/pmm/ethereum/v3/tokens".to_string()),
-        Chain::Base => Some("https://api.bebop.xyz/pmm/base/v3/tokens".to_string()),
-        _ => None,
-    }
-}
-
-/// Get the default Hashflow Filename for the given chain.
-pub fn get_default_hashflow_filename(chain: &Chain) -> Option<String> {
-    match chain {
-        Chain::Ethereum | Chain::Base => Some("./hashflow_supported_tokens.csv".to_string()),
-        _ => None,
-    }
-}
-
-fn profile_protocols(protocols: &[&str]) -> Vec<String> {
-    protocols
-        .iter()
-        .map(|protocol| (*protocol).to_string())
-        .collect()
-}
-
-fn ethereum_profile() -> ChainProfile {
-    let mut reset_tokens = HashMap::new();
-    let mut mainnet = HashSet::new();
-    mainnet.insert(parse_address(ETHEREUM_USDT));
-    reset_tokens.insert(ETHEREUM_CHAIN_ID, mainnet);
-
-    ChainProfile {
-        chain: Chain::Ethereum,
-        native_protocols: profile_protocols(ETHEREUM_NATIVE_PROTOCOLS),
-        vm_protocols: profile_protocols(ETHEREUM_VM_PROTOCOLS),
-        rfq_protocols: profile_protocols(ETHEREUM_RFQ_PROTOCOLS),
-        native_token_protocol_allowlist: vec!["rocketpool".into()],
-        reset_allowance_tokens: reset_tokens,
-    }
-}
-
-fn base_profile() -> ChainProfile {
-    ChainProfile {
-        chain: Chain::Base,
-        native_protocols: profile_protocols(BASE_NATIVE_PROTOCOLS),
-        vm_protocols: profile_protocols(BASE_VM_PROTOCOLS),
-        rfq_protocols: profile_protocols(BASE_RFQ_PROTOCOLS),
-        native_token_protocol_allowlist: vec![],
-        reset_allowance_tokens: HashMap::new(),
-    }
-}
-
-fn resolve_chain_profile(chain_id: u64) -> Result<ChainProfile, String> {
-    match chain_id {
-        1 => Ok(ethereum_profile()),
-        8453 => Ok(base_profile()),
-        other => Err(format!(
-            "Unsupported CHAIN_ID={}: supported values are 1 (Ethereum), 8453 (Base)",
-            other
-        )),
-    }
+    pub erc4626_pair_policies: Vec<Erc4626PairPolicy>,
 }
 
 pub fn load_config() -> AppConfig {
@@ -121,25 +37,55 @@ pub fn load_config() -> AppConfig {
             std::process::exit(2);
         }
     };
-    let chain_profile = match resolve_chain_profile(chain_id) {
-        Ok(profile) => profile,
+    // The manifest owns the chain-specific wiring now. Env vars still cover runtime-only settings
+    // and the handful of overrides we want to keep outside the checked-in defaults.
+    let registries = match load_manifest_registries(std::path::Path::new(MANIFEST_PATH)) {
+        Ok(registries) => registries,
+        Err(message) => {
+            eprintln!("Failed to load simulator-manifest.toml: {message}");
+            std::process::exit(2);
+        }
+    };
+    let network = load_network_config();
+    let resolved_chain = match resolve_chain_config(
+        &registries,
+        chain_id,
+        optional_trimmed_env("HASHFLOW_FILENAME_CSV"),
+    ) {
+        Ok(chain) => chain,
         Err(message) => {
             eprintln!("{message}");
             std::process::exit(2);
         }
     };
-    let network = load_network_config();
     let timeouts = load_timeout_config();
     let concurrency = load_concurrency_config();
     let stream = load_stream_config();
     let slippage = load_slippage_config();
+    // Keep the rest of the runtime on the same AppConfig shape. The manifest is just the new
+    // source of truth for the chain-specific slice.
+    let chain_profile = ChainProfile {
+        chain: resolved_chain.chain_profile.chain,
+        native_protocols: resolved_chain.chain_profile.native_protocols,
+        vm_protocols: resolved_chain.chain_profile.vm_protocols,
+        rfq_protocols: resolved_chain.chain_profile.rfq_protocols,
+        native_token_protocol_allowlist: resolved_chain
+            .chain_profile
+            .native_token_protocol_allowlist,
+        reset_allowance_tokens: resolved_chain.chain_profile.reset_allowance_tokens,
+        erc4626_pair_policies: resolved_chain.chain_profile.erc4626_pair_policies,
+    };
     let reset_allowance_tokens = Arc::new(chain_profile.reset_allowance_tokens.clone());
+    let erc4626_pair_policies = Arc::new(chain_profile.erc4626_pair_policies.clone());
     let memory = MemoryConfig::from_env();
     let rfq_enabled = rfq_effectively_enabled(network.enable_rfq_pools, &chain_profile);
     let (bebop_user, bebop_key, hashflow_user, hashflow_key) = load_rfq_credentials(rfq_enabled);
 
     AppConfig {
         chain_profile,
+        tycho_url: resolved_chain.tycho_url,
+        bebop_url: resolved_chain.bebop_url,
+        hashflow_filename: resolved_chain.hashflow_filename,
         api_key: network.api_key,
         rpc_url: network.rpc_url,
         tvl_threshold: network.tvl_threshold,
@@ -158,6 +104,7 @@ pub fn load_config() -> AppConfig {
         global_vm_sim_concurrency: concurrency.global_vm_sim_concurrency,
         global_rfq_sim_concurrency: concurrency.global_rfq_sim_concurrency,
         reset_allowance_tokens,
+        erc4626_pair_policies,
         stream_stale_secs: stream.stream_stale_secs,
         stream_missing_block_burst: stream.stream_missing_block_burst,
         stream_missing_block_window_secs: stream.stream_missing_block_window_secs,
@@ -280,28 +227,6 @@ impl Default for SlippageConfig {
             saturation_ramp_start_slippage_bps: 45,
         }
     }
-}
-
-/// Resolve the hosted Tycho endpoint for a supported runtime chain.
-pub fn hosted_tycho_url(chain: Chain) -> Result<String, String> {
-    get_default_url(&chain)
-        .ok_or_else(|| format!("No default Tycho URL configured for supported chain {chain}"))
-}
-
-/// Resolve the hosted Bebop endpoint for a supported runtime chain.
-pub fn hosted_bebop_url(chain: Chain) -> Result<String, String> {
-    get_default_bebop_url(&chain)
-        .ok_or_else(|| format!("No default Bebop URL configured for supported chain {chain}"))
-}
-
-/// Resolve the hosted Hashflow endpoint for a supported runtime chain.
-pub fn hosted_hashflow_filename(chain: Chain) -> Result<String, String> {
-    if let Some(filename) = optional_trimmed_env("HASHFLOW_FILENAME_CSV") {
-        return Ok(filename);
-    }
-
-    get_default_hashflow_filename(&chain)
-        .ok_or_else(|| format!("No default Hashflow URL configured for supported chain {chain}"))
 }
 
 fn load_network_config() -> NetworkConfig {
@@ -484,6 +409,9 @@ fn load_slippage_config() -> SlippageConfig {
 #[derive(Clone)]
 pub struct AppConfig {
     pub chain_profile: ChainProfile,
+    pub tycho_url: String,
+    pub bebop_url: String,
+    pub hashflow_filename: String,
     pub api_key: String,
     pub rpc_url: Option<String>,
     pub tvl_threshold: f64,
@@ -502,6 +430,7 @@ pub struct AppConfig {
     pub global_vm_sim_concurrency: usize,
     pub global_rfq_sim_concurrency: usize,
     pub reset_allowance_tokens: Arc<HashMap<u64, HashSet<Bytes>>>,
+    pub erc4626_pair_policies: Arc<Vec<Erc4626PairPolicy>>,
     pub stream_stale_secs: u64,
     pub stream_missing_block_burst: u64,
     pub stream_missing_block_window_secs: u64,
@@ -518,18 +447,6 @@ pub struct AppConfig {
     pub bebop_key: String,
     pub hashflow_user: String,
     pub hashflow_key: String,
-}
-
-const ETHEREUM_CHAIN_ID: u64 = 1;
-const ETHEREUM_USDT: &str = "0xdAC17F958D2ee523a2206206994597C13D831ec7";
-
-fn parse_address(value: &str) -> Bytes {
-    let bytes: Bytes = parse_value_or_panic("reset_allowance_tokens address", value);
-    assert!(
-        bytes.len() == 20,
-        "reset_allowance_tokens address must be 20 bytes"
-    );
-    bytes
 }
 
 fn env_or_default(key: &str, default: &str) -> String {
@@ -613,121 +530,257 @@ mod tests {
         }
     }
 
-    #[test]
-    fn resolve_ethereum_profile() {
-        let Ok(profile) = resolve_chain_profile(1) else {
-            unreachable!("expected ethereum profile");
+    fn manifest_path() -> std::path::PathBuf {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../simulator-manifest.toml")
+    }
+
+    fn load_test_registries() -> manifest::ManifestRegistries {
+        let Ok(registries) = load_manifest_registries(&manifest_path()) else {
+            unreachable!("expected checked-in simulator-manifest.toml to parse");
         };
-        assert_eq!(profile.chain, Chain::Ethereum);
-        assert!(profile.native_protocols.contains(&"uniswap_v2".to_string()));
-        assert!(profile.native_protocols.contains(&"rocketpool".to_string()));
-        assert!(profile.native_protocols.contains(&"erc4626".to_string()));
-        assert!(profile.vm_protocols.contains(&"vm:curve".to_string()));
-        assert!(profile.rfq_protocols.contains(&"rfq:bebop".to_string()));
-        assert!(profile
+        registries
+    }
+
+    #[test]
+    fn resolve_chain_config_reads_ethereum_from_manifest() {
+        let registries = load_test_registries();
+        let Ok(chain) = resolve_chain_config(&registries, 1, None) else {
+            unreachable!("expected ethereum manifest entry");
+        };
+
+        assert_eq!(chain.chain_profile.chain, Chain::Ethereum);
+        assert_eq!(chain.tycho_url, "tycho-beta.propellerheads.xyz");
+        assert_eq!(
+            chain.bebop_url,
+            "https://api.bebop.xyz/pmm/ethereum/v3/tokens"
+        );
+        assert_eq!(chain.hashflow_filename, "./hashflow_supported_tokens.csv");
+        assert!(chain
+            .chain_profile
+            .native_protocols
+            .contains(&"rocketpool".to_string()));
+        assert!(chain
+            .chain_profile
+            .vm_protocols
+            .contains(&"vm:curve".to_string()));
+        assert!(chain
+            .chain_profile
+            .rfq_protocols
+            .contains(&"rfq:bebop".to_string()));
+        assert!(chain
+            .chain_profile
             .native_token_protocol_allowlist
             .contains(&"rocketpool".to_string()));
-        assert!(profile.reset_allowance_tokens.contains_key(&1));
+        assert!(chain.chain_profile.reset_allowance_tokens.contains_key(&1));
+        assert_eq!(chain.chain_profile.erc4626_pair_policies.len(), 3);
     }
 
     #[test]
-    fn resolve_base_profile() {
-        let Ok(profile) = resolve_chain_profile(8453) else {
-            unreachable!("expected base profile");
+    fn resolve_chain_config_reads_base_from_manifest() {
+        let registries = load_test_registries();
+        let Ok(chain) = resolve_chain_config(&registries, 8453, None) else {
+            unreachable!("expected base manifest entry");
         };
-        assert_eq!(profile.chain, Chain::Base);
-        assert!(profile.native_protocols.contains(&"uniswap_v2".to_string()));
-        assert!(profile.native_protocols.contains(&"uniswap_v3".to_string()));
-        assert!(profile.native_protocols.contains(&"uniswap_v4".to_string()));
-        assert!(profile
-            .native_protocols
-            .contains(&"pancakeswap_v3".to_string()));
-        assert!(profile
+
+        assert_eq!(chain.chain_profile.chain, Chain::Base);
+        assert_eq!(chain.tycho_url, "tycho-base-beta.propellerheads.xyz");
+        assert!(chain
+            .chain_profile
             .native_protocols
             .contains(&"aerodrome_slipstreams".to_string()));
-        assert_eq!(profile.native_protocols.len(), 5);
-        assert!(profile.vm_protocols.is_empty());
-        assert!(profile.rfq_protocols.contains(&"rfq:bebop".to_string()));
-        assert!(profile.rfq_protocols.contains(&"rfq:hashflow".to_string()));
-        assert!(profile.native_token_protocol_allowlist.is_empty());
-        assert!(profile.reset_allowance_tokens.is_empty());
+        assert!(chain.chain_profile.vm_protocols.is_empty());
+        assert!(chain
+            .chain_profile
+            .rfq_protocols
+            .contains(&"rfq:hashflow".to_string()));
+        assert!(chain
+            .chain_profile
+            .native_token_protocol_allowlist
+            .is_empty());
+        assert!(chain.chain_profile.reset_allowance_tokens.is_empty());
+        assert!(chain.chain_profile.erc4626_pair_policies.is_empty());
     }
 
     #[test]
-    fn resolve_unsupported_chain_errors() {
-        let Err(err) = resolve_chain_profile(999) else {
-            unreachable!("expected unsupported chain to error");
+    fn resolve_chain_config_prefers_hashflow_env_override() {
+        let registries = load_test_registries();
+        let Ok(chain) = resolve_chain_config(&registries, 8453, Some("/tmp/hashflow.csv".into()))
+        else {
+            unreachable!("expected base manifest entry");
         };
-        assert!(err.contains("Unsupported CHAIN_ID=999"));
+
+        assert_eq!(chain.hashflow_filename, "/tmp/hashflow.csv");
     }
 
     #[test]
-    fn hosted_tycho_url_uses_ethereum_default() {
-        let Ok(url) = hosted_tycho_url(Chain::Ethereum) else {
-            unreachable!("expected ethereum hosted Tycho URL");
+    fn parse_manifest_rejects_duplicate_protocol_ids() {
+        let manifest = r#"
+version = 1
+
+[[protocols]]
+id = "uniswap_v2"
+backend = "native"
+
+[[protocols]]
+id = "uniswap_v2"
+backend = "native"
+
+[[route_policies]]
+id = "default"
+native_token_protocol_allowlist = []
+reset_allowance_tokens = []
+
+[[chains]]
+chain_id = 1
+tycho_url = "tycho"
+bebop_url = "bebop"
+hashflow_filename = "./hashflow.csv"
+native_protocols = ["uniswap_v2"]
+vm_protocols = []
+rfq_protocols = []
+route_policy = "default"
+"#;
+
+        let Err(err) = manifest::parse_manifest_registries(manifest) else {
+            unreachable!("expected duplicate protocol ids to fail");
         };
-        assert_eq!(url, "tycho-beta.propellerheads.xyz");
+
+        assert!(err.to_string().contains("duplicate protocol id"));
     }
 
     #[test]
-    fn hosted_tycho_url_uses_base_default() {
-        let Ok(url) = hosted_tycho_url(Chain::Base) else {
-            unreachable!("expected base hosted Tycho URL");
+    fn parse_manifest_rejects_unknown_route_policy_references() {
+        let manifest = r#"
+version = 1
+
+[[protocols]]
+id = "uniswap_v2"
+backend = "native"
+
+[[route_policies]]
+id = "default"
+native_token_protocol_allowlist = []
+reset_allowance_tokens = []
+
+[[chains]]
+chain_id = 1
+tycho_url = "tycho"
+bebop_url = "bebop"
+hashflow_filename = "./hashflow.csv"
+native_protocols = ["uniswap_v2"]
+vm_protocols = []
+rfq_protocols = []
+route_policy = "missing"
+"#;
+
+        let Err(err) = manifest::parse_manifest_registries(manifest) else {
+            unreachable!("expected missing route-policy reference to fail");
         };
-        assert_eq!(url, "tycho-base-beta.propellerheads.xyz");
+
+        assert!(err.to_string().contains("unknown route policy"));
     }
 
     #[test]
-    fn hosted_bebop_url_uses_ethereum_default() {
-        let Ok(url) = hosted_bebop_url(Chain::Ethereum) else {
-            unreachable!("expected ethereum hosted Bebop URL");
+    fn parse_manifest_rejects_unsupported_chain_ids() {
+        let manifest = r#"
+version = 1
+
+[[protocols]]
+id = "uniswap_v2"
+backend = "native"
+
+[[route_policies]]
+id = "default"
+native_token_protocol_allowlist = []
+reset_allowance_tokens = []
+
+[[chains]]
+chain_id = 999999
+tycho_url = "tycho"
+bebop_url = "bebop"
+hashflow_filename = "./hashflow.csv"
+native_protocols = ["uniswap_v2"]
+vm_protocols = []
+rfq_protocols = []
+route_policy = "default"
+"#;
+
+        let Err(err) = manifest::parse_manifest_registries(manifest) else {
+            unreachable!("expected unsupported chain id to fail");
         };
-        assert_eq!(url, "https://api.bebop.xyz/pmm/ethereum/v3/tokens");
+
+        assert!(err
+            .to_string()
+            .contains("not supported by the current runtime"));
     }
 
     #[test]
-    fn hosted_bebop_url_uses_base_default() {
-        let Ok(url) = hosted_bebop_url(Chain::Base) else {
-            unreachable!("expected base hosted Bebop URL");
+    fn parse_manifest_rejects_erc4626_pairs_without_enabled_directions() {
+        let manifest = r#"
+version = 1
+
+[[protocols]]
+id = "erc4626"
+backend = "native"
+
+[[route_policies]]
+id = "default"
+native_token_protocol_allowlist = []
+reset_allowance_tokens = []
+
+[[route_policies.erc4626_pairs]]
+asset_symbol = "USDS"
+share_symbol = "sUSDS"
+asset = "0xdC035D45d973E3EC169d2276DDab16f1e407384F"
+share = "0xa3931d71877c0e7a3148cb7eb4463524fec27fbd"
+allow_asset_to_share = false
+allow_share_to_asset = false
+
+[[chains]]
+chain_id = 1
+tycho_url = "tycho"
+bebop_url = "bebop"
+hashflow_filename = "./hashflow.csv"
+native_protocols = ["erc4626"]
+vm_protocols = []
+rfq_protocols = []
+route_policy = "default"
+"#;
+
+        let Err(err) = manifest::parse_manifest_registries(manifest) else {
+            unreachable!("expected invalid ERC4626 pair to fail");
         };
-        assert_eq!(url, "https://api.bebop.xyz/pmm/base/v3/tokens");
-    }
 
-    #[test]
-    fn hosted_hashflow_filename_uses_ethereum_default() {
-        let Ok(filename) = hosted_hashflow_filename(Chain::Ethereum) else {
-            unreachable!("expected ethereum hosted Hashflow filename");
-        };
-        assert_eq!(filename, "./hashflow_supported_tokens.csv");
-    }
-
-    #[test]
-    fn hosted_hashflow_filename_uses_base_default() {
-        let Ok(filename) = hosted_hashflow_filename(Chain::Base) else {
-            unreachable!("expected base hosted Hashflow filename");
-        };
-        assert_eq!(filename, "./hashflow_supported_tokens.csv");
-    }
-
-    #[test]
-    fn hosted_hashflow_filename_prefers_env_override() {
-        let _guard = ENV_MUTEX
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        std::env::set_var("HASHFLOW_FILENAME_CSV", "/tmp/hashflow.csv");
-
-        let Ok(filename) = hosted_hashflow_filename(Chain::Base) else {
-            unreachable!("expected base hosted Hashflow filename");
-        };
-
-        std::env::remove_var("HASHFLOW_FILENAME_CSV");
-        assert_eq!(filename, "/tmp/hashflow.csv");
+        assert!(err.to_string().contains("no enabled directions"));
     }
 
     #[test]
     fn rfq_effectively_enabled_requires_flag_and_protocols() {
-        let ethereum = ethereum_profile();
-        let base = base_profile();
+        let registries = load_test_registries();
+        let ethereum = resolve_chain_config(&registries, 1, None)
+            .unwrap_or_else(|_| unreachable!("expected ethereum manifest entry"))
+            .chain_profile;
+        let base = resolve_chain_config(&registries, 8453, None)
+            .unwrap_or_else(|_| unreachable!("expected base manifest entry"))
+            .chain_profile;
+        let ethereum = ChainProfile {
+            chain: ethereum.chain,
+            native_protocols: ethereum.native_protocols,
+            vm_protocols: ethereum.vm_protocols,
+            rfq_protocols: ethereum.rfq_protocols,
+            native_token_protocol_allowlist: ethereum.native_token_protocol_allowlist,
+            reset_allowance_tokens: ethereum.reset_allowance_tokens,
+            erc4626_pair_policies: ethereum.erc4626_pair_policies,
+        };
+        let base = ChainProfile {
+            chain: base.chain,
+            native_protocols: base.native_protocols,
+            vm_protocols: base.vm_protocols,
+            rfq_protocols: base.rfq_protocols,
+            native_token_protocol_allowlist: base.native_token_protocol_allowlist,
+            reset_allowance_tokens: base.reset_allowance_tokens,
+            erc4626_pair_policies: base.erc4626_pair_policies,
+        };
 
         assert!(rfq_effectively_enabled(true, &ethereum));
         assert!(!rfq_effectively_enabled(false, &ethereum));

--- a/crates/runtime/src/models/erc4626.rs
+++ b/crates/runtime/src/models/erc4626.rs
@@ -2,89 +2,52 @@ use tycho_simulation::{protocol::models::ProtocolComponent, tycho_common::Bytes}
 
 use super::protocol::ProtocolKind;
 
-struct SupportedErc4626Pair {
-    asset_symbol: &'static str,
-    share_symbol: &'static str,
-    asset: &'static str,
-    share: &'static str,
-    allow_asset_to_share: bool,
-    allow_share_to_asset: bool,
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Erc4626PairPolicy {
+    pub asset_symbol: String,
+    pub share_symbol: String,
+    pub asset: Bytes,
+    pub share: Bytes,
+    pub allow_asset_to_share: bool,
+    pub allow_share_to_asset: bool,
 }
 
-impl SupportedErc4626Pair {
+impl Erc4626PairPolicy {
     fn supports_direction(
         &self,
         token_in: &Bytes,
         token_out: &Bytes,
         deposits_enabled: bool,
     ) -> bool {
-        let token_in = token_in.to_string();
-        let token_out = token_out.to_string();
         (deposits_enabled
             && self.allow_asset_to_share
-            && token_in.eq_ignore_ascii_case(self.asset)
-            && token_out.eq_ignore_ascii_case(self.share))
-            || (self.allow_share_to_asset
-                && token_in.eq_ignore_ascii_case(self.share)
-                && token_out.eq_ignore_ascii_case(self.asset))
+            && token_in == &self.asset
+            && token_out == &self.share)
+            || (self.allow_share_to_asset && token_in == &self.share && token_out == &self.asset)
     }
 
     fn component_matches(&self, component: &ProtocolComponent) -> bool {
-        component.id.to_string().eq_ignore_ascii_case(self.share)
+        component.id == self.share
             && component.tokens.len() == 2
             && component
                 .tokens
                 .iter()
-                .any(|token| token.address.to_string().eq_ignore_ascii_case(self.asset))
+                .any(|token| token.address == self.asset)
             && component
                 .tokens
                 .iter()
-                .any(|token| token.address.to_string().eq_ignore_ascii_case(self.share))
+                .any(|token| token.address == self.share)
     }
 
     fn direction_label(&self, token_in: &Bytes, token_out: &Bytes) -> Option<String> {
-        if token_in.to_string().eq_ignore_ascii_case(self.asset)
-            && token_out.to_string().eq_ignore_ascii_case(self.share)
-        {
+        if token_in == &self.asset && token_out == &self.share {
             return Some(format!("{} -> {}", self.asset_symbol, self.share_symbol));
         }
-        if token_in.to_string().eq_ignore_ascii_case(self.share)
-            && token_out.to_string().eq_ignore_ascii_case(self.asset)
-        {
+        if token_in == &self.share && token_out == &self.asset {
             return Some(format!("{} -> {}", self.share_symbol, self.asset_symbol));
         }
         None
     }
-}
-
-fn supported_pairs() -> &'static [SupportedErc4626Pair] {
-    const SUPPORTED: &[SupportedErc4626Pair] = &[
-        SupportedErc4626Pair {
-            asset_symbol: "USDS",
-            share_symbol: "sUSDS",
-            asset: "0xdC035D45d973E3EC169d2276DDab16f1e407384F",
-            share: "0xa3931d71877c0e7a3148cb7eb4463524fec27fbd",
-            allow_asset_to_share: true,
-            allow_share_to_asset: true,
-        },
-        SupportedErc4626Pair {
-            asset_symbol: "USDC",
-            share_symbol: "sUSDC",
-            asset: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-            share: "0xBc65ad17c5C0a2A4D159fa5a503f4992c7B545FE",
-            allow_asset_to_share: true,
-            allow_share_to_asset: true,
-        },
-        SupportedErc4626Pair {
-            asset_symbol: "PYUSD",
-            share_symbol: "spPYUSD",
-            asset: "0x6c3ea9036406852006290770BEdFcAbA0e23A0e8",
-            share: "0x80128DbB9f07b93DDE62A6daeadb69ED14a7D354",
-            allow_asset_to_share: true,
-            allow_share_to_asset: true,
-        },
-    ];
-    SUPPORTED
 }
 
 fn normalize_protocol_id(protocol: &str) -> String {
@@ -107,9 +70,10 @@ pub(crate) fn request_direction_supported(
     token_in: &Bytes,
     token_out: &Bytes,
     deposits_enabled: bool,
+    pair_policies: &[Erc4626PairPolicy],
 ) -> bool {
     !is_erc4626_protocol(protocol)
-        || supported_pairs()
+        || pair_policies
             .iter()
             .any(|pair| pair.supports_direction(token_in, token_out, deposits_enabled))
 }
@@ -119,9 +83,10 @@ pub(crate) fn component_direction_supported(
     token_in: &Bytes,
     token_out: &Bytes,
     deposits_enabled: bool,
+    pair_policies: &[Erc4626PairPolicy],
 ) -> bool {
     !component_is_erc4626(component)
-        || supported_pairs().iter().any(|pair| {
+        || pair_policies.iter().any(|pair| {
             pair.supports_direction(token_in, token_out, deposits_enabled)
                 && pair.component_matches(component)
         })
@@ -131,20 +96,24 @@ pub(crate) fn unsupported_direction_message(
     token_in: &Bytes,
     token_out: &Bytes,
     deposits_enabled: bool,
+    pair_policies: &[Erc4626PairPolicy],
 ) -> String {
-    let requested = supported_pairs()
+    let requested = pair_policies
         .iter()
         .find_map(|pair| pair.direction_label(token_in, token_out))
         .unwrap_or_else(|| format!("{token_in} -> {token_out}"));
-    let supported = supported_direction_labels(deposits_enabled).join(", ");
+    let supported = supported_direction_labels(deposits_enabled, pair_policies).join(", ");
     format!(
         "ERC4626 direction {requested} is not currently supported by this server; supported directions are [{supported}]"
     )
 }
 
-pub(crate) fn supported_direction_labels(deposits_enabled: bool) -> Vec<String> {
+pub(crate) fn supported_direction_labels(
+    deposits_enabled: bool,
+    pair_policies: &[Erc4626PairPolicy],
+) -> Vec<String> {
     let mut directions = Vec::new();
-    for pair in supported_pairs() {
+    for pair in pair_policies {
         if deposits_enabled && pair.allow_asset_to_share {
             directions.push(format!("{} -> {}", pair.asset_symbol, pair.share_symbol));
         }
@@ -168,6 +137,35 @@ mod tests {
     use tycho_simulation::tycho_common::models::{token::Token, Chain};
 
     use super::*;
+
+    fn pair_policies() -> Vec<Erc4626PairPolicy> {
+        vec![
+            Erc4626PairPolicy {
+                asset_symbol: "USDS".to_string(),
+                share_symbol: "sUSDS".to_string(),
+                asset: Bytes::from_str("0xdC035D45d973E3EC169d2276DDab16f1e407384F").unwrap(),
+                share: Bytes::from_str("0xa3931d71877c0e7a3148cb7eb4463524fec27fbd").unwrap(),
+                allow_asset_to_share: true,
+                allow_share_to_asset: true,
+            },
+            Erc4626PairPolicy {
+                asset_symbol: "USDC".to_string(),
+                share_symbol: "sUSDC".to_string(),
+                asset: Bytes::from_str("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48").unwrap(),
+                share: Bytes::from_str("0xBc65ad17c5C0a2A4D159fa5a503f4992c7B545FE").unwrap(),
+                allow_asset_to_share: true,
+                allow_share_to_asset: true,
+            },
+            Erc4626PairPolicy {
+                asset_symbol: "PYUSD".to_string(),
+                share_symbol: "spPYUSD".to_string(),
+                asset: Bytes::from_str("0x6c3ea9036406852006290770BEdFcAbA0e23A0e8").unwrap(),
+                share: Bytes::from_str("0x80128DbB9f07b93DDE62A6daeadb69ED14a7D354").unwrap(),
+                allow_asset_to_share: true,
+                allow_share_to_asset: true,
+            },
+        ]
+    }
 
     fn token(address: &str, symbol: &str, decimals: u32) -> Token {
         Token::new(
@@ -202,6 +200,7 @@ mod tests {
 
     #[test]
     fn supports_all_allowlisted_request_directions() {
+        let pair_policies = pair_policies();
         for (protocol, token_in, token_out) in [
             (
                 "erc4626",
@@ -239,12 +238,14 @@ mod tests {
                 &Bytes::from_str(token_in).unwrap(),
                 &Bytes::from_str(token_out).unwrap(),
                 true,
+                &pair_policies,
             ));
         }
     }
 
     #[test]
     fn disables_allowlisted_deposit_directions_without_rpc_capability() {
+        let pair_policies = pair_policies();
         for (protocol, token_in, token_out) in [
             (
                 "erc4626",
@@ -267,12 +268,14 @@ mod tests {
                 &Bytes::from_str(token_in).unwrap(),
                 &Bytes::from_str(token_out).unwrap(),
                 false,
+                &pair_policies,
             ));
         }
     }
 
     #[test]
     fn keeps_allowlisted_redeem_directions_without_rpc_capability() {
+        let pair_policies = pair_policies();
         for (protocol, token_in, token_out) in [
             (
                 "erc4626",
@@ -295,12 +298,14 @@ mod tests {
                 &Bytes::from_str(token_in).unwrap(),
                 &Bytes::from_str(token_out).unwrap(),
                 false,
+                &pair_policies,
             ));
         }
     }
 
     #[test]
     fn rejects_non_allowlisted_request_directions() {
+        let pair_policies = pair_policies();
         for (protocol, token_in, token_out) in [
             (
                 "erc4626",
@@ -323,12 +328,14 @@ mod tests {
                 &Bytes::from_str(token_in).unwrap(),
                 &Bytes::from_str(token_out).unwrap(),
                 true,
+                &pair_policies,
             ));
         }
     }
 
     #[test]
     fn component_support_requires_matching_share_token() {
+        let pair_policies = pair_policies();
         let usds = token("0xdC035D45d973E3EC169d2276DDab16f1e407384F", "USDS", 18);
         let susds = token("0xa3931d71877c0e7a3148cb7eb4463524fec27fbd", "sUSDS", 18);
         let wrong_share = token("0x9d39a5de30e57443bff2a8307a4256c8797a3497", "sUSDe", 18);
@@ -346,6 +353,7 @@ mod tests {
             &token_in,
             &token_out,
             true,
+            &pair_policies,
         ));
 
         let unsupported_component = component(
@@ -359,11 +367,13 @@ mod tests {
             &token_in,
             &token_out,
             true,
+            &pair_policies,
         ));
     }
 
     #[test]
     fn recognizes_erc4626_component_by_protocol_type_name() {
+        let pair_policies = pair_policies();
         let usds = token("0xdC035D45d973E3EC169d2276DDab16f1e407384F", "USDS", 18);
         let susds = token("0xa3931d71877c0e7a3148cb7eb4463524fec27fbd", "sUSDS", 18);
         let token_in = usds.address.clone();
@@ -378,17 +388,25 @@ mod tests {
 
         assert!(component_is_erc4626(&component));
         assert!(component_direction_supported(
-            &component, &token_in, &token_out, true,
+            &component,
+            &token_in,
+            &token_out,
+            true,
+            &pair_policies,
         ));
         assert!(!component_direction_supported(
-            &component, &token_in, &token_out, false,
+            &component,
+            &token_in,
+            &token_out,
+            false,
+            &pair_policies,
         ));
     }
 
     #[test]
     fn supported_direction_labels_reflect_deposit_capability() {
         assert_eq!(
-            supported_direction_labels(false),
+            supported_direction_labels(false, &pair_policies()),
             vec![
                 "sUSDS -> USDS".to_string(),
                 "sUSDC -> USDC".to_string(),

--- a/crates/runtime/src/models/state.rs
+++ b/crates/runtime/src/models/state.rs
@@ -16,7 +16,10 @@ use tycho_simulation::{
 
 use crate::config::SlippageConfig;
 
-use super::{protocol::ProtocolKind, stream_health::StreamHealth, tokens::TokenStore};
+use super::{
+    erc4626::Erc4626PairPolicy, protocol::ProtocolKind, stream_health::StreamHealth,
+    tokens::TokenStore,
+};
 
 const UPDATE_ANOMALY_SAMPLE_CAP: usize = 6;
 const NATIVE_TOKEN_ADDRESS_BYTES: [u8; 20] = [0u8; 20];
@@ -51,6 +54,7 @@ pub struct AppState {
     pub rfq_sim_semaphore: Arc<Semaphore>,
     pub slippage: SlippageConfig,
     pub erc4626_deposits_enabled: bool,
+    pub erc4626_pair_policies: Arc<Vec<Erc4626PairPolicy>>,
     pub reset_allowance_tokens: Arc<HashMap<u64, HashSet<Bytes>>>,
     pub native_sim_concurrency: usize,
     pub vm_sim_concurrency: usize,
@@ -1184,6 +1188,7 @@ mod tests {
             rfq_sim_semaphore: Arc::new(Semaphore::new(concurrency.rfq)),
             slippage: SlippageConfig::default(),
             erc4626_deposits_enabled: false,
+            erc4626_pair_policies: Arc::new(Vec::new()),
             reset_allowance_tokens: Arc::new(HashMap::new()),
             native_sim_concurrency: concurrency.native,
             vm_sim_concurrency: concurrency.vm,

--- a/crates/runtime/src/services/encode.rs
+++ b/crates/runtime/src/services/encode.rs
@@ -54,6 +54,7 @@ pub async fn encode_route(
         &amount_in,
         &native_address,
         state.erc4626_deposits_enabled,
+        &state.erc4626_pair_policies,
         allowlist,
     )?;
     let (uses_native, uses_vm, uses_rfq) = normalize::route_backend_usage(&normalized);

--- a/crates/runtime/src/services/encode/fixtures.rs
+++ b/crates/runtime/src/services/encode/fixtures.rs
@@ -11,6 +11,7 @@ use tycho_simulation::tycho_common::models::Chain;
 use tycho_simulation::tycho_common::Bytes;
 
 use crate::config::SlippageConfig;
+use crate::models::erc4626::Erc4626PairPolicy;
 use crate::models::messages::PoolRef;
 use crate::models::state::{AppState, RfqStreamStatus, StateStore, VmStreamStatus};
 use crate::models::stream_health::StreamHealth;
@@ -94,6 +95,35 @@ pub(super) fn test_state_stores(
     )
 }
 
+fn erc4626_pair_policies() -> Vec<Erc4626PairPolicy> {
+    vec![
+        Erc4626PairPolicy {
+            asset_symbol: "USDS".to_string(),
+            share_symbol: "sUSDS".to_string(),
+            asset: fixture_bytes("0xdC035D45d973E3EC169d2276DDab16f1e407384F"),
+            share: fixture_bytes("0xa3931d71877c0e7a3148cb7eb4463524fec27fbd"),
+            allow_asset_to_share: true,
+            allow_share_to_asset: true,
+        },
+        Erc4626PairPolicy {
+            asset_symbol: "USDC".to_string(),
+            share_symbol: "sUSDC".to_string(),
+            asset: fixture_bytes("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
+            share: fixture_bytes("0xBc65ad17c5C0a2A4D159fa5a503f4992c7B545FE"),
+            allow_asset_to_share: true,
+            allow_share_to_asset: true,
+        },
+        Erc4626PairPolicy {
+            asset_symbol: "PYUSD".to_string(),
+            share_symbol: "spPYUSD".to_string(),
+            asset: fixture_bytes("0x6c3ea9036406852006290770BEdFcAbA0e23A0e8"),
+            share: fixture_bytes("0x80128DbB9f07b93DDE62A6daeadb69ED14a7D354"),
+            allow_asset_to_share: true,
+            allow_share_to_asset: true,
+        },
+    ]
+}
+
 pub(super) struct TestAppStateConfig {
     pub(super) enable_vm_pools: bool,
     pub(super) enable_rfq_pools: bool,
@@ -152,6 +182,7 @@ pub(super) fn test_app_state(
         rfq_sim_semaphore: Arc::new(Semaphore::new(1)),
         slippage: SlippageConfig::default(),
         erc4626_deposits_enabled: config.erc4626_deposits_enabled,
+        erc4626_pair_policies: Arc::new(erc4626_pair_policies()),
         reset_allowance_tokens: Arc::new(HashMap::new()),
         native_sim_concurrency: 1,
         vm_sim_concurrency: 1,

--- a/crates/runtime/src/services/encode/normalize.rs
+++ b/crates/runtime/src/services/encode/normalize.rs
@@ -5,6 +5,7 @@ use tycho_simulation::tycho_common::Bytes;
 
 use crate::models::erc4626::{
     is_erc4626_protocol, request_direction_supported, unsupported_direction_message,
+    Erc4626PairPolicy,
 };
 use crate::models::messages::{HopDraft, PoolSwapDraft, RouteEncodeRequest, SegmentDraft};
 
@@ -18,6 +19,10 @@ use super::request::{format_native_protocol_allowlist, is_native_protocol_allowl
 use super::wire::parse_address;
 use super::EncodeError;
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "route normalization validates independent request, token, and policy inputs together"
+)]
 pub(super) fn normalize_route(
     request: &RouteEncodeRequest,
     request_token_in: &Bytes,
@@ -25,6 +30,7 @@ pub(super) fn normalize_route(
     total_amount_in: &BigUint,
     native_address: &Bytes,
     erc4626_deposits_enabled: bool,
+    erc4626_pair_policies: &[Erc4626PairPolicy],
     native_token_protocol_allowlist: &[String],
 ) -> Result<NormalizedRouteInternal, EncodeError> {
     if request.segments.is_empty() {
@@ -55,6 +61,7 @@ pub(super) fn normalize_route(
                     hop,
                     native_address,
                     erc4626_deposits_enabled,
+                    erc4626_pair_policies,
                     native_token_protocol_allowlist,
                 )
             })
@@ -165,6 +172,7 @@ fn normalize_hop(
     hop: &HopDraft,
     native_address: &Bytes,
     erc4626_deposits_enabled: bool,
+    erc4626_pair_policies: &[Erc4626PairPolicy],
     native_token_protocol_allowlist: &[String],
 ) -> Result<NormalizedHopInternal, EncodeError> {
     if hop.swaps.is_empty() {
@@ -188,7 +196,15 @@ fn normalize_hop(
     let swaps = hop
         .swaps
         .iter()
-        .map(|swap| normalize_swap(swap, &token_in, &token_out, erc4626_deposits_enabled))
+        .map(|swap| {
+            normalize_swap(
+                swap,
+                &token_in,
+                &token_out,
+                erc4626_deposits_enabled,
+                erc4626_pair_policies,
+            )
+        })
         .collect::<Result<Vec<_>, _>>()?;
 
     Ok(NormalizedHopInternal {
@@ -203,6 +219,7 @@ fn normalize_swap(
     hop_token_in: &Bytes,
     hop_token_out: &Bytes,
     erc4626_deposits_enabled: bool,
+    erc4626_pair_policies: &[Erc4626PairPolicy],
 ) -> Result<NormalizedSwapDraftInternal, EncodeError> {
     let token_in = parse_address(&swap.token_in)?;
     let token_out = parse_address(&swap.token_out)?;
@@ -216,7 +233,13 @@ fn normalize_swap(
             "swap tokenOut does not match hop tokenOut",
         ));
     }
-    validate_erc4626_swap_supported(swap, &token_in, &token_out, erc4626_deposits_enabled)?;
+    validate_erc4626_swap_supported(
+        swap,
+        &token_in,
+        &token_out,
+        erc4626_deposits_enabled,
+        erc4626_pair_policies,
+    )?;
 
     if swap.split_bps > BPS_DENOMINATOR {
         return Err(EncodeError::invalid("swap splitBps must be <= 10000"));
@@ -235,6 +258,7 @@ fn validate_erc4626_swap_supported(
     token_in: &Bytes,
     token_out: &Bytes,
     erc4626_deposits_enabled: bool,
+    erc4626_pair_policies: &[Erc4626PairPolicy],
 ) -> Result<(), EncodeError> {
     if !is_erc4626_protocol(&swap.pool.protocol) {
         return Ok(());
@@ -244,6 +268,7 @@ fn validate_erc4626_swap_supported(
         token_in,
         token_out,
         erc4626_deposits_enabled,
+        erc4626_pair_policies,
     ) {
         return Ok(());
     }
@@ -259,6 +284,7 @@ fn validate_erc4626_swap_supported(
         token_in,
         token_out,
         erc4626_deposits_enabled,
+        erc4626_pair_policies,
     )))
 }
 
@@ -285,6 +311,7 @@ mod tests {
     use tycho_simulation::tycho_common::models::Chain;
 
     use super::*;
+    use crate::models::erc4626::Erc4626PairPolicy;
     use crate::models::messages::PoolRef;
     use crate::models::messages::{PoolSwapDraft, SwapKind};
     use crate::services::encode::fixtures::pool_ref;
@@ -292,6 +319,35 @@ mod tests {
 
     fn allowlist() -> Vec<String> {
         vec!["rocketpool".to_string()]
+    }
+
+    fn erc4626_pair_policies() -> Vec<Erc4626PairPolicy> {
+        vec![
+            Erc4626PairPolicy {
+                asset_symbol: "USDS".to_string(),
+                share_symbol: "sUSDS".to_string(),
+                asset: Bytes::from_str("0xdC035D45d973E3EC169d2276DDab16f1e407384F").unwrap(),
+                share: Bytes::from_str("0xa3931d71877c0e7a3148cb7eb4463524fec27fbd").unwrap(),
+                allow_asset_to_share: true,
+                allow_share_to_asset: true,
+            },
+            Erc4626PairPolicy {
+                asset_symbol: "USDC".to_string(),
+                share_symbol: "sUSDC".to_string(),
+                asset: Bytes::from_str("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48").unwrap(),
+                share: Bytes::from_str("0xBc65ad17c5C0a2A4D159fa5a503f4992c7B545FE").unwrap(),
+                allow_asset_to_share: true,
+                allow_share_to_asset: true,
+            },
+            Erc4626PairPolicy {
+                asset_symbol: "PYUSD".to_string(),
+                share_symbol: "spPYUSD".to_string(),
+                asset: Bytes::from_str("0x6c3ea9036406852006290770BEdFcAbA0e23A0e8").unwrap(),
+                share: Bytes::from_str("0x80128DbB9f07b93DDE62A6daeadb69ED14a7D354").unwrap(),
+                allow_asset_to_share: true,
+                allow_share_to_asset: true,
+            },
+        ]
     }
 
     #[test]
@@ -350,6 +406,7 @@ mod tests {
             &BigUint::from(100u32),
             &Chain::Ethereum.native_token().address,
             false,
+            &erc4626_pair_policies(),
             &allowlist(),
         )
         .unwrap();
@@ -397,6 +454,7 @@ mod tests {
             &BigUint::from(100u32),
             &Chain::Ethereum.native_token().address,
             false,
+            &erc4626_pair_policies(),
             &allowlist(),
         )
         .unwrap();
@@ -461,6 +519,7 @@ mod tests {
             &amount_in,
             &native_address,
             false,
+            &erc4626_pair_policies(),
             &allowlist(),
         )
         .unwrap();
@@ -528,6 +587,7 @@ mod tests {
             &amount_in,
             &native,
             false,
+            &erc4626_pair_policies(),
             &allowlist(),
         ) {
             Ok(_) => panic!("Expected segment share rounding to zero to be rejected"),
@@ -601,6 +661,7 @@ mod tests {
             &amount_in,
             &native_address,
             false,
+            &erc4626_pair_policies(),
             &allowlist(),
         ) {
             Err(err) => assert_eq!(
@@ -664,6 +725,7 @@ mod tests {
             &amount_in,
             &native,
             false,
+            &erc4626_pair_policies(),
             &allowlist(),
         ) {
             Err(err) => assert_eq!(
@@ -720,6 +782,7 @@ mod tests {
             &amount_in,
             &native,
             false,
+            &erc4626_pair_policies(),
             &allowlist(),
         )
         .expect("rocketpool native route should normalize");
@@ -774,6 +837,7 @@ mod tests {
             &amount_in,
             &native,
             false,
+            &erc4626_pair_policies(),
             &allowlist(),
         ) {
             Ok(_) => panic!("allowlisted deposit should be rejected when deposits are disabled"),
@@ -836,6 +900,7 @@ mod tests {
             &amount_in,
             &native,
             true,
+            &erc4626_pair_policies(),
             &allowlist(),
         )
         .expect("allowlisted deposit should normalize when deposits are enabled");

--- a/crates/runtime/src/services/encode/resimulate.rs
+++ b/crates/runtime/src/services/encode/resimulate.rs
@@ -179,6 +179,7 @@ impl<'a> RouteResimulator<'a> {
     ) -> Result<ResimulatedSwapInternal, EncodeError> {
         let pool_entry = self.load_pool_entry(&allocated.pool.component_id).await?;
         ensure_erc4626_swap_supported(
+            self.state,
             &pool_entry.component,
             &allocated.pool.component_id,
             &allocated.token_in,
@@ -511,6 +512,7 @@ fn validate_native_request_tokens(
 }
 
 fn ensure_erc4626_swap_supported(
+    state: &AppState,
     component: &ProtocolComponent,
     pool_id: &str,
     token_in: &Bytes,
@@ -520,7 +522,13 @@ fn ensure_erc4626_swap_supported(
     if !component_is_erc4626(component) {
         return Ok(());
     }
-    if component_direction_supported(component, token_in, token_out, erc4626_deposits_enabled) {
+    if component_direction_supported(
+        component,
+        token_in,
+        token_out,
+        erc4626_deposits_enabled,
+        &state.erc4626_pair_policies,
+    ) {
         return Ok(());
     }
 
@@ -536,6 +544,7 @@ fn ensure_erc4626_swap_supported(
         token_in,
         token_out,
         erc4626_deposits_enabled,
+        &state.erc4626_pair_policies,
     )))
 }
 

--- a/crates/runtime/src/services/quotes.rs
+++ b/crates/runtime/src/services/quotes.rs
@@ -869,6 +869,7 @@ impl QuoteRequestRunner {
             &pair.token_in_bytes,
             &pair.token_out_bytes,
             self.state.erc4626_deposits_enabled,
+            &self.state.erc4626_pair_policies,
         );
         let vm_ready = self.state.vm_ready().await;
         if self.state.enable_vm_pools && !vm_ready {
@@ -1342,6 +1343,7 @@ fn filter_unsupported_erc4626_candidates(
     token_in: &Bytes,
     token_out: &Bytes,
     erc4626_deposits_enabled: bool,
+    erc4626_pair_policies: &[crate::models::erc4626::Erc4626PairPolicy],
 ) -> Vec<CandidatePool> {
     candidates
         .into_iter()
@@ -1351,6 +1353,7 @@ fn filter_unsupported_erc4626_candidates(
                 token_in,
                 token_out,
                 erc4626_deposits_enabled,
+                erc4626_pair_policies,
             );
             if !supported {
                 debug!(
@@ -3065,7 +3068,7 @@ mod tests {
         tokens: Vec<Token>,
     ) -> ProtocolComponent {
         ProtocolComponent::new(
-            Bytes::from_str(address).expect("valid pool address"),
+            test_address(address),
             protocol_system.to_string(),
             protocol_type_name.to_string(),
             Chain::Ethereum,
@@ -3075,6 +3078,46 @@ mod tests {
             Bytes::default(),
             NaiveDateTime::default(),
         )
+    }
+
+    #[expect(
+        clippy::panic,
+        reason = "quote test fixtures should fail immediately on invalid literal addresses"
+    )]
+    fn test_address(value: &str) -> Bytes {
+        match Bytes::from_str(value) {
+            Ok(address) => address,
+            Err(err) => panic!("test address must parse: {err}"),
+        }
+    }
+
+    fn erc4626_pair_policies() -> Vec<crate::models::erc4626::Erc4626PairPolicy> {
+        vec![
+            crate::models::erc4626::Erc4626PairPolicy {
+                asset_symbol: "USDS".to_string(),
+                share_symbol: "sUSDS".to_string(),
+                asset: test_address("0xdC035D45d973E3EC169d2276DDab16f1e407384F"),
+                share: test_address("0xa3931d71877c0e7a3148cb7eb4463524fec27fbd"),
+                allow_asset_to_share: true,
+                allow_share_to_asset: true,
+            },
+            crate::models::erc4626::Erc4626PairPolicy {
+                asset_symbol: "USDC".to_string(),
+                share_symbol: "sUSDC".to_string(),
+                asset: test_address("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
+                share: test_address("0xBc65ad17c5C0a2A4D159fa5a503f4992c7B545FE"),
+                allow_asset_to_share: true,
+                allow_share_to_asset: true,
+            },
+            crate::models::erc4626::Erc4626PairPolicy {
+                asset_symbol: "PYUSD".to_string(),
+                share_symbol: "spPYUSD".to_string(),
+                asset: test_address("0x6c3ea9036406852006290770BEdFcAbA0e23A0e8"),
+                share: test_address("0x80128DbB9f07b93DDE62A6daeadb69ED14a7D354"),
+                allow_asset_to_share: true,
+                allow_share_to_asset: true,
+            },
+        ]
     }
 
     struct TestAppStateConfig {
@@ -3141,6 +3184,7 @@ mod tests {
             rfq_sim_semaphore: Arc::new(Semaphore::new(config.rfq_sim_concurrency)),
             slippage: SlippageConfig::default(),
             erc4626_deposits_enabled: config.erc4626_deposits_enabled,
+            erc4626_pair_policies: Arc::new(erc4626_pair_policies()),
             reset_allowance_tokens: Arc::new(HashMap::new()),
             native_sim_concurrency: config.native_sim_concurrency,
             vm_sim_concurrency: config.vm_sim_concurrency,

--- a/crates/runtime/src/services/stream_builder.rs
+++ b/crates/runtime/src/services/stream_builder.rs
@@ -310,6 +310,7 @@ fn decode_skip_state_failures(policy: StreamDecodePolicy) -> bool {
 mod tests {
     use std::{
         collections::{BTreeSet, HashMap},
+        path::PathBuf,
         str::FromStr,
         sync::Arc,
         time::Duration,
@@ -319,9 +320,7 @@ mod tests {
         decode_skip_state_failures, merge_missing_tokens, register_native_protocol,
         register_vm_protocol, rfq_decoder_tokens, StreamDecodePolicy,
     };
-    use crate::config::{
-        BASE_NATIVE_PROTOCOLS, BASE_VM_PROTOCOLS, ETHEREUM_NATIVE_PROTOCOLS, ETHEREUM_VM_PROTOCOLS,
-    };
+    use crate::config::{load_manifest_registries, resolve_chain_config, MANIFEST_PATH};
     use tycho_simulation::{
         evm::stream::ProtocolStreamBuilder,
         tycho_client::feed::component_tracker::ComponentFilter,
@@ -344,8 +343,22 @@ mod tests {
         ComponentFilter::with_tvl_range(0.0, 1.0)
     }
 
-    fn unique_protocols<'a>(left: &'a [&'a str], right: &'a [&'a str]) -> BTreeSet<&'a str> {
-        left.iter().chain(right.iter()).copied().collect()
+    fn manifest_path() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../")
+            .join(MANIFEST_PATH)
+    }
+
+    fn chain_protocols(chain_id: u64) -> (Vec<String>, Vec<String>) {
+        let registries = load_manifest_registries(&manifest_path())
+            .unwrap_or_else(|err| panic!("test manifest must load: {err}"));
+        let resolved = resolve_chain_config(&registries, chain_id, None)
+            .unwrap_or_else(|err| panic!("test manifest must resolve chain {chain_id}: {err}"));
+
+        (
+            resolved.chain_profile.native_protocols,
+            resolved.chain_profile.vm_protocols,
+        )
     }
 
     fn test_token(address: &str, symbol: &str) -> Token {
@@ -414,10 +427,17 @@ mod tests {
     }
 
     #[test]
-    fn chain_profile_native_protocols_all_register_successfully() {
+    fn manifest_native_protocols_all_register_successfully() {
         let filter = test_filter();
+        let (ethereum_native_protocols, _) = chain_protocols(1);
+        let (base_native_protocols, _) = chain_protocols(8453);
 
-        for protocol in unique_protocols(ETHEREUM_NATIVE_PROTOCOLS, BASE_NATIVE_PROTOCOLS) {
+        for protocol in ethereum_native_protocols
+            .iter()
+            .chain(base_native_protocols.iter())
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>()
+        {
             let result = register_native_protocol(test_builder(), protocol, &filter);
             assert!(
                 result.is_ok(),
@@ -427,10 +447,17 @@ mod tests {
     }
 
     #[test]
-    fn chain_profile_vm_protocols_all_register_successfully() {
+    fn manifest_vm_protocols_all_register_successfully() {
         let filter = test_filter();
+        let (_, ethereum_vm_protocols) = chain_protocols(1);
+        let (_, base_vm_protocols) = chain_protocols(8453);
 
-        for protocol in unique_protocols(ETHEREUM_VM_PROTOCOLS, BASE_VM_PROTOCOLS) {
+        for protocol in ethereum_vm_protocols
+            .iter()
+            .chain(base_vm_protocols.iter())
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>()
+        {
             let result = register_vm_protocol(test_builder(), protocol, &filter);
             assert!(
                 result.is_ok(),

--- a/crates/runtime/src/simulator_service.rs
+++ b/crates/runtime/src/simulator_service.rs
@@ -11,10 +11,7 @@ use tycho_simulation::tycho_common::{
 };
 use tycho_simulation::utils::load_all_tokens;
 
-use crate::config::{
-    hosted_bebop_url, hosted_hashflow_filename, hosted_tycho_url, init_logging, load_config,
-    AppConfig, MemoryConfig,
-};
+use crate::config::{init_logging, load_config, AppConfig, MemoryConfig};
 use crate::memory::maybe_log_memory_snapshot;
 use crate::models::rfq::bebop::BebopResponse;
 use crate::models::rfq::hashflow::read_hashflow_csv;
@@ -45,7 +42,7 @@ pub async fn build_simulator_service() -> anyhow::Result<SimulatorServiceParts> 
     init_logging();
     let config = load_config();
     let chain = config.chain_profile.chain;
-    let tycho_url = hosted_tycho_url(chain).map_err(anyhow::Error::msg)?;
+    let tycho_url = config.tycho_url.clone();
     let effective_rfq_enabled =
         config.enable_rfq_pools && !config.chain_profile.rfq_protocols.is_empty();
     info!(chain_id = chain.id(), chain = %chain, "Initializing price service...");
@@ -59,11 +56,10 @@ pub async fn build_simulator_service() -> anyhow::Result<SimulatorServiceParts> 
 
     if effective_rfq_enabled {
         // RFQ enabled means RFQ bootstrap must succeed.
-        let bebop_url = hosted_bebop_url(chain).map_err(anyhow::Error::msg)?;
-        let hashflow_filename = hosted_hashflow_filename(chain).map_err(anyhow::Error::msg)?;
-        bebop_tokens = load_bebop_token_store(&config, &tycho_url, &bebop_url, chain).await?;
+        bebop_tokens =
+            load_bebop_token_store(&config, &tycho_url, &config.bebop_url, chain).await?;
         hashflow_tokens =
-            load_hashflow_token_store(&config, &tycho_url, &hashflow_filename, chain)?;
+            load_hashflow_token_store(&config, &tycho_url, &config.hashflow_filename, chain)?;
     } else {
         bebop_tokens = new_token_store(HashMap::new(), &tycho_url, &config);
         hashflow_tokens = new_token_store(HashMap::new(), &tycho_url, &config);
@@ -315,6 +311,7 @@ fn build_app_state(
         rfq_sim_semaphore: Arc::new(Semaphore::new(rfq_sim_concurrency)),
         slippage: config.slippage,
         erc4626_deposits_enabled: config.rpc_url.is_some(),
+        erc4626_pair_policies: Arc::clone(&config.erc4626_pair_policies),
         reset_allowance_tokens: Arc::clone(&config.reset_allowance_tokens),
         native_sim_concurrency,
         vm_sim_concurrency,
@@ -593,9 +590,13 @@ mod tests {
         rpc_url: Option<&str>,
     ) -> AppConfig {
         let reset_allowance_tokens = Arc::new(chain_profile.reset_allowance_tokens.clone());
+        let erc4626_pair_policies = Arc::new(chain_profile.erc4626_pair_policies.clone());
 
         AppConfig {
             chain_profile,
+            tycho_url: "http://localhost:4242".to_string(),
+            bebop_url: "https://example.com/bebop".to_string(),
+            hashflow_filename: "./hashflow.csv".to_string(),
             api_key: "test-api-key".to_string(),
             rpc_url: rpc_url.map(str::to_string),
             tvl_threshold: 100.0,
@@ -614,6 +615,7 @@ mod tests {
             global_vm_sim_concurrency: 4,
             global_rfq_sim_concurrency: 4,
             reset_allowance_tokens,
+            erc4626_pair_policies,
             stream_stale_secs: 120,
             stream_missing_block_burst: 3,
             stream_missing_block_window_secs: 60,
@@ -662,6 +664,7 @@ mod tests {
             rfq_protocols: vec!["rfq:bebop".to_string(), "rfq:hashflow".to_string()],
             native_token_protocol_allowlist: Vec::new(),
             reset_allowance_tokens: HashMap::new(),
+            erc4626_pair_policies: Vec::new(),
         }
     }
 
@@ -680,6 +683,7 @@ mod tests {
             rfq_protocols: vec!["rfq:hashflow".to_string()],
             native_token_protocol_allowlist: vec!["rocketpool".to_string()],
             reset_allowance_tokens,
+            erc4626_pair_policies: Vec::new(),
         }
     }
 

--- a/scripts/start_server.sh
+++ b/scripts/start_server.sh
@@ -10,21 +10,11 @@ Start the dsolver-simulator-service from a repo checkout.
 Options:
   --repo             Path to repo root (default: current directory)
   --log-file         Log file path (default: <repo>/logs/tycho-sim-server.log)
-  --chain-id         Runtime chain id (1 or 8453). Overrides CHAIN_ID from env/.env.
+  --chain-id         Runtime chain id from simulator-manifest.toml. Overrides CHAIN_ID from env/.env.
   --env              Export KEY=VALUE before starting (repeatable)
   --enable-vm-pools  Shortcut for --env ENABLE_VM_POOLS=true
   -h, --help         Show this help
 USAGE
-}
-
-validate_chain_id() {
-  case "$1" in
-    1|8453) ;;
-    *)
-      echo "Error: unsupported chain id '$1'. Supported values: 1 (Ethereum), 8453 (Base)." >&2
-      return 1
-      ;;
-  esac
 }
 
 repo="."
@@ -114,7 +104,6 @@ if [[ -z "${CHAIN_ID:-}" ]]; then
   echo "Error: missing chain id. Pass --chain-id or set CHAIN_ID in env/.env." >&2
   exit 2
 fi
-validate_chain_id "$CHAIN_ID"
 
 if [[ -z "$log_file" ]]; then
   mkdir -p "$repo/logs"

--- a/simulator-manifest.toml
+++ b/simulator-manifest.toml
@@ -1,0 +1,145 @@
+version = 1
+
+# Declare protocols once up top, then let each chain opt into the ones it actually wants.
+[[protocols]]
+id = "uniswap_v2"
+backend = "native"
+
+[[protocols]]
+id = "sushiswap_v2"
+backend = "native"
+
+[[protocols]]
+id = "pancakeswap_v2"
+backend = "native"
+
+[[protocols]]
+id = "uniswap_v3"
+backend = "native"
+
+[[protocols]]
+id = "pancakeswap_v3"
+backend = "native"
+
+[[protocols]]
+id = "uniswap_v4"
+backend = "native"
+
+[[protocols]]
+id = "ekubo_v2"
+backend = "native"
+
+[[protocols]]
+id = "fluid_v1"
+backend = "native"
+
+[[protocols]]
+id = "rocketpool"
+backend = "native"
+
+[[protocols]]
+id = "ekubo_v3"
+backend = "native"
+
+[[protocols]]
+id = "erc4626"
+backend = "native"
+
+[[protocols]]
+id = "aerodrome_slipstreams"
+backend = "native"
+
+[[protocols]]
+id = "vm:curve"
+backend = "vm"
+
+[[protocols]]
+id = "vm:balancer_v2"
+backend = "vm"
+
+[[protocols]]
+id = "vm:maverick_v2"
+backend = "vm"
+
+[[protocols]]
+id = "rfq:bebop"
+backend = "rfq"
+
+[[protocols]]
+id = "rfq:hashflow"
+backend = "rfq"
+
+# Route policies hold the routing nuances that do not belong in the plain chain protocol lists.
+[[route_policies]]
+id = "ethereum"
+native_token_protocol_allowlist = ["rocketpool"]
+reset_allowance_tokens = ["0xdAC17F958D2ee523a2206206994597C13D831ec7"]
+
+# ERC4626 is the one case where direction really matters, so it stays explicit here.
+[[route_policies.erc4626_pairs]]
+asset_symbol = "USDS"
+share_symbol = "sUSDS"
+asset = "0xdC035D45d973E3EC169d2276DDab16f1e407384F"
+share = "0xa3931d71877c0e7a3148cb7eb4463524fec27fbd"
+allow_asset_to_share = true
+allow_share_to_asset = true
+
+[[route_policies.erc4626_pairs]]
+asset_symbol = "USDC"
+share_symbol = "sUSDC"
+asset = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+share = "0xBc65ad17c5C0a2A4D159fa5a503f4992c7B545FE"
+allow_asset_to_share = true
+allow_share_to_asset = true
+
+[[route_policies.erc4626_pairs]]
+asset_symbol = "PYUSD"
+share_symbol = "spPYUSD"
+asset = "0x6c3ea9036406852006290770BEdFcAbA0e23A0e8"
+share = "0x80128DbB9f07b93DDE62A6daeadb69ED14a7D354"
+allow_asset_to_share = true
+allow_share_to_asset = true
+
+[[route_policies]]
+id = "base"
+native_token_protocol_allowlist = []
+reset_allowance_tokens = []
+
+# Chain entries stay intentionally small: endpoints, enabled protocol sets, and the route policy to use.
+[[chains]]
+chain_id = 1
+tycho_url = "tycho-beta.propellerheads.xyz"
+bebop_url = "https://api.bebop.xyz/pmm/ethereum/v3/tokens"
+hashflow_filename = "./hashflow_supported_tokens.csv"
+native_protocols = [
+    "uniswap_v2",
+    "sushiswap_v2",
+    "pancakeswap_v2",
+    "uniswap_v3",
+    "pancakeswap_v3",
+    "uniswap_v4",
+    "ekubo_v2",
+    "fluid_v1",
+    "rocketpool",
+    "ekubo_v3",
+    "erc4626",
+]
+vm_protocols = ["vm:curve", "vm:balancer_v2", "vm:maverick_v2"]
+rfq_protocols = ["rfq:bebop", "rfq:hashflow"]
+route_policy = "ethereum"
+
+[[chains]]
+chain_id = 8453
+tycho_url = "tycho-base-beta.propellerheads.xyz"
+bebop_url = "https://api.bebop.xyz/pmm/base/v3/tokens"
+hashflow_filename = "./hashflow_supported_tokens.csv"
+native_protocols = [
+    "uniswap_v2",
+    "uniswap_v3",
+    "uniswap_v4",
+    "pancakeswap_v3",
+    "aerodrome_slipstreams",
+]
+vm_protocols = []
+rfq_protocols = ["rfq:bebop", "rfq:hashflow"]
+route_policy = "base"


### PR DESCRIPTION
This moves the chain-specific simulator config into a checked-in config file so protocol sets, endpoints, and route policies live in one place instead of being spread across runtime code.

It also wires ERC4626 pair policy handling through the runtime, and updates Docker, the startup script, env/docs, and tests to match the new setup.
