### PR TITLE
feat: Move encode handling into runtime service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5382,7 +5382,6 @@ dependencies = [
  "alloy-primitives 1.5.7",
  "alloy-sol-types",
  "anyhow",
- "axum 0.7.9",
  "chrono",
  "csv",
  "dotenv",

--- a/crates/rpc/src/api/mod.rs
+++ b/crates/rpc/src/api/mod.rs
@@ -15,7 +15,10 @@ use tower::{
 };
 use tracing::warn;
 
-use runtime::{services::QuoteService, simulator_service::SimulatorRuntime};
+use runtime::{
+    services::{EncodeService, QuoteService},
+    simulator_service::SimulatorRuntime,
+};
 
 use crate::handlers::{encode::encode, quote::simulate, readiness::status};
 use crate::metrics::{
@@ -45,6 +48,12 @@ impl FromRef<SimulatorRouterState> for AppState {
 impl FromRef<SimulatorRouterState> for QuoteService {
     fn from_ref(state: &SimulatorRouterState) -> Self {
         state.runtime.quote_service()
+    }
+}
+
+impl FromRef<SimulatorRouterState> for EncodeService {
+    fn from_ref(state: &SimulatorRouterState) -> Self {
+        state.runtime.encode_service()
     }
 }
 

--- a/crates/rpc/src/handlers/encode.rs
+++ b/crates/rpc/src/handlers/encode.rs
@@ -1,60 +1,95 @@
-use std::time::Instant;
-
 use axum::{
     extract::State,
     http::StatusCode,
     response::{IntoResponse, Response},
     Json,
 };
+use runtime::services::encode::{EncodeErrorKind, EncodeService, EncodeServiceError};
 
 use crate::models::messages::{EncodeErrorResponse, RouteEncodeRequest, RouteEncodeResponse};
-use crate::models::state::AppState;
-use crate::services::encode::{
-    encode_route, log_failure, log_handler_timeout, log_received, log_success,
-};
+use crate::services::encode::{log_failure, log_handler_timeout, log_success};
 
 pub async fn encode(
-    State(state): State<AppState>,
+    State(encode_service): State<EncodeService>,
     Json(request): Json<RouteEncodeRequest>,
 ) -> Response {
-    let started_at = Instant::now();
-    log_received(&request);
-
-    let request_timeout = state.request_timeout();
-    let state_for_computation = state.clone();
-    let request_for_computation = request.clone();
-
-    let computation_future = encode_route(state_for_computation, request_for_computation);
-
-    let Ok(computation) = tokio::time::timeout(request_timeout, computation_future).await else {
-        let timeout_ms = request_timeout.as_millis() as u64;
-        log_handler_timeout(
-            &request,
-            timeout_ms,
-            started_at.elapsed().as_millis() as u64,
-        );
-
-        let body = Json(EncodeErrorResponse {
-            error: format!("Encode request timed out after {timeout_ms}ms"),
-            request_id: request.request_id.clone(),
-        });
-        return (StatusCode::REQUEST_TIMEOUT, body).into_response();
-    };
-
-    let latency_ms = started_at.elapsed().as_millis() as u64;
-    match computation {
-        Ok(computation) => {
-            log_success(&request, &computation, latency_ms);
-            Json::<RouteEncodeResponse>(computation.response).into_response()
+    let request_for_logging = request.clone();
+    match encode_service.encode(request).await {
+        Ok(success) => {
+            log_success(
+                &request_for_logging,
+                &success.computation,
+                success.latency_ms,
+            );
+            Json::<RouteEncodeResponse>(success.computation.response).into_response()
         }
-        Err(err) => {
-            let status = err.status_code();
+        Err(EncodeServiceError::Timeout {
+            timeout_ms,
+            latency_ms,
+        }) => {
+            log_handler_timeout(&request_for_logging, timeout_ms, latency_ms);
             let body = Json(EncodeErrorResponse {
-                error: err.message().to_string(),
-                request_id: request.request_id.clone(),
+                error: format!("Encode request timed out after {timeout_ms}ms"),
+                request_id: request_for_logging.request_id.clone(),
             });
-            log_failure(&request, status, err.kind(), err.message(), latency_ms);
+            (StatusCode::REQUEST_TIMEOUT, body).into_response()
+        }
+        Err(EncodeServiceError::Failed { error, latency_ms }) => {
+            let status = encode_status_code(error.kind());
+            let body = Json(EncodeErrorResponse {
+                error: error.message().to_string(),
+                request_id: request_for_logging.request_id.clone(),
+            });
+            log_failure(
+                &request_for_logging,
+                error.kind(),
+                error.message(),
+                latency_ms,
+            );
             (status, body).into_response()
         }
+    }
+}
+
+fn encode_status_code(kind: EncodeErrorKind) -> StatusCode {
+    match kind {
+        EncodeErrorKind::InvalidRequest => StatusCode::BAD_REQUEST,
+        EncodeErrorKind::NotFound => StatusCode::NOT_FOUND,
+        EncodeErrorKind::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
+        EncodeErrorKind::Simulation => StatusCode::UNPROCESSABLE_ENTITY,
+        EncodeErrorKind::Encoding | EncodeErrorKind::Internal => StatusCode::INTERNAL_SERVER_ERROR,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{encode_status_code, EncodeErrorKind, StatusCode};
+
+    #[test]
+    fn encode_status_mapping_stays_in_rpc_adapter() {
+        assert_eq!(
+            encode_status_code(EncodeErrorKind::InvalidRequest),
+            StatusCode::BAD_REQUEST
+        );
+        assert_eq!(
+            encode_status_code(EncodeErrorKind::NotFound),
+            StatusCode::NOT_FOUND
+        );
+        assert_eq!(
+            encode_status_code(EncodeErrorKind::Unavailable),
+            StatusCode::SERVICE_UNAVAILABLE
+        );
+        assert_eq!(
+            encode_status_code(EncodeErrorKind::Simulation),
+            StatusCode::UNPROCESSABLE_ENTITY
+        );
+        assert_eq!(
+            encode_status_code(EncodeErrorKind::Encoding),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+        assert_eq!(
+            encode_status_code(EncodeErrorKind::Internal),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
     }
 }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -11,7 +11,6 @@ description = "DSolver simulator runtime assembly, state, streams, and services.
 alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
 anyhow.workspace = true
-axum.workspace = true
 csv.workspace = true
 dotenv.workspace = true
 futures.workspace = true

--- a/crates/runtime/src/services/encode.rs
+++ b/crates/runtime/src/services/encode.rs
@@ -18,8 +18,60 @@ mod mocks;
 pub use error::{EncodeError, EncodeErrorKind};
 pub use response::{log_failure, log_handler_timeout, log_received, log_success};
 
+use std::time::Instant;
+
 use crate::models::messages::{RouteEncodeRequest, RouteEncodeResponse};
 use crate::models::state::AppState;
+
+/// Transport-free runtime wrapper for `/encode` route encoding.
+#[derive(Clone)]
+pub struct EncodeService {
+    state: AppState,
+}
+
+pub struct EncodeServiceSuccess {
+    pub computation: EncodeComputation,
+    pub latency_ms: u64,
+}
+
+#[derive(Debug)]
+pub enum EncodeServiceError {
+    Timeout { timeout_ms: u64, latency_ms: u64 },
+    Failed { error: EncodeError, latency_ms: u64 },
+}
+
+impl EncodeService {
+    pub fn new(state: AppState) -> Self {
+        Self { state }
+    }
+
+    pub async fn encode(
+        &self,
+        request: RouteEncodeRequest,
+    ) -> Result<EncodeServiceSuccess, EncodeServiceError> {
+        let started_at = Instant::now();
+        response::log_received(&request);
+
+        let request_timeout = self.state.request_timeout();
+        let computation_future = encode_route(self.state.clone(), request);
+
+        let Ok(computation) = tokio::time::timeout(request_timeout, computation_future).await
+        else {
+            return Err(EncodeServiceError::Timeout {
+                timeout_ms: request_timeout.as_millis() as u64,
+                latency_ms: started_at.elapsed().as_millis() as u64,
+            });
+        };
+
+        let latency_ms = started_at.elapsed().as_millis() as u64;
+        computation
+            .map(|computation| EncodeServiceSuccess {
+                computation,
+                latency_ms,
+            })
+            .map_err(|error| EncodeServiceError::Failed { error, latency_ms })
+    }
+}
 
 pub struct EncodeComputation {
     pub response: RouteEncodeResponse,
@@ -28,7 +80,7 @@ pub struct EncodeComputation {
     pub reset_approval: bool,
 }
 
-pub async fn encode_route(
+async fn encode_route(
     state: AppState,
     request: RouteEncodeRequest,
 ) -> Result<EncodeComputation, EncodeError> {

--- a/crates/runtime/src/services/encode/error.rs
+++ b/crates/runtime/src/services/encode/error.rs
@@ -1,4 +1,3 @@
-use axum::http::StatusCode;
 use tycho_execution::encoding::errors::EncodingError;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -60,18 +59,6 @@ impl EncodeError {
         }
     }
 
-    pub fn status_code(&self) -> StatusCode {
-        match self.kind {
-            EncodeErrorKind::InvalidRequest => StatusCode::BAD_REQUEST,
-            EncodeErrorKind::NotFound => StatusCode::NOT_FOUND,
-            EncodeErrorKind::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
-            EncodeErrorKind::Simulation => StatusCode::UNPROCESSABLE_ENTITY,
-            EncodeErrorKind::Encoding | EncodeErrorKind::Internal => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
-        }
-    }
-
     pub fn message(&self) -> &str {
         &self.message
     }
@@ -93,13 +80,15 @@ pub(super) fn map_encoding_error(err: EncodingError) -> EncodeError {
 #[cfg(test)]
 mod tests {
     use super::{EncodeError, EncodeErrorKind};
-    use axum::http::StatusCode;
 
     #[test]
-    fn unavailable_errors_map_to_service_unavailable() {
+    fn unavailable_errors_keep_kind_and_message() {
         let error = EncodeError::unavailable("Encode unavailable: native state warming up");
 
         assert_eq!(error.kind(), EncodeErrorKind::Unavailable);
-        assert_eq!(error.status_code(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            error.message(),
+            "Encode unavailable: native state warming up"
+        );
     }
 }

--- a/crates/runtime/src/services/encode/response.rs
+++ b/crates/runtime/src/services/encode/response.rs
@@ -1,6 +1,5 @@
 use std::collections::BTreeSet;
 
-use axum::http::StatusCode;
 use num_bigint::BigUint;
 use num_traits::Zero;
 use tracing::{debug, info, warn};
@@ -122,7 +121,6 @@ pub fn log_success(request: &RouteEncodeRequest, computation: &EncodeComputation
         scope = "handler_complete",
         request_id = summary.request_id.as_deref(),
         latency_ms,
-        status_code = StatusCode::OK.as_u16(),
         chain_id = summary.chain_id,
         swap_kind = summary.swap_kind,
         segments = summary.segments,
@@ -163,7 +161,6 @@ pub fn log_received(request: &RouteEncodeRequest) {
 
 pub fn log_failure(
     request: &RouteEncodeRequest,
-    status_code: StatusCode,
     kind: EncodeErrorKind,
     message: &str,
     latency_ms: u64,
@@ -174,7 +171,6 @@ pub fn log_failure(
         scope = "handler_complete",
         request_id = summary.request_id.as_deref(),
         latency_ms,
-        status_code = status_code.as_u16(),
         encode_error_kind = encode_error_kind_label(kind),
         failure_stage = stage.label(),
         error = message,
@@ -203,7 +199,6 @@ pub fn log_handler_timeout(request: &RouteEncodeRequest, timeout_ms: u64, latenc
         request_id = summary.request_id.as_deref(),
         latency_ms,
         timeout_ms,
-        status_code = StatusCode::REQUEST_TIMEOUT.as_u16(),
         encode_error_kind = "timeout",
         failure_stage = EncodeFailureStage::HandlerTimeout.label(),
         error,

--- a/crates/runtime/src/services/mod.rs
+++ b/crates/runtime/src/services/mod.rs
@@ -7,4 +7,5 @@ pub mod quotes;
 pub(crate) mod simulation_executor;
 pub mod stream_builder;
 
+pub use encode::EncodeService;
 pub use quote_service::QuoteService;

--- a/crates/runtime/src/simulator_service.rs
+++ b/crates/runtime/src/simulator_service.rs
@@ -27,7 +27,7 @@ use crate::services::broadcaster_subscription::{
     NativeBroadcasterSubscriptionControls, VmBroadcasterSubscriptionControls,
 };
 use crate::services::stream_builder::{build_rfq_stream, RFQConfig, RFQTokenStores};
-use crate::services::QuoteService;
+use crate::services::{EncodeService, QuoteService};
 use crate::stream::{supervise_rfq_stream, RfqStreamControls, StreamSupervisorConfig};
 
 const TOKEN_SNAPSHOT_RETRY_INITIAL_DELAY: Duration = Duration::from_millis(250);
@@ -51,12 +51,14 @@ pub struct SimulatorServiceParts {
 pub struct SimulatorRuntime {
     app_state: AppState,
     quote_service: QuoteService,
+    encode_service: EncodeService,
 }
 
 impl SimulatorRuntime {
     pub fn new(app_state: AppState) -> Self {
         Self {
             quote_service: QuoteService::new(app_state.clone()),
+            encode_service: EncodeService::new(app_state.clone()),
             app_state,
         }
     }
@@ -67,6 +69,10 @@ impl SimulatorRuntime {
 
     pub fn quote_service(&self) -> QuoteService {
         self.quote_service.clone()
+    }
+
+    pub fn encode_service(&self) -> EncodeService {
+        self.encode_service.clone()
     }
 
     pub fn request_timeout(&self) -> Duration {


### PR DESCRIPTION
This moves /encode request execution and timeout handling into a runtime-owned EncodeService, so the Axum handler stays thin while HTTP status mapping remains in the RPC layer and runtime no longer depends on Axum.