### PR TITLE
feat: Nest simulator readiness by backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ is an example setup, not the source of truth for every default.
 
 - `POST /simulate` returns per-pool quotes across the requested amounts plus `meta` describing quote completeness, failures, and readiness-adjacent request outcomes.
 - `POST /encode` accepts a client-provided route, re-simulates the swaps internally, and returns ordered settlement `interactions[]`.
-- `GET /status` reports overall service health plus `native_status`, VM readiness, RFQ readiness, block progress, and VM or RFQ rebuild or restart context for pollers and deploy scripts.
+- `GET /status` reports overall service health plus nested backend readiness, block progress, and VM or RFQ rebuild or restart context for pollers and deploy scripts.
 
 `/encode` keeps its current HTTP control flow, but the server emits one structured completion log per request with route shape, protocol summary, and failure-stage fields. Detailed resimulation traces stay available at `debug`.
 
@@ -168,14 +168,16 @@ Treat `"0"` in `amounts_out` as "this requested amount did not produce a usable 
 
 - `200 OK` with `status="ready"` when the service is healthy
 - `503 Service Unavailable` with `status="warming_up"` while native readiness is not ready
-- `native_status="ready"` when the broadcaster subscription is live, bootstrap is complete, and native state is ready and not stale
-- `native_status="warming_up"` while initial native state is still loading or native updates are stale
+- `backends.native.status="ready"` when the broadcaster subscription is live, bootstrap is complete, and native state is ready and not stale
+- `backends.native.status="warming_up"` while initial native state is still loading
+- `backends.native.status="stale"` when native updates are past the readiness freshness window
 
-`vm_status` and `rfq_status` are one of:
+`backends.vm.status` and `backends.rfq.status` are one of:
 
 - `disabled`
 - `warming_up`
 - `rebuilding`
+- `stale`
 - `ready`
 
 Timeout behavior differs by endpoint:

--- a/crates/apps/src/sim_analysis/mod.rs
+++ b/crates/apps/src/sim_analysis/mod.rs
@@ -40,7 +40,7 @@ const DEFAULT_READY_TIMEOUT_SECS: u64 = 300;
 const DEFAULT_VM_READY_TIMEOUT_SECS: u64 = 600;
 const DEFAULT_RFQ_READY_TIMEOUT_SECS: u64 = 600;
 const DEFAULT_SLIPPAGE_BPS: u32 = 25;
-const SIMULATION_REPORT_SCHEMA_VERSION: u64 = 3;
+const SIMULATION_REPORT_SCHEMA_VERSION: u64 = 4;
 const SAMPLE_LIMIT: usize = 4;
 const LOG_SCAN_LINE_LIMIT: usize = 500;
 const LOG_EXCERPT_LIMIT: usize = 40;
@@ -277,7 +277,10 @@ async fn analyze_run(
         &lifecycle.initial_readiness,
     )?;
 
-    let profile = balanced_profile(args.chain_id, lifecycle.initial_readiness.vm_enabled)?;
+    let profile = balanced_profile(
+        args.chain_id,
+        lifecycle.initial_readiness.backend_enabled("vm"),
+    )?;
     let mut scenarios = Vec::new();
 
     for scenario in &profile.simulate_scenarios {
@@ -416,8 +419,10 @@ async fn ensure_server_ready(
                 .context("failed to fetch readiness after native wait")?;
         }
 
-        let require_vm = snapshot.vm_enabled && snapshot.vm_status.as_deref() != Some("ready");
-        let require_rfq = snapshot.rfq_enabled && snapshot.rfq_status.as_deref() != Some("ready");
+        let require_vm =
+            snapshot.backend_enabled("vm") && snapshot.backend_status("vm") != Some("ready");
+        let require_rfq =
+            snapshot.backend_enabled("rfq") && snapshot.backend_status("rfq") != Some("ready");
 
         if require_vm || require_rfq {
             let wait_label = readiness_wait_label(require_vm, require_rfq);
@@ -1431,9 +1436,9 @@ async fn wait_for_native_readiness(client: &Client, status_url: &str, chain_id: 
                     return Ok(());
                 }
                 last_observation = format!(
-                    "status={} native_status={}",
+                    "status={} native={}",
                     snapshot.status,
-                    snapshot.native_status.as_deref().unwrap_or("unknown")
+                    snapshot.native_status().unwrap_or("unknown")
                 );
                 saw_observation = true;
             }
@@ -1461,11 +1466,7 @@ async fn wait_for_native_readiness(client: &Client, status_url: &str, chain_id: 
 }
 
 fn snapshot_native_ready(snapshot: &ReadinessSnapshot) -> bool {
-    snapshot
-        .native_status
-        .as_deref()
-        .unwrap_or(snapshot.status.as_str())
-        == "ready"
+    snapshot.native_status().unwrap_or(snapshot.status.as_str()) == "ready"
 }
 
 fn build_wait_ready_args(

--- a/crates/apps/src/sim_analysis/report.rs
+++ b/crates/apps/src/sim_analysis/report.rs
@@ -8,27 +8,78 @@ const EXPECTED_RFQ_PROTOCOL_VISIBILITY_NOTE: &str = "expected RFQ protocol visib
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ReadinessSnapshot {
     pub status: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub native_status: Option<String>,
     pub chain_id: u64,
-    pub block: Option<u64>,
-    pub pools: Option<u64>,
-    pub vm_enabled: bool,
-    pub vm_status: Option<String>,
-    pub vm_block: Option<u64>,
-    pub vm_pools: Option<u64>,
-    pub vm_restarts: Option<u64>,
-    pub vm_last_error: Option<String>,
-    pub vm_rebuild_duration_ms: Option<u64>,
-    pub vm_last_update_age_ms: Option<u64>,
-    pub rfq_enabled: bool,
-    pub rfq_status: Option<String>,
-    pub rfq_block: Option<u64>,
-    pub rfq_pools: Option<u64>,
-    pub rfq_restarts: Option<u64>,
-    pub rfq_last_error: Option<String>,
-    pub rfq_rebuild_duration_ms: Option<u64>,
-    pub rfq_last_update_age_ms: Option<u64>,
+    pub backends: BTreeMap<String, ReadinessBackendSnapshot>,
+}
+
+impl ReadinessSnapshot {
+    pub fn backend(&self, kind: &str) -> Option<&ReadinessBackendSnapshot> {
+        self.backends.get(kind)
+    }
+
+    pub fn native_status(&self) -> Option<&str> {
+        self.backend("native")
+            .map(|backend| backend.status.as_str())
+    }
+
+    pub fn native_block_number(&self) -> Option<u64> {
+        self.backend("native")
+            .and_then(|backend| backend.block_number)
+    }
+
+    pub fn native_pool_count(&self) -> Option<u64> {
+        self.backend("native")
+            .and_then(|backend| backend.pool_count)
+    }
+
+    pub fn backend_enabled(&self, kind: &str) -> bool {
+        self.backend(kind)
+            .map(|backend| backend.enabled)
+            .unwrap_or(false)
+    }
+
+    pub fn backend_status(&self, kind: &str) -> Option<&str> {
+        self.backend(kind).map(|backend| backend.status.as_str())
+    }
+
+    pub fn backend_pool_count(&self, kind: &str) -> Option<u64> {
+        self.backend(kind).and_then(|backend| backend.pool_count)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ReadinessBackendSnapshot {
+    pub enabled: bool,
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub block_number: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pool_count: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub restart_count: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rebuild_duration_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_update_age_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subscription: Option<ReadinessSubscriptionSnapshot>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ReadinessSubscriptionSnapshot {
+    pub connected: bool,
+    pub bootstrap_complete: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stream_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub snapshot_id: Option<String>,
+    pub restart_count: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -163,28 +214,28 @@ fn add_readiness_findings(report: &AnalysisReport, findings: &mut Vec<Finding>) 
             severity: "investigate".to_string(),
             title: "Initial service health was not ready".to_string(),
             detail: format!(
-                "The analyzer began with /status={} and native_status={}. The run still proceeded, but overall service health looked unstable at the start.",
+                "The analyzer began with /status={} and native={}. The run still proceeded, but overall service health looked unstable at the start.",
                 report.readiness.initial.status,
-                display_status(report.readiness.initial.native_status.as_deref())
+                display_status(report.readiness.initial.native_status())
             ),
         });
     }
 
-    if let Some(native_status) = report.readiness.initial.native_status.as_deref() {
+    if let Some(native_status) = report.readiness.initial.native_status() {
         if native_status != "ready" {
             findings.push(Finding {
                 severity: "investigate".to_string(),
                 title: "Initial native readiness was not ready".to_string(),
                 detail: format!(
-                    "The analyzer saw native_status={} at the start of the run.",
+                    "The analyzer saw native={} at the start of the run.",
                     native_status
                 ),
             });
         }
     }
 
-    if report.readiness.initial.vm_enabled
-        && report.readiness.initial.vm_status.as_deref() != Some("ready")
+    if report.readiness.initial.backend_enabled("vm")
+        && report.readiness.initial.backend_status("vm") != Some("ready")
     {
         findings.push(Finding {
             severity: "attention".to_string(),
@@ -194,20 +245,19 @@ fn add_readiness_findings(report: &AnalysisReport, findings: &mut Vec<Finding>) 
                 report
                     .readiness
                     .initial
-                    .vm_status
-                    .as_deref()
+                    .backend_status("vm")
                     .unwrap_or("unknown"),
                 report
                     .readiness
                     .initial
-                    .vm_pools
+                    .backend_pool_count("vm")
                     .map_or_else(|| "unknown".to_string(), |value| value.to_string())
             ),
         });
     }
 
-    if report.readiness.initial.rfq_enabled
-        && report.readiness.initial.rfq_status.as_deref() != Some("ready")
+    if report.readiness.initial.backend_enabled("rfq")
+        && report.readiness.initial.backend_status("rfq") != Some("ready")
     {
         findings.push(Finding {
             severity: "attention".to_string(),
@@ -217,13 +267,12 @@ fn add_readiness_findings(report: &AnalysisReport, findings: &mut Vec<Finding>) 
                 report
                     .readiness
                     .initial
-                    .rfq_status
-                    .as_deref()
+                    .backend_status("rfq")
                     .unwrap_or("unknown"),
                 report
                     .readiness
                     .initial
-                    .rfq_pools
+                    .backend_pool_count("rfq")
                     .map_or_else(|| "unknown".to_string(), |value| value.to_string())
             ),
         });
@@ -420,14 +469,20 @@ fn append_readiness_section(lines: &mut Vec<String>, report: &AnalysisReport) {
 
 fn append_readiness_snapshot(lines: &mut Vec<String>, label: &str, snapshot: &ReadinessSnapshot) {
     lines.push(format!(
-        "- {}: status={} native_status={} block={} pools={} vm_status={} rfq_status={}",
+        "- {}: status={} native={} block={} pools={} vm={} rfq={}",
         label,
         snapshot.status,
-        display_status(snapshot.native_status.as_deref()),
-        fmt_optional_u64(snapshot.block),
-        fmt_optional_u64(snapshot.pools),
-        readiness_component_status(snapshot.vm_enabled, snapshot.vm_status.as_deref()),
-        readiness_component_status(snapshot.rfq_enabled, snapshot.rfq_status.as_deref())
+        display_status(snapshot.native_status()),
+        fmt_optional_u64(snapshot.native_block_number()),
+        fmt_optional_u64(snapshot.native_pool_count()),
+        readiness_component_status(
+            snapshot.backend_enabled("vm"),
+            snapshot.backend_status("vm")
+        ),
+        readiness_component_status(
+            snapshot.backend_enabled("rfq"),
+            snapshot.backend_status("rfq")
+        )
     ));
 }
 
@@ -497,7 +552,7 @@ mod tests {
         build_findings, render_summary, AnalysisReport, Finding, LatencySummary, LogSummary,
         ReadinessReport, EXPECTED_RFQ_PROTOCOL_VISIBILITY_NOTE,
     };
-    use super::{ReadinessSnapshot, RunMetadata, ScenarioReport};
+    use super::{ReadinessBackendSnapshot, ReadinessSnapshot, RunMetadata, ScenarioReport};
     use std::collections::BTreeMap;
 
     fn scenario(label: &str, degraded_count: usize, error_count: usize) -> ScenarioReport {
@@ -518,9 +573,29 @@ mod tests {
         }
     }
 
+    fn readiness_backend(
+        enabled: bool,
+        status: &str,
+        block_number: Option<u64>,
+        pool_count: Option<u64>,
+    ) -> ReadinessBackendSnapshot {
+        ReadinessBackendSnapshot {
+            enabled,
+            status: status.to_string(),
+            reason: None,
+            block_number,
+            pool_count,
+            restart_count: Some(0),
+            last_error: None,
+            rebuild_duration_ms: None,
+            last_update_age_ms: None,
+            subscription: None,
+        }
+    }
+
     fn report(findings: Vec<Finding>, scenarios: Vec<ScenarioReport>) -> AnalysisReport {
         AnalysisReport {
-            schema_version: 3,
+            schema_version: 4,
             run: RunMetadata {
                 started_at_epoch_s: 1,
                 finished_at_epoch_s: 2,
@@ -536,26 +611,11 @@ mod tests {
             readiness: ReadinessReport {
                 initial: ReadinessSnapshot {
                     status: "ready".to_string(),
-                    native_status: Some("ready".to_string()),
                     chain_id: 1,
-                    block: Some(1),
-                    pools: Some(10),
-                    vm_enabled: false,
-                    vm_status: Some("disabled".to_string()),
-                    vm_block: None,
-                    vm_pools: None,
-                    vm_restarts: None,
-                    vm_last_error: None,
-                    vm_rebuild_duration_ms: None,
-                    vm_last_update_age_ms: None,
-                    rfq_enabled: false,
-                    rfq_status: None,
-                    rfq_block: None,
-                    rfq_pools: None,
-                    rfq_restarts: None,
-                    rfq_last_error: None,
-                    rfq_rebuild_duration_ms: None,
-                    rfq_last_update_age_ms: None,
+                    backends: BTreeMap::from([(
+                        "native".to_string(),
+                        readiness_backend(true, "ready", Some(1), Some(10)),
+                    )]),
                 },
                 final_state: None,
             },
@@ -592,11 +652,11 @@ mod tests {
     #[test]
     fn build_findings_marks_rfq_not_ready() {
         let mut analysis = report(Vec::new(), vec![scenario("core simulate", 0, 0)]);
-        analysis.readiness.initial.rfq_enabled = true;
-        analysis.readiness.initial.rfq_status = Some("warming_up".to_string());
-        analysis.readiness.initial.rfq_pools = Some(0);
+        analysis.readiness.initial.backends.insert(
+            "rfq".to_string(),
+            readiness_backend(true, "warming_up", Some(0), Some(0)),
+        );
         analysis.readiness.initial.status = "warming_up".to_string();
-        analysis.readiness.initial.native_status = Some("ready".to_string());
 
         let findings = build_findings(&analysis);
 
@@ -629,22 +689,37 @@ mod tests {
     #[test]
     fn render_summary_includes_rfq_status() {
         let mut analysis = report(Vec::new(), vec![scenario("core simulate", 0, 0)]);
-        analysis.readiness.initial.rfq_enabled = true;
-        analysis.readiness.initial.rfq_status = Some("ready".to_string());
-        analysis.readiness.initial.native_status = Some("warming_up".to_string());
-        analysis.readiness.final_state = Some(ReadinessSnapshot {
-            native_status: Some("ready".to_string()),
-            rfq_enabled: true,
-            rfq_status: Some("rebuilding".to_string()),
-            status: "ready".to_string(),
-            ..analysis.readiness.initial.clone()
-        });
+        analysis.readiness.initial.backends.insert(
+            "rfq".to_string(),
+            readiness_backend(true, "ready", Some(1), Some(1)),
+        );
+        analysis
+            .readiness
+            .initial
+            .backends
+            .entry("native".to_string())
+            .or_insert_with(|| readiness_backend(true, "ready", Some(1), Some(10)))
+            .status = "warming_up".to_string();
+
+        let mut final_state = analysis.readiness.initial.clone();
+        final_state.status = "ready".to_string();
+        final_state
+            .backends
+            .entry("native".to_string())
+            .or_insert_with(|| readiness_backend(true, "ready", Some(1), Some(10)))
+            .status = "ready".to_string();
+        final_state
+            .backends
+            .entry("rfq".to_string())
+            .or_insert_with(|| readiness_backend(true, "ready", Some(1), Some(1)))
+            .status = "rebuilding".to_string();
+        analysis.readiness.final_state = Some(final_state);
 
         let summary = render_summary(&analysis);
 
-        assert!(summary.contains("status=ready native_status=warming_up"));
-        assert!(summary.contains("vm_status=disabled rfq_status=ready"));
-        assert!(summary.contains("native_status=ready"));
-        assert!(summary.contains("vm_status=disabled rfq_status=rebuilding"));
+        assert!(summary.contains("status=ready native=warming_up"));
+        assert!(summary.contains("vm=disabled rfq=ready"));
+        assert!(summary.contains("native=ready"));
+        assert!(summary.contains("vm=disabled rfq=rebuilding"));
     }
 }

--- a/crates/apps/tests/integration/encode_route.rs
+++ b/crates/apps/tests/integration/encode_route.rs
@@ -15,7 +15,8 @@ use rpc::create_router;
 use runtime::config::SlippageConfig;
 use runtime::models::erc4626::Erc4626PairPolicy;
 use runtime::models::state::{
-    AppState, BroadcasterSubscriptionStatus, RfqStreamStatus, StateStore, VmStreamStatus,
+    AppState, BroadcasterSubscriptionStatus, ConfiguredBackends, RfqStreamStatus, StateStore,
+    VmStreamStatus,
 };
 use runtime::models::stream_health::StreamHealth;
 use runtime::models::tokens::TokenStore;
@@ -598,6 +599,10 @@ async fn build_app_state_and_request(
         rfq_stream_health,
         vm_stream,
         rfq_stream,
+        configured_backends: ConfiguredBackends {
+            vm: config.enable_vm_pools,
+            rfq: config.enable_rfq_pools,
+        },
         enable_vm_pools: config.enable_vm_pools,
         enable_rfq_pools: config.enable_rfq_pools,
         readiness_stale: Duration::from_secs(120),
@@ -702,6 +707,10 @@ async fn setup_timeout_app(
         rfq_stream_health,
         vm_stream: Arc::new(tokio::sync::RwLock::new(VmStreamStatus::default())),
         rfq_stream: Arc::new(tokio::sync::RwLock::new(RfqStreamStatus::default())),
+        configured_backends: ConfiguredBackends {
+            vm: false,
+            rfq: false,
+        },
         enable_vm_pools: false,
         enable_rfq_pools: false,
         readiness_stale: Duration::from_secs(120),
@@ -1491,6 +1500,10 @@ async fn encode_route_rejects_mixed_route_with_unsupported_erc4626_hop() -> Resu
         rfq_stream_health: Arc::new(StreamHealth::new()),
         vm_stream: Arc::new(tokio::sync::RwLock::new(VmStreamStatus::default())),
         rfq_stream: Arc::new(tokio::sync::RwLock::new(RfqStreamStatus::default())),
+        configured_backends: ConfiguredBackends {
+            vm: false,
+            rfq: false,
+        },
         enable_vm_pools: false,
         enable_rfq_pools: false,
         readiness_stale: Duration::from_secs(120),

--- a/crates/apps/tests/integration/protocol_reset_memory.rs
+++ b/crates/apps/tests/integration/protocol_reset_memory.rs
@@ -11,7 +11,8 @@ use jemallocator::Jemalloc;
 use num_bigint::BigUint;
 use runtime::config::{MemoryConfig, SlippageConfig};
 use runtime::models::state::{
-    AppState, BroadcasterSubscriptionStatus, RfqStreamStatus, StateStore, VmStreamStatus,
+    AppState, BroadcasterSubscriptionStatus, ConfiguredBackends, RfqStreamStatus, StateStore,
+    VmStreamStatus,
 };
 use runtime::models::stream_health::StreamHealth;
 use runtime::models::tokens::TokenStore;
@@ -621,6 +622,10 @@ async fn vm_rebuild_resets_store_and_blocks_quotes() {
         rfq_stream_health: Arc::new(StreamHealth::new()),
         vm_stream: Arc::new(tokio::sync::RwLock::new(VmStreamStatus::default())),
         rfq_stream: Arc::new(tokio::sync::RwLock::new(RfqStreamStatus::default())),
+        configured_backends: ConfiguredBackends {
+            vm: true,
+            rfq: true,
+        },
         enable_vm_pools: true,
         enable_rfq_pools: true,
         readiness_stale: Duration::from_secs(120),

--- a/crates/rpc/src/handlers/readiness.rs
+++ b/crates/rpc/src/handlers/readiness.rs
@@ -1,117 +1,105 @@
+use std::collections::BTreeMap;
+
 use axum::{extract::State, http::StatusCode, Json};
 use serde::Serialize;
 
-use crate::models::state::{AppState, NativeReadiness, RfqReadiness, VmReadiness};
+use crate::models::state::{
+    AppState, SimulatorBackendStatusSnapshot, SimulatorBackendSubscriptionSnapshot,
+    SimulatorReadinessReason, SimulatorServiceStatus, SimulatorStatusSnapshot,
+};
 
 #[derive(Serialize)]
 pub struct StatusPayload {
     status: &'static str,
     chain_id: u64,
-    block: u64,
-    pools: usize,
-    native_status: &'static str,
-    vm_enabled: bool,
-    vm_status: &'static str,
-    vm_block: u64,
-    vm_pools: usize,
-    vm_restarts: u64,
+    backends: BTreeMap<&'static str, BackendStatusPayload>,
+}
+
+impl From<SimulatorStatusSnapshot> for StatusPayload {
+    fn from(snapshot: SimulatorStatusSnapshot) -> Self {
+        Self {
+            status: snapshot.status.label(),
+            chain_id: snapshot.chain_id,
+            backends: snapshot
+                .backends
+                .into_iter()
+                .map(|backend| (backend.kind.label(), backend.into()))
+                .collect(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub struct BackendStatusPayload {
+    enabled: bool,
+    status: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
-    vm_last_error: Option<String>,
+    reason: Option<&'static str>,
+    block_number: u64,
+    pool_count: usize,
+    restart_count: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
-    vm_rebuild_duration_ms: Option<u64>,
+    last_error: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    vm_last_update_age_ms: Option<u64>,
-    rfq_enabled: bool,
-    rfq_status: &'static str,
-    rfq_block: u64,
-    rfq_pools: usize,
-    rfq_restarts: u64,
+    rebuild_duration_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    rfq_last_error: Option<String>,
+    last_update_age_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    rfq_rebuild_duration_ms: Option<u64>,
+    subscription: Option<BackendSubscriptionPayload>,
+}
+
+impl From<SimulatorBackendStatusSnapshot> for BackendStatusPayload {
+    fn from(snapshot: SimulatorBackendStatusSnapshot) -> Self {
+        Self {
+            enabled: snapshot.enabled,
+            status: snapshot.readiness.label(),
+            reason: snapshot.reason.map(SimulatorReadinessReason::label),
+            block_number: snapshot.block_number,
+            pool_count: snapshot.pool_count,
+            restart_count: snapshot.restart_count,
+            last_error: snapshot.last_error,
+            rebuild_duration_ms: snapshot.rebuild_duration_ms,
+            last_update_age_ms: snapshot.last_update_age_ms,
+            subscription: snapshot.subscription.map(Into::into),
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub struct BackendSubscriptionPayload {
+    connected: bool,
+    bootstrap_complete: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
-    rfq_last_update_age_ms: Option<u64>,
+    stream_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    snapshot_id: Option<String>,
+    restart_count: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_error: Option<String>,
+}
+
+impl From<SimulatorBackendSubscriptionSnapshot> for BackendSubscriptionPayload {
+    fn from(snapshot: SimulatorBackendSubscriptionSnapshot) -> Self {
+        Self {
+            connected: snapshot.connected,
+            bootstrap_complete: snapshot.bootstrap_complete,
+            stream_id: snapshot.stream_id,
+            snapshot_id: snapshot.snapshot_id,
+            restart_count: snapshot.restart_count,
+            last_error: snapshot.last_error,
+        }
+    }
 }
 
 pub async fn status(State(state): State<AppState>) -> (StatusCode, Json<StatusPayload>) {
-    let block = state.current_block().await;
-    let pools = state.total_pools().await;
-    let native_readiness = state.native_readiness().await;
-
-    let vm_enabled = state.enable_vm_pools;
-    let rfq_enabled = state.enable_rfq_pools;
-    let vm_status_snapshot = state.vm_stream.read().await.clone();
-    let rfq_status_snapshot = state.rfq_stream.read().await.clone();
-    let vm_readiness = state.vm_readiness().await;
-    let rfq_readiness = state.rfq_readiness().await;
-    let vm_status = vm_readiness.label();
-    let rfq_status = rfq_readiness.label();
-
-    let vm_block = state.vm_block().await;
-    let rfq_block = state.rfq_block().await;
-    let vm_pools = state.vm_pools().await;
-    let rfq_pools = state.rfq_pools().await;
-    let vm_restarts = vm_status_snapshot.restart_count;
-    let rfq_restarts = rfq_status_snapshot.restart_count;
-    let vm_last_error = vm_status_snapshot.last_error.clone();
-    let rfq_last_error = rfq_status_snapshot.last_error.clone();
-    let vm_rebuild_duration_ms = if matches!(vm_readiness, VmReadiness::Rebuilding) {
-        vm_status_snapshot
-            .rebuild_started_at
-            .map(|instant| instant.elapsed().as_millis() as u64)
-    } else {
-        None
-    };
-    let rfq_rebuild_duration_ms = if matches!(rfq_readiness, RfqReadiness::Rebuilding) {
-        rfq_status_snapshot
-            .rebuild_started_at
-            .map(|instant| instant.elapsed().as_millis() as u64)
-    } else {
-        None
-    };
-    let vm_last_update_age_ms = state.vm_update_age_ms().await;
-    let rfq_last_update_age_ms = state.rfq_update_age_ms().await;
-    let native_status = native_readiness.label();
-    let service_is_ready = matches!(native_readiness, NativeReadiness::Ready);
-    let status = if service_is_ready {
-        "ready"
-    } else {
-        "warming_up"
-    };
-
-    let status_code = if service_is_ready {
+    let snapshot = state.status_snapshot().await;
+    let status_code = if snapshot.status == SimulatorServiceStatus::Ready {
         StatusCode::OK
     } else {
         StatusCode::SERVICE_UNAVAILABLE
     };
 
-    (
-        status_code,
-        Json(StatusPayload {
-            status,
-            chain_id: state.chain.id(),
-            block,
-            pools,
-            native_status,
-            vm_enabled,
-            vm_status,
-            vm_block,
-            vm_pools,
-            vm_restarts,
-            vm_last_error,
-            vm_rebuild_duration_ms,
-            vm_last_update_age_ms,
-            rfq_enabled,
-            rfq_status,
-            rfq_block,
-            rfq_pools,
-            rfq_restarts,
-            rfq_last_error,
-            rfq_rebuild_duration_ms,
-            rfq_last_update_age_ms,
-        }),
-    )
+    (status_code, Json(snapshot.into()))
 }
 
 #[cfg(test)]
@@ -124,7 +112,8 @@ mod tests {
     use super::{status, StatusPayload};
     use crate::config::SlippageConfig;
     use crate::models::state::{
-        AppState, BroadcasterSubscriptionStatus, RfqStreamStatus, StateStore, VmStreamStatus,
+        AppState, BroadcasterSubscriptionStatus, ConfiguredBackends, RfqStreamStatus, StateStore,
+        VmStreamStatus,
     };
     use crate::models::stream_health::StreamHealth;
     use crate::models::tokens::TokenStore;
@@ -254,6 +243,10 @@ mod tests {
             rfq_stream_health: Arc::new(StreamHealth::new()),
             vm_stream: Arc::new(tokio::sync::RwLock::new(VmStreamStatus::default())),
             rfq_stream: Arc::new(tokio::sync::RwLock::new(RfqStreamStatus::default())),
+            configured_backends: ConfiguredBackends {
+                vm: enable_vm_pools,
+                rfq: enable_rfq_pools,
+            },
             enable_vm_pools,
             enable_rfq_pools,
             readiness_stale: Duration::from_secs(120),
@@ -286,8 +279,9 @@ mod tests {
         let (status_code, Json(payload)): (_, Json<StatusPayload>) = status(State(state)).await;
 
         assert_eq!(status_code, StatusCode::SERVICE_UNAVAILABLE);
-        assert_eq!(payload.status, "warming_up");
-        assert_eq!(payload.native_status, "warming_up");
+        assert_eq!(payload.status, "stale");
+        assert_eq!(payload.backends["native"].status, "stale");
+        assert_eq!(payload.backends["native"].reason, Some("stale"));
     }
 
     #[tokio::test]
@@ -329,9 +323,25 @@ mod tests {
 
         assert_eq!(status_code, StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(payload.status, "warming_up");
-        assert_eq!(payload.native_status, "warming_up");
-        assert_eq!(payload.vm_status, "ready");
-        assert!(payload.rfq_enabled);
-        assert_eq!(payload.rfq_status, "rebuilding");
+        assert_eq!(payload.backends["native"].status, "warming_up");
+        assert_eq!(payload.backends["native"].reason, Some("state_warming_up"));
+        assert_eq!(payload.backends["vm"].status, "ready");
+        assert!(payload.backends["rfq"].enabled);
+        assert_eq!(payload.backends["rfq"].status, "rebuilding");
+        assert_eq!(payload.backends["rfq"].reason, Some("rebuilding"));
+    }
+
+    #[tokio::test]
+    async fn status_reports_configured_disabled_backends_and_omits_unconfigured() {
+        let mut state = test_state(false, false);
+        state.configured_backends.vm = true;
+
+        let (_status_code, Json(payload)): (_, Json<StatusPayload>) = status(State(state)).await;
+
+        assert!(payload.backends.contains_key("native"));
+        assert!(!payload.backends["vm"].enabled);
+        assert_eq!(payload.backends["vm"].status, "disabled");
+        assert_eq!(payload.backends["vm"].reason, Some("disabled_by_config"));
+        assert!(!payload.backends.contains_key("rfq"));
     }
 }

--- a/crates/rpc/src/models/broadcaster_rpc.rs
+++ b/crates/rpc/src/models/broadcaster_rpc.rs
@@ -86,6 +86,8 @@ impl From<BroadcasterSnapshotStatus> for BroadcasterSnapshotPayload {
 pub struct BroadcasterSubscribersPayload {
     pub active: usize,
     pub lag_disconnects: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
 }
 
 impl From<BroadcasterSubscriberSnapshot> for BroadcasterSubscribersPayload {
@@ -93,6 +95,7 @@ impl From<BroadcasterSubscriberSnapshot> for BroadcasterSubscribersPayload {
         Self {
             active: snapshot.active,
             lag_disconnects: snapshot.lag_disconnects,
+            last_error: snapshot.last_error,
         }
     }
 }

--- a/crates/runtime/src/models/broadcaster.rs
+++ b/crates/runtime/src/models/broadcaster.rs
@@ -59,10 +59,11 @@ pub struct BroadcasterSnapshotStatus {
     pub chunk_size: usize,
 }
 
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct BroadcasterSubscriberSnapshot {
     pub active: usize,
     pub lag_disconnects: u64,
+    pub last_error: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/runtime/src/models/state.rs
+++ b/crates/runtime/src/models/state.rs
@@ -436,9 +436,7 @@ impl AppState {
             reason,
             block_number: self.current_block().await,
             pool_count: self.native_state_store.total_states().await,
-            restart_count: subscription
-                .restart_count
-                .saturating_add(stream_restart_count),
+            restart_count: stream_restart_count,
             last_error: subscription.last_error.clone().or(stream_last_error),
             rebuild_duration_ms: None,
             last_update_age_ms,
@@ -479,9 +477,7 @@ impl AppState {
             reason,
             block_number: self.vm_block().await,
             pool_count: self.vm_pools().await,
-            restart_count: subscription
-                .restart_count
-                .saturating_add(stream_status.restart_count),
+            restart_count: stream_status.restart_count,
             last_error: subscription
                 .last_error
                 .clone()
@@ -1667,6 +1663,17 @@ mod tests {
         )
     }
 
+    fn backend_snapshot(
+        snapshot: &SimulatorStatusSnapshot,
+        kind: SimulatorBackendKind,
+    ) -> &SimulatorBackendStatusSnapshot {
+        snapshot
+            .backends
+            .iter()
+            .find(|backend| backend.kind == kind)
+            .unwrap_or_else(|| unreachable!("status snapshot must include {kind:?} backend"))
+    }
+
     #[tokio::test]
     async fn native_readiness_distinguishes_ready_stale_and_warming_up() {
         let warming_up_state = {
@@ -1741,6 +1748,54 @@ mod tests {
             .await;
         assert!(state.is_ready().await);
         assert_eq!(state.native_readiness().await, NativeReadiness::Ready);
+    }
+
+    #[tokio::test]
+    async fn native_status_keeps_backend_and_subscription_restart_counts_separate() {
+        let state = build_readiness_test_state(false, false).await;
+        state
+            .native_broadcaster_subscription
+            .mark_disconnected(Some("native broadcaster dropped".to_string()))
+            .await;
+        state.native_stream_health.increment_restart().await;
+
+        let snapshot = state.status_snapshot().await;
+        let native = backend_snapshot(&snapshot, SimulatorBackendKind::Native);
+
+        assert_eq!(native.restart_count, 1);
+        assert_eq!(
+            native
+                .subscription
+                .as_ref()
+                .unwrap_or_else(|| unreachable!("native status must include subscription"))
+                .restart_count,
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn vm_status_keeps_backend_and_subscription_restart_counts_separate() {
+        let state = build_readiness_test_state(true, false).await;
+        state
+            .vm_broadcaster_subscription
+            .mark_disconnected(Some("vm broadcaster dropped".to_string()))
+            .await;
+        {
+            let mut vm_status = state.vm_stream.write().await;
+            vm_status.restart_count = 1;
+        }
+
+        let snapshot = state.status_snapshot().await;
+        let vm = backend_snapshot(&snapshot, SimulatorBackendKind::Vm);
+
+        assert_eq!(vm.restart_count, 1);
+        assert_eq!(
+            vm.subscription
+                .as_ref()
+                .unwrap_or_else(|| unreachable!("VM status must include subscription"))
+                .restart_count,
+            1
+        );
     }
 
     #[tokio::test]

--- a/crates/runtime/src/models/state.rs
+++ b/crates/runtime/src/models/state.rs
@@ -44,6 +44,7 @@ pub struct AppState {
     pub rfq_stream_health: Arc<StreamHealth>,
     pub vm_stream: Arc<RwLock<VmStreamStatus>>,
     pub rfq_stream: Arc<RwLock<RfqStreamStatus>>,
+    pub configured_backends: ConfiguredBackends,
     pub enable_vm_pools: bool,
     pub enable_rfq_pools: bool,
     pub readiness_stale: Duration,
@@ -62,6 +63,13 @@ pub struct AppState {
     pub native_sim_concurrency: usize,
     pub vm_sim_concurrency: usize,
     pub rfq_sim_concurrency: usize,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ConfiguredBackends {
+    // Native is always configured; only optional manifest-backed backends live here.
+    pub vm: bool,
+    pub rfq: bool,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -165,7 +173,8 @@ impl NativeReadiness {
     pub const fn label(self) -> &'static str {
         match self {
             Self::Ready => "ready",
-            Self::WarmingUp | Self::Stale => "warming_up",
+            Self::WarmingUp => "warming_up",
+            Self::Stale => "stale",
         }
     }
 }
@@ -192,9 +201,10 @@ impl VmReadiness {
     pub const fn label(self) -> &'static str {
         match self {
             Self::Disabled => "disabled",
-            Self::WarmingUp | Self::Stale => "warming_up",
+            Self::WarmingUp => "warming_up",
             Self::Rebuilding => "rebuilding",
             Self::Ready => "ready",
+            Self::Stale => "stale",
         }
     }
 }
@@ -203,11 +213,122 @@ impl RfqReadiness {
     pub const fn label(self) -> &'static str {
         match self {
             Self::Disabled => "disabled",
-            Self::WarmingUp | Self::Stale => "warming_up",
+            Self::WarmingUp => "warming_up",
             Self::Rebuilding => "rebuilding",
             Self::Ready => "ready",
+            Self::Stale => "stale",
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SimulatorServiceStatus {
+    Ready,
+    WarmingUp,
+    Stale,
+}
+
+impl SimulatorServiceStatus {
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Ready => "ready",
+            Self::WarmingUp => "warming_up",
+            Self::Stale => "stale",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SimulatorBackendKind {
+    Native,
+    Vm,
+    Rfq,
+}
+
+impl SimulatorBackendKind {
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Native => "native",
+            Self::Vm => "vm",
+            Self::Rfq => "rfq",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SimulatorBackendReadiness {
+    Disabled,
+    WarmingUp,
+    Rebuilding,
+    Ready,
+    Stale,
+}
+
+impl SimulatorBackendReadiness {
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Disabled => "disabled",
+            Self::WarmingUp => "warming_up",
+            Self::Rebuilding => "rebuilding",
+            Self::Ready => "ready",
+            Self::Stale => "stale",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SimulatorReadinessReason {
+    DisabledByConfig,
+    BroadcasterDisconnected,
+    SnapshotBootstrapping,
+    StateWarmingUp,
+    Rebuilding,
+    Stale,
+}
+
+impl SimulatorReadinessReason {
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::DisabledByConfig => "disabled_by_config",
+            Self::BroadcasterDisconnected => "broadcaster_disconnected",
+            Self::SnapshotBootstrapping => "snapshot_bootstrapping",
+            Self::StateWarmingUp => "state_warming_up",
+            Self::Rebuilding => "rebuilding",
+            Self::Stale => "stale",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SimulatorStatusSnapshot {
+    pub status: SimulatorServiceStatus,
+    pub chain_id: u64,
+    pub backends: Vec<SimulatorBackendStatusSnapshot>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SimulatorBackendStatusSnapshot {
+    pub kind: SimulatorBackendKind,
+    pub enabled: bool,
+    pub readiness: SimulatorBackendReadiness,
+    pub reason: Option<SimulatorReadinessReason>,
+    pub block_number: u64,
+    pub pool_count: usize,
+    pub restart_count: u64,
+    pub last_error: Option<String>,
+    pub rebuild_duration_ms: Option<u64>,
+    pub last_update_age_ms: Option<u64>,
+    pub subscription: Option<SimulatorBackendSubscriptionSnapshot>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SimulatorBackendSubscriptionSnapshot {
+    pub connected: bool,
+    pub bootstrap_complete: bool,
+    pub stream_id: Option<String>,
+    pub snapshot_id: Option<String>,
+    pub restart_count: u64,
+    pub last_error: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -262,6 +383,164 @@ impl AppState {
         subscription.connected && subscription.bootstrap_complete
     }
 
+    pub async fn status_snapshot(&self) -> SimulatorStatusSnapshot {
+        let native = self.native_status_snapshot().await;
+        let status = match native.readiness {
+            SimulatorBackendReadiness::Ready => SimulatorServiceStatus::Ready,
+            SimulatorBackendReadiness::Stale => SimulatorServiceStatus::Stale,
+            _ => SimulatorServiceStatus::WarmingUp,
+        };
+        let mut backends = vec![native];
+
+        if self.configured_backends.vm {
+            backends.push(self.vm_status_snapshot().await);
+        }
+        if self.configured_backends.rfq {
+            backends.push(self.rfq_status_snapshot().await);
+        }
+
+        SimulatorStatusSnapshot {
+            status,
+            chain_id: self.chain.id(),
+            backends,
+        }
+    }
+
+    async fn native_status_snapshot(&self) -> SimulatorBackendStatusSnapshot {
+        let subscription = self.native_broadcaster_subscription.snapshot().await;
+        let subscription_reason = subscription_readiness_reason(&subscription);
+        let last_update_age_ms = self.native_update_age_ms().await;
+        let stream_restart_count = self.native_stream_health.restart_count().await;
+        let stream_last_error = self.native_stream_health.last_error().await;
+        let readiness = if subscription_reason.is_some() || !self.native_state_store.is_ready() {
+            SimulatorBackendReadiness::WarmingUp
+        } else if is_update_stale(last_update_age_ms, self.readiness_stale_ms()) {
+            SimulatorBackendReadiness::Stale
+        } else {
+            SimulatorBackendReadiness::Ready
+        };
+        let reason = match readiness {
+            SimulatorBackendReadiness::WarmingUp => {
+                subscription_reason.or(Some(SimulatorReadinessReason::StateWarmingUp))
+            }
+            SimulatorBackendReadiness::Stale => Some(SimulatorReadinessReason::Stale),
+            SimulatorBackendReadiness::Ready
+            | SimulatorBackendReadiness::Disabled
+            | SimulatorBackendReadiness::Rebuilding => None,
+        };
+
+        SimulatorBackendStatusSnapshot {
+            kind: SimulatorBackendKind::Native,
+            enabled: true,
+            readiness,
+            reason,
+            block_number: self.current_block().await,
+            pool_count: self.native_state_store.total_states().await,
+            restart_count: subscription
+                .restart_count
+                .saturating_add(stream_restart_count),
+            last_error: subscription.last_error.clone().or(stream_last_error),
+            rebuild_duration_ms: None,
+            last_update_age_ms,
+            subscription: Some(subscription.into()),
+        }
+    }
+
+    async fn vm_status_snapshot(&self) -> SimulatorBackendStatusSnapshot {
+        let subscription = self.vm_broadcaster_subscription.snapshot().await;
+        let subscription_reason = subscription_readiness_reason(&subscription);
+        let stream_status = self.vm_stream.read().await.clone();
+        let last_update_age_ms = self.vm_update_age_ms().await;
+        let readiness = if !self.enable_vm_pools {
+            SimulatorBackendReadiness::Disabled
+        } else if stream_status.rebuilding {
+            SimulatorBackendReadiness::Rebuilding
+        } else if subscription_reason.is_some() || !self.vm_state_store.is_ready() {
+            SimulatorBackendReadiness::WarmingUp
+        } else if is_update_stale(last_update_age_ms, self.readiness_stale_ms()) {
+            SimulatorBackendReadiness::Stale
+        } else {
+            SimulatorBackendReadiness::Ready
+        };
+        let reason = match readiness {
+            SimulatorBackendReadiness::Disabled => Some(SimulatorReadinessReason::DisabledByConfig),
+            SimulatorBackendReadiness::Rebuilding => Some(SimulatorReadinessReason::Rebuilding),
+            SimulatorBackendReadiness::WarmingUp => {
+                subscription_reason.or(Some(SimulatorReadinessReason::StateWarmingUp))
+            }
+            SimulatorBackendReadiness::Stale => Some(SimulatorReadinessReason::Stale),
+            SimulatorBackendReadiness::Ready => None,
+        };
+
+        SimulatorBackendStatusSnapshot {
+            kind: SimulatorBackendKind::Vm,
+            enabled: self.enable_vm_pools,
+            readiness,
+            reason,
+            block_number: self.vm_block().await,
+            pool_count: self.vm_pools().await,
+            restart_count: subscription
+                .restart_count
+                .saturating_add(stream_status.restart_count),
+            last_error: subscription
+                .last_error
+                .clone()
+                .or_else(|| stream_status.last_error.clone()),
+            rebuild_duration_ms: if matches!(readiness, SimulatorBackendReadiness::Rebuilding) {
+                stream_status
+                    .rebuild_started_at
+                    .map(|instant| instant.elapsed().as_millis() as u64)
+            } else {
+                None
+            },
+            last_update_age_ms,
+            subscription: self.enable_vm_pools.then_some(subscription.into()),
+        }
+    }
+
+    async fn rfq_status_snapshot(&self) -> SimulatorBackendStatusSnapshot {
+        let stream_status = self.rfq_stream.read().await.clone();
+        let last_update_age_ms = self.rfq_update_age_ms().await;
+        let readiness = if !self.enable_rfq_pools {
+            SimulatorBackendReadiness::Disabled
+        } else if stream_status.rebuilding {
+            SimulatorBackendReadiness::Rebuilding
+        } else if !self.rfq_state_store.is_ready() {
+            SimulatorBackendReadiness::WarmingUp
+        } else if is_update_stale(last_update_age_ms, self.readiness_stale_ms()) {
+            SimulatorBackendReadiness::Stale
+        } else {
+            SimulatorBackendReadiness::Ready
+        };
+        let reason = match readiness {
+            SimulatorBackendReadiness::Disabled => Some(SimulatorReadinessReason::DisabledByConfig),
+            SimulatorBackendReadiness::Rebuilding => Some(SimulatorReadinessReason::Rebuilding),
+            SimulatorBackendReadiness::WarmingUp => Some(SimulatorReadinessReason::StateWarmingUp),
+            SimulatorBackendReadiness::Stale => Some(SimulatorReadinessReason::Stale),
+            SimulatorBackendReadiness::Ready => None,
+        };
+
+        SimulatorBackendStatusSnapshot {
+            kind: SimulatorBackendKind::Rfq,
+            enabled: self.enable_rfq_pools,
+            readiness,
+            reason,
+            block_number: self.rfq_block().await,
+            pool_count: self.rfq_pools().await,
+            restart_count: stream_status.restart_count,
+            last_error: stream_status.last_error.clone(),
+            rebuild_duration_ms: if matches!(readiness, SimulatorBackendReadiness::Rebuilding) {
+                stream_status
+                    .rebuild_started_at
+                    .map(|instant| instant.elapsed().as_millis() as u64)
+            } else {
+                None
+            },
+            last_update_age_ms,
+            subscription: None,
+        }
+    }
+
     pub async fn current_block(&self) -> u64 {
         self.native_state_store.current_block().await
     }
@@ -288,13 +567,7 @@ impl AppState {
     }
 
     pub async fn is_ready(&self) -> bool {
-        if !self.native_broadcaster_bootstrap_ready().await {
-            return false;
-        }
-        if !self.native_state_store.is_ready() {
-            return false;
-        }
-        !is_update_stale(self.native_update_age_ms().await, self.readiness_stale_ms())
+        matches!(self.native_readiness().await, NativeReadiness::Ready)
     }
 
     pub fn readiness_stale_ms(&self) -> u64 {
@@ -498,26 +771,11 @@ impl AppState {
     }
 
     pub async fn vm_ready(&self) -> bool {
-        if !self.enable_vm_pools {
-            return false;
-        }
-        if self.vm_rebuilding().await {
-            return false;
-        }
-        if !self.vm_broadcaster_bootstrap_ready().await {
-            return false;
-        }
-        self.vm_state_store.is_ready()
+        matches!(self.vm_readiness().await, VmReadiness::Ready)
     }
 
     pub async fn rfq_ready(&self) -> bool {
-        if !self.enable_rfq_pools {
-            return false;
-        }
-        if self.rfq_rebuilding().await {
-            return false;
-        }
-        self.rfq_state_store.is_ready()
+        matches!(self.rfq_readiness().await, RfqReadiness::Ready)
     }
 
     pub async fn vm_rebuilding(&self) -> bool {
@@ -549,6 +807,31 @@ fn is_update_stale(last_update_age_ms: Option<u64>, readiness_stale_ms: u64) -> 
     last_update_age_ms
         .map(|age| age >= readiness_stale_ms)
         .unwrap_or(false)
+}
+
+fn subscription_readiness_reason(
+    subscription: &BroadcasterSubscriptionSnapshot,
+) -> Option<SimulatorReadinessReason> {
+    if !subscription.connected {
+        Some(SimulatorReadinessReason::BroadcasterDisconnected)
+    } else if !subscription.bootstrap_complete {
+        Some(SimulatorReadinessReason::SnapshotBootstrapping)
+    } else {
+        None
+    }
+}
+
+impl From<BroadcasterSubscriptionSnapshot> for SimulatorBackendSubscriptionSnapshot {
+    fn from(snapshot: BroadcasterSubscriptionSnapshot) -> Self {
+        Self {
+            connected: snapshot.connected,
+            bootstrap_complete: snapshot.bootstrap_complete,
+            stream_id: snapshot.stream_id,
+            snapshot_id: snapshot.snapshot_id,
+            restart_count: snapshot.restart_count,
+            last_error: snapshot.last_error,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -1315,6 +1598,10 @@ mod tests {
             rfq_stream_health: Arc::new(StreamHealth::new()),
             vm_stream: Arc::new(RwLock::new(VmStreamStatus::default())),
             rfq_stream: Arc::new(RwLock::new(RfqStreamStatus::default())),
+            configured_backends: ConfiguredBackends {
+                vm: flags.enable_vm_pools,
+                rfq: flags.enable_rfq_pools,
+            },
             enable_vm_pools: flags.enable_vm_pools,
             enable_rfq_pools: flags.enable_rfq_pools,
             readiness_stale: Duration::from_secs(120),

--- a/crates/runtime/src/services/broadcaster_sessions.rs
+++ b/crates/runtime/src/services/broadcaster_sessions.rs
@@ -14,6 +14,16 @@ pub enum SessionCloseReason {
     Shutdown,
 }
 
+impl SessionCloseReason {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Lagged => "lagged",
+            Self::GenerationReset => "generation_reset",
+            Self::Shutdown => "shutdown",
+        }
+    }
+}
+
 pub struct BroadcasterSessionRegistration {
     pub session_id: u64,
     pub stream_id: String,
@@ -27,6 +37,7 @@ pub struct BroadcasterSubscriberRegistry {
     buffer_capacity: usize,
     next_session_id: Arc<AtomicU64>,
     lag_disconnects: Arc<AtomicU64>,
+    last_error: Arc<Mutex<Option<String>>>,
     inner: Arc<Mutex<HashMap<u64, SubscriberHandle>>>,
 }
 
@@ -42,6 +53,7 @@ impl BroadcasterSubscriberRegistry {
             buffer_capacity,
             next_session_id: Arc::new(AtomicU64::new(1)),
             lag_disconnects: Arc::new(AtomicU64::new(0)),
+            last_error: Arc::new(Mutex::new(None)),
             inner: Arc::new(Mutex::new(HashMap::new())),
         }
     }
@@ -74,6 +86,7 @@ impl BroadcasterSubscriberRegistry {
     pub async fn broadcast(&self, payload: BroadcasterPayload) {
         let mut lagged = Vec::new();
         let mut closed = Vec::new();
+        let mut last_error = None;
         let mut guard = self.inner.lock().await;
 
         for (session_id, handle) in guard.iter_mut() {
@@ -84,9 +97,16 @@ impl BroadcasterSubscriberRegistry {
                     if let Some(close_tx) = handle.close_tx.take() {
                         let _ = close_tx.send(SessionCloseReason::Lagged);
                     }
+                    last_error = Some(format!(
+                        "subscriber {session_id} disconnected: {}",
+                        SessionCloseReason::Lagged.label()
+                    ));
                     lagged.push(*session_id);
                 }
                 Err(mpsc::error::TrySendError::Closed(_)) => {
+                    last_error = Some(format!(
+                        "subscriber {session_id} disconnected: channel_closed"
+                    ));
                     closed.push(*session_id);
                 }
             }
@@ -94,6 +114,11 @@ impl BroadcasterSubscriberRegistry {
 
         for session_id in lagged.into_iter().chain(closed) {
             guard.remove(&session_id);
+        }
+        drop(guard);
+
+        if let Some(last_error) = last_error {
+            self.record_last_error(last_error).await;
         }
     }
 
@@ -109,13 +134,22 @@ impl BroadcasterSubscriberRegistry {
             }
         }
         guard.clear();
+        drop(guard);
+
+        self.record_last_error(format!("all subscribers disconnected: {}", reason.label()))
+            .await;
     }
 
     pub async fn snapshot(&self) -> BroadcasterSubscriberSnapshot {
         BroadcasterSubscriberSnapshot {
             active: self.inner.lock().await.len(),
             lag_disconnects: self.lag_disconnects.load(Ordering::Relaxed),
+            last_error: self.last_error.lock().await.clone(),
         }
+    }
+
+    async fn record_last_error(&self, message: String) {
+        *self.last_error.lock().await = Some(message);
     }
 }
 
@@ -166,6 +200,10 @@ mod tests {
         let snapshot = registry.snapshot().await;
         assert_eq!(snapshot.active, 1);
         assert_eq!(snapshot.lag_disconnects, 1);
+        assert_eq!(
+            snapshot.last_error.as_deref(),
+            Some("subscriber 1 disconnected: lagged")
+        );
         Ok(())
     }
 
@@ -180,7 +218,12 @@ mod tests {
 
         let reason = session.close_receiver.await?;
         assert_eq!(reason, SessionCloseReason::GenerationReset);
-        assert_eq!(registry.snapshot().await.active, 0);
+        let snapshot = registry.snapshot().await;
+        assert_eq!(snapshot.active, 0);
+        assert_eq!(
+            snapshot.last_error.as_deref(),
+            Some("all subscribers disconnected: generation_reset")
+        );
         Ok(())
     }
 }

--- a/crates/runtime/src/services/encode/fixtures.rs
+++ b/crates/runtime/src/services/encode/fixtures.rs
@@ -14,7 +14,8 @@ use crate::config::SlippageConfig;
 use crate::models::erc4626::Erc4626PairPolicy;
 use crate::models::messages::PoolRef;
 use crate::models::state::{
-    AppState, BroadcasterSubscriptionStatus, RfqStreamStatus, StateStore, VmStreamStatus,
+    AppState, BroadcasterSubscriptionStatus, ConfiguredBackends, RfqStreamStatus, StateStore,
+    VmStreamStatus,
 };
 use crate::models::stream_health::StreamHealth;
 use crate::models::tokens::TokenStore;
@@ -173,6 +174,10 @@ pub(super) fn test_app_state(
         rfq_stream_health: Arc::new(StreamHealth::new()),
         vm_stream: Arc::new(RwLock::new(VmStreamStatus::default())),
         rfq_stream: Arc::new(RwLock::new(RfqStreamStatus::default())),
+        configured_backends: ConfiguredBackends {
+            vm: config.enable_vm_pools,
+            rfq: config.enable_rfq_pools,
+        },
         enable_vm_pools: config.enable_vm_pools,
         enable_rfq_pools: config.enable_rfq_pools,
         readiness_stale: Duration::from_secs(120),

--- a/crates/runtime/src/services/quotes.rs
+++ b/crates/runtime/src/services/quotes.rs
@@ -2702,7 +2702,8 @@ mod tests {
     use tycho_simulation::tycho_common::Bytes;
 
     use crate::models::state::{
-        BroadcasterSubscriptionStatus, RfqStreamStatus, StateStore, VmStreamStatus,
+        BroadcasterSubscriptionStatus, ConfiguredBackends, RfqStreamStatus, StateStore,
+        VmStreamStatus,
     };
     use crate::models::stream_health::StreamHealth;
     use crate::models::tokens::TokenStore;
@@ -3175,6 +3176,10 @@ mod tests {
             rfq_stream_health: Arc::new(StreamHealth::new()),
             vm_stream: Arc::new(RwLock::new(VmStreamStatus::default())),
             rfq_stream: Arc::new(RwLock::new(RfqStreamStatus::default())),
+            configured_backends: ConfiguredBackends {
+                vm: config.enable_vm_pools,
+                rfq: config.enable_rfq_pools,
+            },
             enable_vm_pools: config.enable_vm_pools,
             enable_rfq_pools: config.enable_rfq_pools,
             readiness_stale: Duration::from_secs(120),

--- a/crates/runtime/src/simulator_service.rs
+++ b/crates/runtime/src/simulator_service.rs
@@ -264,12 +264,12 @@ fn build_app_state(
     let pool_timeout_vm = Duration::from_millis(config.pool_timeout_vm_ms);
     let pool_timeout_rfq = Duration::from_millis(config.pool_timeout_rfq_ms);
     let request_timeout = Duration::from_millis(config.request_timeout_ms);
+    let configured_vm_pools = !config.chain_profile.vm_protocols.is_empty();
+    let configured_rfq_pools = !config.chain_profile.rfq_protocols.is_empty();
     // VM is only effective when enabled and the selected chain exposes VM protocols.
-    let effective_vm_enabled =
-        config.enable_vm_pools && !config.chain_profile.vm_protocols.is_empty();
+    let effective_vm_enabled = config.enable_vm_pools && configured_vm_pools;
     // RFQ is only effective when enabled and the selected chain exposes RFQ protocols.
-    let effective_rfq_enabled =
-        config.enable_rfq_pools && !config.chain_profile.rfq_protocols.is_empty();
+    let effective_rfq_enabled = config.enable_rfq_pools && configured_rfq_pools;
 
     AppState {
         chain,
@@ -287,6 +287,10 @@ fn build_app_state(
         rfq_stream_health: Arc::clone(&resources.rfq_stream_health),
         vm_stream: Arc::clone(&resources.vm_stream),
         rfq_stream: Arc::clone(&resources.rfq_stream),
+        configured_backends: crate::models::state::ConfiguredBackends {
+            vm: configured_vm_pools,
+            rfq: configured_rfq_pools,
+        },
         enable_vm_pools: effective_vm_enabled,
         enable_rfq_pools: effective_rfq_enabled,
         readiness_stale,

--- a/docs/quote_service.md
+++ b/docs/quote_service.md
@@ -101,16 +101,19 @@ The current classification logic is:
 Service health and native readiness:
 
 - `status="ready"` with HTTP `200` means the service is healthy
-- `status="warming_up"` with HTTP `503` means no backend is ready yet
-- `native_status="ready"` means native state is ready and recent enough
-- `native_status="warming_up"` means initial native state is still loading or native updates are stale
+- `status="warming_up"` with HTTP `503` means native state is still loading
+- `status="stale"` with HTTP `503` means native state was ready before but is now stale
+- `backends.native.status="ready"` means native state is ready and recent enough
+- `backends.native.status="warming_up"` means the native subscriber, snapshot bootstrap, or state store is still loading
+- `backends.native.status="stale"` means native updates are past the readiness freshness window
 
 VM readiness:
 
-- `vm_status="disabled"` when VM pools are turned off
-- `vm_status="warming_up"` while VM state is still loading
-- `vm_status="rebuilding"` during VM rebuilds
-- `vm_status="ready"` when VM state is usable
+- `backends.vm.status="disabled"` when VM pools are configured but turned off
+- `backends.vm.status="warming_up"` while VM subscriber bootstrap or VM state is still loading
+- `backends.vm.status="rebuilding"` during VM rebuilds
+- `backends.vm.status="stale"` when VM updates are past the readiness freshness window
+- `backends.vm.status="ready"` when VM state is usable
 
 Quote-path implications:
 

--- a/scripts/wait_ready.sh
+++ b/scripts/wait_ready.sh
@@ -12,10 +12,10 @@ Options:
   --timeout              Timeout in seconds (default: 180)
   --interval             Poll interval in seconds (default: 2)
   --expect-chain-id      Require /status.chain_id to match this chain id
-  --require-vm-ready     Require vm_status=ready before succeeding
-  --require-vm-pools-min Minimum vm_pools required when --require-vm-ready is set (default: 1)
-  --require-rfq-ready    Require rfq_status=ready before succeeding
-  --require-rfq-pools-min Minimum rfq_pools required when --require-rfq-ready is set (default: 1)
+  --require-vm-ready     Require backends.vm.status=ready before succeeding
+  --require-vm-pools-min Minimum backends.vm.pool_count required when --require-vm-ready is set (default: 1)
+  --require-rfq-ready    Require backends.rfq.status=ready before succeeding
+  --require-rfq-pools-min Minimum backends.rfq.pool_count required when --require-rfq-ready is set (default: 1)
   -h, --help             Show this help
 USAGE
 }
@@ -108,24 +108,26 @@ if expected_chain is not None:
 if status_code != "200":
     raise SystemExit(2)
 
-if payload.get("native_status") != "ready":
+backends = payload.get("backends") or {}
+native = backends.get("native") or {}
+
+if native.get("status") != "ready":
     raise SystemExit(2)
 
-if require_vm:
-    if not payload.get("vm_enabled"):
+def require_backend(kind, pools_min):
+    backend = backends.get(kind) or {}
+    if not backend.get("enabled"):
         raise SystemExit(2)
-    if payload.get("vm_status") != "ready":
+    if backend.get("status") != "ready":
         raise SystemExit(2)
-    if int(payload.get("vm_pools") or 0) < vm_pools_min:
+    if int(backend.get("pool_count") or 0) < pools_min:
         raise SystemExit(2)
 
+if require_vm:
+    require_backend("vm", vm_pools_min)
+
 if require_rfq:
-    if not payload.get("rfq_enabled"):
-        raise SystemExit(2)
-    if payload.get("rfq_status") != "ready":
-        raise SystemExit(2)
-    if int(payload.get("rfq_pools") or 0) < rfq_pools_min:
-        raise SystemExit(2)
+    require_backend("rfq", rfq_pools_min)
 ' "$status_code" "$require_vm_ready" "$require_vm_pools_min" "$require_rfq_ready" "$require_rfq_pools_min" "$expect_chain_id" <<<"$body" 2>&1)"
   then
     echo "ready"

--- a/skills/simulation-service-analysis/SKILL.md
+++ b/skills/simulation-service-analysis/SKILL.md
@@ -31,7 +31,7 @@ metadata:
 - Runs latency and light stress sweeps.
 - Saves sampled request/response artifacts plus log excerpts.
 - Optionally compares the current run against the latest compatible saved report.
-- Top-level `/status.status` is service health; `native_status` carries native readiness separately.
+- Top-level `/status.status` is service health; nested `backends.*.status` carries backend readiness.
 
 ## Behavior model
 

--- a/skills/simulation-service-analysis/references/project.md
+++ b/skills/simulation-service-analysis/references/project.md
@@ -18,9 +18,9 @@
 
 ## Readiness
 - `GET /status` returns:
-  - `200 OK` with `{ "status": "ready", "native_status": "ready", "chain_id": <u64>, "block": <u64>, "pools": <usize>, ... }` when the service is healthy
-  - `503 Service Unavailable` with `{ "status": "warming_up", "native_status": "...", ... }` while no backend is ready yet
-- `native_status` carries native readiness; `vm_status` and `rfq_status` keep backend-specific readiness separate.
+  - `200 OK` with `{ "status": "ready", "chain_id": <u64>, "backends": { "native": { "status": "ready", ... } } }` when the service is healthy
+  - `503 Service Unavailable` with nested backend status details while native readiness is not ready.
+- `backends.native.status` carries native readiness; `backends.vm.status` and `backends.rfq.status` keep backend-specific readiness separate when those backends are configured.
 - Cold starts can take several minutes (3–5+ mins; VM or RFQ pools can take up to roughly 10 minutes on a fresh warmup).
 - `scripts/wait_ready.sh --expect-chain-id <id>` is still the manual guard if you want the native readiness gate directly.
 - When VM pools matter, prefer `scripts/wait_ready.sh --url http://localhost:3000/status --expect-chain-id <id> --require-vm-ready --timeout 600`.

--- a/skills/simulation-service-analysis/references/protocols.md
+++ b/skills/simulation-service-analysis/references/protocols.md
@@ -48,7 +48,7 @@ The service subscribes to chain-specific Tycho exchanges at startup (see
 ## Effective VM enablement
 
 - Runtime VM state is `effective_vm_enabled = ENABLE_VM_POOLS && vm_protocols_not_empty`.
-- This means Base reports `vm_enabled=false` even if `ENABLE_VM_POOLS=true`.
+- This means Base omits `backends.vm` even if `ENABLE_VM_POOLS=true`.
 - The local analyzer waits for VM readiness automatically on Ethereum when VM pools are enabled.
 
 ## Effective RFQ enablement


### PR DESCRIPTION
Switch `/status` to report readiness under separate native, VM, and RFQ entries, while keeping the service-level readiness tied to native state.