### PR TITLE
feat: Capture broadcaster logs in sim-analysis

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,8 @@ __pycache__
 .DS_Store
 .env
 .tycho-sim-server.pid
+.tycho-broadcaster-service.pid
+.tycho-broadcaster-service.meta
 .codex
 .cursor
 .claude

--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ TYCHO_API_KEY=your_api_key_here
 # Runtime chain selection (required): must match a chain in simulator-manifest.toml
 CHAIN_ID=1
 # Required for the simulator service: websocket endpoint for the Tycho broadcaster.
-# The local default assumes the broadcaster runs separately with PORT=3001.
+# Local helpers use this loopback URL to start the broadcaster on PORT=3001 before the simulator.
 TYCHO_BROADCASTER_WS_URL=ws://127.0.0.1:3001/ws
 # Hosted Tycho endpoint is selected automatically from CHAIN_ID.
 # Optional JSON-RPC endpoint matching CHAIN_ID, used for on-chain helpers like ERC4626 deposits

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ skills/**/*.skill
 logs/
 *.log
 .tycho-sim-server.pid
+.tycho-broadcaster-service.pid
+.tycho-broadcaster-service.meta
 .cursorrules
 AGENTS.md
 CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -71,12 +71,15 @@ DSolver Simulator is a Rust service for DeFi quote simulation and route encoding
 
 ```bash
 cp .env.example .env
-PORT=3001 cargo run -p apps --bin dsolver-tycho-broadcaster-service --release
-cargo run -p apps --bin dsolver-simulator-service --release
+scripts/start_server.sh --repo . --chain-id 1
+scripts/wait_ready.sh --url http://localhost:3000/status --expect-chain-id 1
 ```
 
 Use the explicit `-p ... --bin ...` form for local runs and builds so it's always clear which
 workspace binary you're targeting.
+
+For manual service runs, start `dsolver-tycho-broadcaster-service` first on the port used by
+`TYCHO_BROADCASTER_WS_URL`, then start `dsolver-simulator-service`.
 
 Required runtime inputs:
 
@@ -213,6 +216,10 @@ cargo run -p apps --bin sim-analysis -- --chain-id 1 --stop
 cargo run -p apps --bin sim-analysis -- --chain-id 8453 --stop
 ```
 
+When `TYCHO_BROADCASTER_WS_URL` points at local loopback, the analyzer uses the repo lifecycle
+helper to start the broadcaster before the simulator. Non-local broadcaster URLs are treated as
+externally managed.
+
 Container builds:
 
 ```bash
@@ -222,12 +229,12 @@ docker build -f Dockerfile.broadcaster-service -t dsolver-tycho-broadcaster-serv
 
 Useful helpers:
 
-- `scripts/start_server.sh` to start the server with repo-local PID and log files
+- `scripts/start_server.sh` to start the local broadcaster plus simulator stack with repo-local PID and log files
 - `scripts/wait_ready.sh` to poll `/status` and enforce chain, native, VM, and RFQ readiness expectations; native readiness remains the default gate
-- `scripts/stop_server.sh` to stop a server started by the repo helper
+- `scripts/stop_server.sh` to stop services started by the repo helper
 - `cargo run -p apps --bin sim-analysis -- ...` to generate a JSON and markdown local behavior report
 
-The analyzer is intentionally reporting-first. It exercises representative `/simulate` and `/encode` flows, plus latency and light stress probes, then writes artifacts under `logs/simulation-reports/` so agents can inspect anomalies, compare against previous local runs, and decide what matters instead of relying on a rigid pass or fail harness.
+The analyzer is intentionally reporting-first. It exercises representative `/simulate` and `/encode` flows, plus latency and light stress probes, then writes artifacts under `logs/simulation-reports/`, including simulator and broadcaster log excerpts, so agents can inspect anomalies, compare against previous local runs, and decide what matters instead of relying on a rigid pass or fail harness.
 
 ## Docs Map
 

--- a/STRESS_TEST_README.md
+++ b/STRESS_TEST_README.md
@@ -1,6 +1,6 @@
 # DSolver Simulator Local Analysis
 
-This repo ships a reporting-first Rust CLI for local DSolver Simulator analysis. It starts or reuses the server, waits for readiness, exercises representative `/simulate` and `/encode` flows, runs latency and light stress probes, captures sampled evidence, and writes a structured report instead of enforcing a strict pass/fail gate.
+This repo ships a reporting-first Rust CLI for local DSolver Simulator analysis. It starts or reuses the local Tycho broadcaster plus simulator stack, waits for simulator readiness, exercises representative `/simulate` and `/encode` flows, runs latency and light stress probes, captures sampled evidence, and writes a structured report instead of enforcing a strict pass/fail gate.
 
 ## Quick start
 
@@ -16,7 +16,7 @@ Base:
 cargo run -p apps --bin sim-analysis -- --chain-id 8453 --stop
 ```
 
-Keep the server running after the analysis:
+Keep the helper-managed local services running after the analysis:
 
 ```bash
 cargo run -p apps --bin sim-analysis -- --chain-id 1
@@ -30,13 +30,14 @@ cargo run -p apps --bin sim-analysis -- --chain-id 1 --baseline none --stop
 
 ## What the analyzer does
 
-- reuses the existing local server if it is already responding, otherwise starts it
-- waits for `/status` service health, then confirms native readiness first and includes VM readiness when VM pools are enabled
-- allows longer VM warmups on fresh starts; budget up to about 10 minutes before assuming VM pools are stuck
+- reuses the existing local simulator if it is already responding, otherwise starts the local stack with the repo lifecycle helper
+- starts `dsolver-tycho-broadcaster-service` first when `TYCHO_BROADCASTER_WS_URL` points at local loopback, then starts `dsolver-simulator-service`; non-local broadcaster URLs are treated as externally managed
+- waits for `/status` service health, then confirms native readiness first and includes VM and RFQ readiness when those backends are enabled
+- allows longer VM or RFQ warmups on fresh starts; budget up to about 10 minutes before assuming either backend is stuck
 - runs a balanced `/simulate` sweep across representative pairs
-- builds a narrow 2-hop `/encode` probe from live `/simulate` results
+- builds the balanced `/encode` route matrix from live `/simulate` prep hops: 3 SimpleSwap routes, 3 MultiSwap routes, and 2 MegaSwap routes per supported chain
 - runs latency and light stress sweeps
-- saves a JSON report, markdown summary, sampled request/response artifacts, and log excerpts
+- saves a JSON report, markdown summary, sampled request/response artifacts, and simulator/broadcaster log excerpts
 - optionally compares the current run with the most recent compatible saved report
 
 ## Output
@@ -51,7 +52,7 @@ Main artifacts:
 
 - `report.json`: machine-readable run summary
 - `summary.md`: human-readable findings and investigation hints
-- `evidence/`: readiness snapshots, sampled request/response bodies, and log excerpts
+- `evidence/`: readiness snapshots, sampled request/response bodies, and simulator/broadcaster log excerpts
 
 ## Behavior model
 
@@ -64,7 +65,7 @@ Main artifacts:
 After a run:
 
 1. Read `summary.md` for the high-level picture.
-2. Inspect `report.json` for exact counts, latencies, and protocol visibility.
+2. Inspect `report.json` for exact counts, latencies, status/result-quality splits, protocol visibility, and RFQ findings.
 3. Open any sampled artifacts in `evidence/` that look suspicious.
 4. Compare against the saved baseline when the current behavior looks off.
 5. Follow up with targeted manual requests or deeper log analysis when a protocol-specific anomaly needs explanation.

--- a/crates/apps/src/sim_analysis/mod.rs
+++ b/crates/apps/src/sim_analysis/mod.rs
@@ -4,6 +4,7 @@ mod report;
 use std::collections::{BTreeMap, BTreeSet};
 use std::env;
 use std::fs;
+use std::io::{Read, Seek, SeekFrom};
 use std::net::IpAddr;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -30,8 +31,8 @@ use self::presets::{
 };
 use self::report::{
     build_findings, relative_path, render_summary, AnalysisReport, BaselineComparison,
-    LatencySummary, LogSummary, ReadinessReport, ReadinessSnapshot, RunMetadata, ScenarioDiff,
-    ScenarioReport,
+    LatencySummary, LogSourceSummary, LogSummary, ReadinessReport, ReadinessSnapshot, RunMetadata,
+    ScenarioDiff, ScenarioReport,
 };
 
 const DEFAULT_BASE_URL: &str = "http://localhost:3000";
@@ -41,10 +42,13 @@ const DEFAULT_READY_TIMEOUT_SECS: u64 = 300;
 const DEFAULT_VM_READY_TIMEOUT_SECS: u64 = 600;
 const DEFAULT_RFQ_READY_TIMEOUT_SECS: u64 = 600;
 const DEFAULT_SLIPPAGE_BPS: u32 = 25;
-const SIMULATION_REPORT_SCHEMA_VERSION: u64 = 5;
+const SIMULATION_REPORT_SCHEMA_VERSION: u64 = 6;
 const SAMPLE_LIMIT: usize = 4;
 const LOG_SCAN_LINE_LIMIT: usize = 500;
 const LOG_EXCERPT_LIMIT: usize = 40;
+const LOG_BOUNDARY_TAIL_BYTES: u64 = 64;
+const SIMULATOR_LOG_FILE: &str = "logs/tycho-sim-server.log";
+const BROADCASTER_LOG_FILE: &str = "logs/tycho-broadcaster-service.log";
 const EXPECTED_RFQ_PROTOCOL_VISIBILITY_NOTE: &str = "expected RFQ protocol visibility, saw none";
 
 pub async fn run() -> Result<()> {
@@ -62,8 +66,8 @@ pub async fn run() -> Result<()> {
         .build()
         .context("failed to build HTTP client")?;
     let scripts = ScriptPaths::new(&repo);
+    let log_boundary = capture_log_boundaries(&repo);
     let lifecycle = ensure_server_ready(&client, &scripts, &repo, &args).await?;
-    let log_boundary = capture_log_boundary(&repo);
 
     let analysis_result = analyze_run(
         &client,
@@ -86,7 +90,9 @@ pub async fn run() -> Result<()> {
     match (analysis_result, stop_result) {
         (Ok(()), Ok(())) => Ok(()),
         (Err(err), Ok(())) | (Ok(()), Err(err)) => Err(err),
-        (Err(err), Err(stop_err)) => Err(anyhow!("{err}; failed to stop server: {stop_err}")),
+        (Err(err), Err(stop_err)) => {
+            Err(anyhow!("{err}; failed to stop local services: {stop_err}"))
+        }
     }
 }
 
@@ -122,8 +128,18 @@ struct StartupBindConfig {
     port: u16,
 }
 
+struct LogSourceConfig {
+    source: &'static str,
+    log_file: &'static str,
+}
+
 struct LogBoundary {
+    checkpoints: BTreeMap<&'static str, LogBoundaryCheckpoint>,
+}
+
+struct LogBoundaryCheckpoint {
     byte_offset: u64,
+    tail: Vec<u8>,
 }
 
 struct LoadProbePlan<'a> {
@@ -466,7 +482,7 @@ async fn ensure_server_ready(
             return match stop_server(scripts, repo) {
                 Ok(()) => Err(err),
                 Err(stop_err) => Err(anyhow!(
-                    "{err}; failed to stop server after readiness failure: {stop_err}"
+                    "{err}; failed to stop local services after readiness failure: {stop_err}"
                 )),
             };
         }
@@ -1871,26 +1887,126 @@ fn compare_with_baseline(
     })
 }
 
-fn capture_log_boundary(repo: &Path) -> LogBoundary {
-    let log_path = repo.join("logs/tycho-sim-server.log");
-    let byte_offset = fs::metadata(&log_path).map_or(0, |metadata| metadata.len());
-    LogBoundary { byte_offset }
+fn capture_log_boundaries(repo: &Path) -> LogBoundary {
+    let checkpoints = log_sources()
+        .iter()
+        .map(|source| {
+            let log_path = repo.join(source.log_file);
+            (source.source, capture_log_checkpoint(&log_path))
+        })
+        .collect();
+
+    LogBoundary { checkpoints }
+}
+
+fn capture_log_checkpoint(log_path: &Path) -> LogBoundaryCheckpoint {
+    let byte_offset = fs::metadata(log_path).map_or(0, |metadata| metadata.len());
+    let tail_len = byte_offset.min(LOG_BOUNDARY_TAIL_BYTES);
+    if tail_len == 0 {
+        return LogBoundaryCheckpoint {
+            byte_offset,
+            tail: Vec::new(),
+        };
+    }
+
+    let mut tail = vec![0; tail_len as usize];
+    let read_tail = fs::File::open(log_path)
+        .and_then(|mut file| {
+            file.seek(SeekFrom::Start(byte_offset - tail_len))?;
+            file.read_exact(&mut tail)
+        })
+        .is_ok();
+
+    LogBoundaryCheckpoint {
+        byte_offset,
+        tail: if read_tail { tail } else { Vec::new() },
+    }
 }
 
 fn collect_logs(repo: &Path, report_dir: &Path, log_boundary: &LogBoundary) -> Result<LogSummary> {
-    let log_path = repo.join("logs/tycho-sim-server.log");
+    let mut sources = Vec::new();
+    let mut excerpt_sections = Vec::new();
+    let mut highlights = Vec::new();
+    let mut total_matched_lines = 0;
+
+    for source in log_sources() {
+        let log_path = repo.join(source.log_file);
+        let matched_lines = collect_log_source(&log_path, log_boundary.checkpoint(source.source))?;
+        let source_summary = LogSourceSummary {
+            source: source.source.to_string(),
+            log_file: relative_path(repo, &log_path),
+            matched_lines: matched_lines.len(),
+            highlights: matched_lines.iter().take(6).cloned().collect(),
+        };
+
+        if !matched_lines.is_empty() {
+            let excerpt = matched_lines
+                .iter()
+                .rev()
+                .take(LOG_EXCERPT_LIMIT)
+                .cloned()
+                .collect::<Vec<_>>()
+                .join("\n");
+            excerpt_sections.push(format!(
+                "# {} ({})\n{}",
+                source.source, source_summary.log_file, excerpt
+            ));
+            highlights.extend(
+                source_summary
+                    .highlights
+                    .iter()
+                    .map(|line| format!("{}: {}", source.source, line)),
+            );
+        }
+
+        total_matched_lines += source_summary.matched_lines;
+        sources.push(source_summary);
+    }
+
+    let excerpt_file = if excerpt_sections.is_empty() {
+        None
+    } else {
+        let excerpt_path = report_dir.join("evidence/log-excerpts.txt");
+        fs::write(
+            &excerpt_path,
+            format!("{}\n", excerpt_sections.join("\n\n")),
+        )
+        .with_context(|| format!("failed to write {}", excerpt_path.display()))?;
+        Some(relative_path(repo, &excerpt_path))
+    };
+
+    Ok(LogSummary {
+        sources,
+        matched_lines: total_matched_lines,
+        excerpt_file,
+        highlights: highlights.into_iter().take(6).collect(),
+    })
+}
+
+fn log_sources() -> [LogSourceConfig; 2] {
+    [
+        LogSourceConfig {
+            source: "simulator",
+            log_file: SIMULATOR_LOG_FILE,
+        },
+        LogSourceConfig {
+            source: "broadcaster",
+            log_file: BROADCASTER_LOG_FILE,
+        },
+    ]
+}
+
+fn collect_log_source(
+    log_path: &Path,
+    checkpoint: Option<&LogBoundaryCheckpoint>,
+) -> Result<Vec<String>> {
     if !log_path.exists() {
-        return Ok(LogSummary {
-            log_file: log_path.display().to_string(),
-            matched_lines: 0,
-            excerpt_file: None,
-            highlights: Vec::new(),
-        });
+        return Ok(Vec::new());
     }
 
     let contents =
-        fs::read(&log_path).with_context(|| format!("failed to read {}", log_path.display()))?;
-    let start = usize::try_from(log_boundary.byte_offset).unwrap_or(usize::MAX);
+        fs::read(log_path).with_context(|| format!("failed to read {}", log_path.display()))?;
+    let start = log_scan_start(&contents, checkpoint);
     let scoped_contents = if start >= contents.len() {
         String::new()
     } else {
@@ -1910,28 +2026,41 @@ fn collect_logs(repo: &Path, report_dir: &Path, log_boundary: &LogBoundary) -> R
         .map(|line| (*line).to_string())
         .collect::<Vec<_>>();
 
-    let excerpt_file = if matched_lines.is_empty() {
-        None
-    } else {
-        let excerpt_path = report_dir.join("evidence/log-excerpts.txt");
-        let excerpt = matched_lines
-            .iter()
-            .rev()
-            .take(LOG_EXCERPT_LIMIT)
-            .cloned()
-            .collect::<Vec<_>>()
-            .join("\n");
-        fs::write(&excerpt_path, format!("{excerpt}\n"))
-            .with_context(|| format!("failed to write {}", excerpt_path.display()))?;
-        Some(relative_path(repo, &excerpt_path))
-    };
+    Ok(matched_lines)
+}
 
-    Ok(LogSummary {
-        log_file: log_path.display().to_string(),
-        matched_lines: matched_lines.len(),
-        excerpt_file,
-        highlights: matched_lines.into_iter().take(6).collect(),
-    })
+impl LogBoundary {
+    fn checkpoint(&self, source: &str) -> Option<&LogBoundaryCheckpoint> {
+        self.checkpoints.get(source)
+    }
+}
+
+fn log_scan_start(contents: &[u8], checkpoint: Option<&LogBoundaryCheckpoint>) -> usize {
+    let Some(checkpoint) = checkpoint else {
+        return 0;
+    };
+    let Ok(byte_offset) = usize::try_from(checkpoint.byte_offset) else {
+        return 0;
+    };
+    if byte_offset == 0 {
+        return 0;
+    }
+    if byte_offset > contents.len() {
+        return 0;
+    }
+    if checkpoint.tail.is_empty() {
+        return 0;
+    }
+
+    let tail_len = checkpoint.tail.len();
+    let Some(tail_start) = byte_offset.checked_sub(tail_len) else {
+        return 0;
+    };
+    if &contents[tail_start..byte_offset] == checkpoint.tail.as_slice() {
+        byte_offset
+    } else {
+        0
+    }
 }
 
 fn is_interesting_log_line(line: &str) -> bool {
@@ -2045,7 +2174,7 @@ fn print_help() {
            --base-url <url>     Base URL for the local service (default: http://localhost:3000)\n\
            --out <path>         Custom report output directory\n\
            --baseline <mode>    latest, none, or a report directory path (default: latest)\n\
-           --stop               Stop the server after the run if the analyzer started it\n"
+           --stop               Stop helper-managed local services after the run if the analyzer started them\n"
     );
 }
 
@@ -2109,7 +2238,7 @@ fn fmt_rate(rate: f64) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_encode_route_request, build_wait_ready_args, capture_log_boundary,
+        build_encode_route_request, build_wait_ready_args, capture_log_boundaries,
         classify_simulate_response, collect_logs, discover_latest_baseline, encode_route_swap_kind,
         ensure_server_ready, maybe_load_baseline, percentile, protocol_from_pool_name,
         sanitize_filename, select_best_pool, startup_bind_config, BaselineMode, CliArgs,
@@ -2423,7 +2552,7 @@ mod tests {
         };
         let message = error.to_string();
         assert!(message.contains("wait_ready.sh failed: wait-ready failed"));
-        assert!(message.contains("failed to stop server after readiness failure"));
+        assert!(message.contains("failed to stop local services after readiness failure"));
         assert!(message.contains("stop_server.sh failed: stop failed"));
         assert!(start_marker.exists());
         assert!(stop_marker.exists());
@@ -2482,11 +2611,15 @@ mod tests {
         assert!(fs::create_dir_all(report_dir.join("evidence")).is_ok());
         assert!(fs::create_dir_all(&log_dir).is_ok());
 
-        let log_path = log_dir.join("tycho-sim-server.log");
-        assert!(fs::write(&log_path, "{\"level\":\"warn\",\"msg\":\"old warning\"}\n").is_ok());
-        let boundary = capture_log_boundary(&root);
+        let simulator_log_path = log_dir.join("tycho-sim-server.log");
         assert!(fs::write(
-            &log_path,
+            &simulator_log_path,
+            "{\"level\":\"warn\",\"msg\":\"old warning\"}\n"
+        )
+        .is_ok());
+        let boundary = capture_log_boundaries(&root);
+        assert!(fs::write(
+            &simulator_log_path,
             concat!(
                 "{\"level\":\"warn\",\"msg\":\"old warning\"}\n",
                 "{\"level\":\"info\",\"msg\":\"new info\"}\n",
@@ -2503,6 +2636,125 @@ mod tests {
         assert_eq!(summary.matched_lines, 1);
         assert_eq!(summary.highlights.len(), 1);
         assert!(summary.highlights[0].contains("new error"));
+        let simulator_source = summary
+            .sources
+            .iter()
+            .find(|source| source.source == "simulator");
+        assert!(simulator_source.is_some());
+        let Some(simulator_source) = simulator_source else {
+            return;
+        };
+        assert_eq!(simulator_source.matched_lines, 1);
+        let broadcaster_source = summary
+            .sources
+            .iter()
+            .find(|source| source.source == "broadcaster");
+        assert!(broadcaster_source.is_some());
+        let Some(broadcaster_source) = broadcaster_source else {
+            return;
+        };
+        assert_eq!(broadcaster_source.matched_lines, 0);
+
+        assert!(fs::remove_dir_all(&root).is_ok());
+    }
+
+    #[test]
+    fn collect_logs_includes_broadcaster_log_excerpts() {
+        let root = temp_test_dir("broadcaster-log-excerpts");
+        let log_dir = root.join("logs");
+        let report_dir = root.join("reports/run-1");
+        assert!(fs::create_dir_all(report_dir.join("evidence")).is_ok());
+        assert!(fs::create_dir_all(&log_dir).is_ok());
+
+        let boundary = capture_log_boundaries(&root);
+        let simulator_log_path = log_dir.join("tycho-sim-server.log");
+        let broadcaster_log_path = log_dir.join("tycho-broadcaster-service.log");
+        assert!(fs::write(
+            &simulator_log_path,
+            "{\"level\":\"info\",\"msg\":\"simulator ready\"}\n"
+        )
+        .is_ok());
+        assert!(fs::write(
+            &broadcaster_log_path,
+            concat!(
+                "{\"level\":\"info\",\"msg\":\"broadcaster warming\"}\n",
+                "{\"level\":\"warn\",\"msg\":\"snapshot failed once\"}\n"
+            ),
+        )
+        .is_ok());
+
+        let summary_result = collect_logs(&root, &report_dir, &boundary);
+        assert!(summary_result.is_ok());
+        let Some(summary) = summary_result.ok() else {
+            return;
+        };
+
+        let broadcaster_source = summary
+            .sources
+            .iter()
+            .find(|source| source.source == "broadcaster");
+        assert!(broadcaster_source.is_some());
+        let Some(broadcaster_source) = broadcaster_source else {
+            return;
+        };
+        assert_eq!(summary.matched_lines, 1);
+        assert_eq!(broadcaster_source.matched_lines, 1);
+        assert!(summary.highlights[0].contains("broadcaster:"));
+        assert!(summary.highlights[0].contains("snapshot failed once"));
+        assert!(summary.excerpt_file.is_some());
+        let Some(excerpt_file) = summary.excerpt_file else {
+            return;
+        };
+        let excerpt_path = root.join(excerpt_file);
+        let excerpt = fs::read_to_string(excerpt_path);
+        assert!(excerpt.is_ok());
+        let Some(excerpt) = excerpt.ok() else {
+            return;
+        };
+        assert!(excerpt.contains("# broadcaster (logs/tycho-broadcaster-service.log)"));
+        assert!(excerpt.contains("snapshot failed once"));
+
+        assert!(fs::remove_dir_all(&root).is_ok());
+    }
+
+    #[test]
+    fn collect_logs_scans_from_start_when_log_was_rewritten_after_boundary() {
+        let root = temp_test_dir("log-rewritten-after-boundary");
+        let log_dir = root.join("logs");
+        let report_dir = root.join("reports/run-1");
+        assert!(fs::create_dir_all(report_dir.join("evidence")).is_ok());
+        assert!(fs::create_dir_all(&log_dir).is_ok());
+
+        let log_path = log_dir.join("tycho-broadcaster-service.log");
+        assert!(fs::write(
+            &log_path,
+            concat!(
+                "{\"level\":\"info\",\"msg\":\"old startup line\"}\n",
+                "{\"level\":\"info\",\"msg\":\"another old line\"}\n"
+            ),
+        )
+        .is_ok());
+        let boundary = capture_log_boundaries(&root);
+        assert!(fs::write(
+            &log_path,
+            concat!(
+                "{\"level\":\"error\",\"msg\":\"fresh broadcaster failure\"}\n",
+                "{\"level\":\"info\",\"msg\":\"padding after rewrite so the new file is longer than the old boundary offset\"}\n"
+            )
+        )
+        .is_ok());
+
+        let summary_result = collect_logs(&root, &report_dir, &boundary);
+        assert!(summary_result.is_ok());
+        let Some(summary) = summary_result.ok() else {
+            return;
+        };
+
+        assert_eq!(summary.matched_lines, 1);
+        assert!(summary
+            .highlights
+            .iter()
+            .any(|line| line.contains("fresh broadcaster failure")));
 
         assert!(fs::remove_dir_all(&root).is_ok());
     }

--- a/crates/apps/src/sim_analysis/report.rs
+++ b/crates/apps/src/sim_analysis/report.rs
@@ -155,10 +155,19 @@ pub struct LatencySummary {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct LogSummary {
-    pub log_file: String,
+    pub sources: Vec<LogSourceSummary>,
     pub matched_lines: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub excerpt_file: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub highlights: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct LogSourceSummary {
+    pub source: String,
+    pub log_file: String,
+    pub matched_lines: usize,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub highlights: Vec<String>,
 }
@@ -319,13 +328,23 @@ fn add_scenario_findings(report: &AnalysisReport, findings: &mut Vec<Finding>) {
 }
 
 fn add_log_findings(report: &AnalysisReport, findings: &mut Vec<Finding>) {
-    if report.logs.matched_lines > 0 {
+    for source in &report.logs.sources {
+        if source.matched_lines == 0 {
+            continue;
+        }
+
+        let title = if source.source == "broadcaster" {
+            "Broadcaster log warnings or failures were captured"
+        } else {
+            "Simulator log warnings or failures were captured"
+        };
+
         findings.push(Finding {
             severity: "attention".to_string(),
-            title: "Interesting log lines were captured".to_string(),
+            title: title.to_string(),
             detail: format!(
                 "The analyzer matched {} warning/error-like log line(s) in {}.",
-                report.logs.matched_lines, report.logs.log_file
+                source.matched_lines, source.log_file
             ),
         });
     }
@@ -489,10 +508,16 @@ fn append_readiness_snapshot(lines: &mut Vec<String>, label: &str, snapshot: &Re
 fn append_evidence_section(lines: &mut Vec<String>, report: &AnalysisReport) {
     lines.push(String::new());
     lines.push("## Evidence".to_string());
-    lines.push(format!("- Log file: {}", report.logs.log_file));
+    for source in &report.logs.sources {
+        lines.push(format!(
+            "- Log file ({}): {} matched={}",
+            source.source, source.log_file, source.matched_lines
+        ));
+    }
     if let Some(excerpt) = &report.logs.excerpt_file {
         lines.push(format!("- Log excerpts: {}", excerpt));
     }
+    append_log_highlights(lines, report);
     if let Some(baseline) = &report.baseline {
         lines.push(format!(
             "- Compared against: {}",
@@ -502,6 +527,31 @@ fn append_evidence_section(lines: &mut Vec<String>, report: &AnalysisReport) {
     lines.push("- Primary artifact: report.json".to_string());
     lines.push("- Human summary: summary.md".to_string());
     lines.push(String::new());
+}
+
+fn append_log_highlights(lines: &mut Vec<String>, report: &AnalysisReport) {
+    if report.logs.highlights.is_empty() {
+        return;
+    }
+
+    lines.push("- Log highlights:".to_string());
+    for highlight in report.logs.highlights.iter().take(6) {
+        lines.push(format!("  {}", truncate_log_line(highlight)));
+    }
+}
+
+fn truncate_log_line(line: &str) -> String {
+    const MAX_LOG_HIGHLIGHT_CHARS: usize = 240;
+    let mut chars = line.chars();
+    let truncated = chars
+        .by_ref()
+        .take(MAX_LOG_HIGHLIGHT_CHARS)
+        .collect::<String>();
+    if chars.next().is_some() {
+        format!("{truncated}...")
+    } else {
+        truncated
+    }
 }
 
 pub fn relative_path(root: &Path, path: &Path) -> String {
@@ -549,8 +599,8 @@ fn readiness_component_status(enabled: bool, status: Option<&str>) -> &str {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_findings, render_summary, AnalysisReport, Finding, LatencySummary, LogSummary,
-        ReadinessReport, EXPECTED_RFQ_PROTOCOL_VISIBILITY_NOTE,
+        build_findings, render_summary, AnalysisReport, Finding, LatencySummary, LogSourceSummary,
+        LogSummary, ReadinessReport, EXPECTED_RFQ_PROTOCOL_VISIBILITY_NOTE,
     };
     use super::{ReadinessBackendSnapshot, ReadinessSnapshot, RunMetadata, ScenarioReport};
     use std::collections::BTreeMap;
@@ -595,7 +645,7 @@ mod tests {
 
     fn report(findings: Vec<Finding>, scenarios: Vec<ScenarioReport>) -> AnalysisReport {
         AnalysisReport {
-            schema_version: 5,
+            schema_version: 6,
             run: RunMetadata {
                 started_at_epoch_s: 1,
                 finished_at_epoch_s: 2,
@@ -621,7 +671,20 @@ mod tests {
             },
             scenarios,
             logs: LogSummary {
-                log_file: "logs/tycho-sim-server.log".to_string(),
+                sources: vec![
+                    LogSourceSummary {
+                        source: "simulator".to_string(),
+                        log_file: "logs/tycho-sim-server.log".to_string(),
+                        matched_lines: 0,
+                        highlights: Vec::new(),
+                    },
+                    LogSourceSummary {
+                        source: "broadcaster".to_string(),
+                        log_file: "logs/tycho-broadcaster-service.log".to_string(),
+                        matched_lines: 0,
+                        highlights: Vec::new(),
+                    },
+                ],
                 matched_lines: 0,
                 excerpt_file: None,
                 highlights: Vec::new(),
@@ -687,6 +750,37 @@ mod tests {
     }
 
     #[test]
+    fn build_findings_marks_broadcaster_log_matches() {
+        let mut analysis = report(Vec::new(), vec![scenario("core simulate", 0, 0)]);
+        let broadcaster = analysis
+            .logs
+            .sources
+            .iter_mut()
+            .find(|source| source.source == "broadcaster");
+        assert!(broadcaster.is_some());
+        let Some(broadcaster) = broadcaster else {
+            return;
+        };
+        broadcaster.matched_lines = 2;
+        broadcaster
+            .highlights
+            .push("{\"level\":\"WARN\",\"message\":\"stream build failed\"}".to_string());
+        analysis.logs.matched_lines = 2;
+        analysis.logs.highlights = vec![
+            "broadcaster: {\"level\":\"WARN\",\"message\":\"stream build failed\"}".to_string(),
+        ];
+
+        let findings = build_findings(&analysis);
+
+        assert!(findings.iter().any(|finding| {
+            finding.title == "Broadcaster log warnings or failures were captured"
+                && finding
+                    .detail
+                    .contains("logs/tycho-broadcaster-service.log")
+        }));
+    }
+
+    #[test]
     fn render_summary_includes_rfq_status() {
         let mut analysis = report(Vec::new(), vec![scenario("core simulate", 0, 0)]);
         analysis.readiness.initial.backends.insert(
@@ -721,5 +815,39 @@ mod tests {
         assert!(summary.contains("vm=disabled rfq=ready"));
         assert!(summary.contains("native=ready"));
         assert!(summary.contains("vm=disabled rfq=rebuilding"));
+    }
+
+    #[test]
+    fn render_summary_includes_broadcaster_log_source_and_highlight() {
+        let mut analysis = report(Vec::new(), vec![scenario("core simulate", 0, 0)]);
+        let broadcaster = analysis
+            .logs
+            .sources
+            .iter_mut()
+            .find(|source| source.source == "broadcaster");
+        assert!(broadcaster.is_some());
+        let Some(broadcaster) = broadcaster else {
+            return;
+        };
+        broadcaster.matched_lines = 1;
+        broadcaster
+            .highlights
+            .push("{\"level\":\"ERROR\",\"message\":\"snapshot failed\"}".to_string());
+        analysis.logs.matched_lines = 1;
+        analysis.logs.excerpt_file =
+            Some("logs/simulation-reports/1/balanced/1/evidence/log-excerpts.txt".to_string());
+        analysis.logs.highlights =
+            vec!["broadcaster: {\"level\":\"ERROR\",\"message\":\"snapshot failed\"}".to_string()];
+
+        let summary = render_summary(&analysis);
+
+        assert!(summary
+            .contains("- Log file (broadcaster): logs/tycho-broadcaster-service.log matched=1"));
+        assert!(summary.contains(
+            "- Log excerpts: logs/simulation-reports/1/balanced/1/evidence/log-excerpts.txt"
+        ));
+        assert!(
+            summary.contains("broadcaster: {\"level\":\"ERROR\",\"message\":\"snapshot failed\"}")
+        );
     }
 }

--- a/scripts/start_server.sh
+++ b/scripts/start_server.sh
@@ -5,7 +5,7 @@ usage() {
   cat <<'USAGE'
 Usage: start_server.sh [--repo <path>] [--log-file <path>] [--chain-id <id>] [--env KEY=VALUE] [--enable-vm-pools]
 
-Start the dsolver-simulator-service from a repo checkout.
+Start the local DSolver simulator service stack from a repo checkout.
 
 Options:
   --repo             Path to repo root (default: current directory)
@@ -21,6 +21,318 @@ repo="."
 log_file=""
 chain_id_arg=""
 env_overrides=()
+local_broadcaster_start_timeout=300
+
+pid_is_running() {
+  local pid="$1"
+  [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null
+}
+
+cleanup_stale_pid_file() {
+  local pid_file="$1"
+  local label="$2"
+
+  if [[ ! -f "$pid_file" ]]; then
+    return 1
+  fi
+
+  local pid
+  pid="$(cat "$pid_file" 2>/dev/null || true)"
+  if pid_is_running "$pid"; then
+    echo "$label already running (pid $pid)."
+    return 0
+  fi
+
+  rm -f "$pid_file"
+  return 1
+}
+
+read_pid_file() {
+  local pid_file="$1"
+  cat "$pid_file" 2>/dev/null || true
+}
+
+read_metadata_value() {
+  local metadata_file="$1"
+  local key="$2"
+
+  awk -v key="$key" '
+    index($0, key "=") == 1 {
+      print substr($0, length(key) + 2)
+      exit
+    }
+  ' "$metadata_file" 2>/dev/null || true
+}
+
+broadcaster_metadata_matches() {
+  local metadata_file="$1"
+  local ws_url="$2"
+  local bind_host="$3"
+  local bind_port="$4"
+  local status_url="$5"
+
+  [[ -f "$metadata_file" ]] \
+    && [[ "$(read_metadata_value "$metadata_file" "ws_url")" == "$ws_url" ]] \
+    && [[ "$(read_metadata_value "$metadata_file" "bind_host")" == "$bind_host" ]] \
+    && [[ "$(read_metadata_value "$metadata_file" "bind_port")" == "$bind_port" ]] \
+    && [[ "$(read_metadata_value "$metadata_file" "status_url")" == "$status_url" ]]
+}
+
+write_broadcaster_metadata() {
+  local metadata_file="$1"
+  local ws_url="$2"
+  local bind_host="$3"
+  local bind_port="$4"
+  local status_url="$5"
+
+  {
+    printf 'ws_url=%s\n' "$ws_url"
+    printf 'bind_host=%s\n' "$bind_host"
+    printf 'bind_port=%s\n' "$bind_port"
+    printf 'status_url=%s\n' "$status_url"
+  } > "$metadata_file"
+}
+
+broadcaster_process_is_helper_owned() {
+  local pid="$1"
+  local command
+
+  command="$(ps -p "$pid" -o command= 2>/dev/null || true)"
+  [[ "$command" == *"dsolver-tycho-broadcaster-service"* ]]
+}
+
+stop_broadcaster_pid() {
+  local pid="$1"
+  local pid_file="$2"
+  local metadata_file="$3"
+
+  if [[ -z "$pid" ]] || ! pid_is_running "$pid"; then
+    rm -f "$pid_file" "$metadata_file"
+    return 0
+  fi
+
+  if ! broadcaster_process_is_helper_owned "$pid"; then
+    echo "Refusing to replace live process $pid from $pid_file; it does not look like dsolver-tycho-broadcaster-service." >&2
+    return 1
+  fi
+
+  echo "Stopping broadcaster service with stale launch metadata (pid $pid)."
+  kill "$pid" 2>/dev/null || true
+
+  for _ in {1..10}; do
+    if ! pid_is_running "$pid"; then
+      rm -f "$pid_file" "$metadata_file"
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "Timed out stopping broadcaster service pid $pid." >&2
+  return 1
+}
+
+resolve_local_broadcaster() {
+  python3 - "$TYCHO_BROADCASTER_WS_URL" <<'PY'
+import sys
+from urllib.parse import urlparse
+
+raw_url = sys.argv[1]
+url = urlparse(raw_url)
+scheme = url.scheme.lower()
+
+if scheme not in {"ws", "wss"}:
+    print("TYCHO_BROADCASTER_WS_URL must use ws:// or wss://", file=sys.stderr)
+    raise SystemExit(2)
+
+host = url.hostname or ""
+local_hosts = {"localhost", "127.0.0.1", "::1"}
+
+if scheme != "ws" or host not in local_hosts:
+    print("false\t\t\t")
+    raise SystemExit(0)
+
+try:
+    port = url.port
+except ValueError as error:
+    print(f"invalid TYCHO_BROADCASTER_WS_URL port: {error}", file=sys.stderr)
+    raise SystemExit(2)
+
+if port is None:
+    print("local TYCHO_BROADCASTER_WS_URL must include an explicit port", file=sys.stderr)
+    raise SystemExit(2)
+
+if url.path != "/ws":
+    actual_path = url.path or "/"
+    print(f"local TYCHO_BROADCASTER_WS_URL must use /ws path, got {actual_path}", file=sys.stderr)
+    raise SystemExit(2)
+
+bind_host = "127.0.0.1" if host == "localhost" else host
+status_host = f"[{bind_host}]" if ":" in bind_host else bind_host
+status_url = f"http://{status_host}:{port}/status"
+
+print(f"true\t{bind_host}\t{port}\t{status_url}")
+PY
+}
+
+start_broadcaster_if_local() {
+  local managed bind_host bind_port status_url
+  IFS=$'\t' read -r managed bind_host bind_port status_url < <(resolve_local_broadcaster)
+
+  if [[ "$managed" != "true" ]]; then
+    echo "Broadcaster URL is not loopback ws://; assuming broadcaster is externally managed."
+    return 0
+  fi
+
+  local broadcaster_pid_file="$repo/.tycho-broadcaster-service.pid"
+  local broadcaster_metadata_file="$repo/.tycho-broadcaster-service.meta"
+  local broadcaster_log_file="$repo/logs/tycho-broadcaster-service.log"
+
+  local broadcaster_pid
+  broadcaster_pid="$(read_pid_file "$broadcaster_pid_file")"
+  if pid_is_running "$broadcaster_pid"; then
+    local status_check status_state status_code actual_chain
+    status_check="$(broadcaster_status_check "$status_url" "$CHAIN_ID")"
+    read -r status_state status_code actual_chain <<<"$status_check"
+    if [[ "$status_state" == "ok" ]]; then
+      if ! broadcaster_metadata_matches "$broadcaster_metadata_file" "$TYCHO_BROADCASTER_WS_URL" "$bind_host" "$bind_port" "$status_url"; then
+        write_broadcaster_metadata "$broadcaster_metadata_file" "$TYCHO_BROADCASTER_WS_URL" "$bind_host" "$bind_port" "$status_url"
+      fi
+      echo "Broadcaster service already running (pid $broadcaster_pid)."
+      return 0
+    fi
+    if [[ "$status_state" == "chain-mismatch" ]]; then
+      echo "Broadcaster already responding at $status_url for chain_id=$actual_chain, expected CHAIN_ID=$CHAIN_ID." >&2
+      return 1
+    fi
+
+    if broadcaster_metadata_matches "$broadcaster_metadata_file" "$TYCHO_BROADCASTER_WS_URL" "$bind_host" "$bind_port" "$status_url"; then
+      echo "Broadcaster service already running (pid $broadcaster_pid)."
+      wait_for_broadcaster_http "$status_url" "$broadcaster_pid_file" "$broadcaster_log_file"
+      return 0
+    fi
+
+    stop_broadcaster_pid "$broadcaster_pid" "$broadcaster_pid_file" "$broadcaster_metadata_file"
+  elif [[ -f "$broadcaster_pid_file" || -f "$broadcaster_metadata_file" ]]; then
+    rm -f "$broadcaster_pid_file" "$broadcaster_metadata_file"
+  fi
+
+  if cleanup_stale_pid_file "$broadcaster_pid_file" "Broadcaster service"; then
+    wait_for_broadcaster_http "$status_url" "$broadcaster_pid_file" "$broadcaster_log_file"
+    return 0
+  fi
+
+  local status_check status_state status_code actual_chain
+  status_check="$(broadcaster_status_check "$status_url" "$CHAIN_ID")"
+  read -r status_state status_code actual_chain <<<"$status_check"
+  if [[ "$status_state" == "ok" ]]; then
+    echo "Broadcaster already responding at $status_url (HTTP $status_code)."
+    return 0
+  fi
+  if [[ "$status_state" == "chain-mismatch" ]]; then
+    echo "Broadcaster already responding at $status_url for chain_id=$actual_chain, expected CHAIN_ID=$CHAIN_ID." >&2
+    return 1
+  fi
+
+  mkdir -p "$repo/logs"
+
+  (
+    cd "$repo"
+    HOST="$bind_host" PORT="$bind_port" nohup cargo run -p apps --bin dsolver-tycho-broadcaster-service --release > "$broadcaster_log_file" 2>&1 &
+    echo $! > "$broadcaster_pid_file"
+  )
+  write_broadcaster_metadata "$broadcaster_metadata_file" "$TYCHO_BROADCASTER_WS_URL" "$bind_host" "$bind_port" "$status_url"
+
+  echo "Started dsolver-tycho-broadcaster-service."
+  echo "Broadcaster PID: $(cat "$broadcaster_pid_file")"
+  echo "Broadcaster URL: $TYCHO_BROADCASTER_WS_URL"
+  echo "Broadcaster log: $broadcaster_log_file"
+
+  wait_for_broadcaster_http "$status_url" "$broadcaster_pid_file" "$broadcaster_log_file"
+}
+
+wait_for_broadcaster_http() {
+  local status_url="$1"
+  local pid_file="$2"
+  local log_file="$3"
+  local start_time
+  start_time="$(date +%s)"
+
+  while true; do
+    local status_check status_state status_code actual_chain
+    status_check="$(broadcaster_status_check "$status_url" "$CHAIN_ID")"
+    read -r status_state status_code actual_chain <<<"$status_check"
+    if [[ "$status_state" == "ok" ]]; then
+      echo "Broadcaster HTTP is responding at $status_url (HTTP $status_code)."
+      return 0
+    fi
+    if [[ "$status_state" == "chain-mismatch" ]]; then
+      echo "Broadcaster HTTP at $status_url reports chain_id=$actual_chain, expected CHAIN_ID=$CHAIN_ID. See $log_file." >&2
+      return 1
+    fi
+
+    local pid
+    pid="$(cat "$pid_file" 2>/dev/null || true)"
+    if ! pid_is_running "$pid"; then
+      echo "Broadcaster service exited before HTTP was reachable. See $log_file." >&2
+      rm -f "$pid_file"
+      return 1
+    fi
+
+    local now
+    now="$(date +%s)"
+    if ((now - start_time >= local_broadcaster_start_timeout)); then
+      echo "Timed out waiting for broadcaster HTTP at $status_url. See $log_file." >&2
+      return 1
+    fi
+
+    sleep 2
+  done
+}
+
+broadcaster_status_check() {
+  local status_url="$1"
+  local expected_chain_id="$2"
+  local response http_code body
+
+  response="$(curl -sS --max-time 2 -w $'\n%{http_code}' "$status_url" 2>/dev/null || true)"
+  http_code="${response##*$'\n'}"
+  body="${response%$'\n'*}"
+
+  if [[ -z "$http_code" || "$http_code" == "000" ]]; then
+    return 0
+  fi
+
+  BROADCASTER_STATUS_BODY="$body" python3 - "$http_code" "$expected_chain_id" <<'PY'
+import json
+import os
+import sys
+
+http_code = sys.argv[1]
+expected_chain_id = int(sys.argv[2])
+
+try:
+    payload = json.loads(os.environ["BROADCASTER_STATUS_BODY"])
+except (json.JSONDecodeError, ValueError):
+    raise SystemExit(0)
+
+if not isinstance(payload, dict):
+    raise SystemExit(0)
+
+if (
+    isinstance(payload.get("status"), str)
+    and isinstance(payload.get("chain_id"), int)
+    and isinstance(payload.get("upstream"), dict)
+    and isinstance(payload.get("snapshot"), dict)
+    and isinstance(payload.get("subscribers"), dict)
+    and isinstance(payload.get("backends"), dict)
+):
+    actual_chain_id = payload["chain_id"]
+    if actual_chain_id == expected_chain_id:
+        print(f"ok {http_code}")
+    else:
+        print(f"chain-mismatch {http_code} {actual_chain_id}")
+PY
+}
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -64,13 +376,9 @@ if [[ ! -f "$repo/Cargo.toml" ]]; then
 fi
 
 pid_file="$repo/.tycho-sim-server.pid"
-if [[ -f "$pid_file" ]]; then
-  pid="$(cat "$pid_file" 2>/dev/null || true)"
-  if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
-    echo "Server already running (pid $pid)."
-    exit 0
-  fi
-  rm -f "$pid_file"
+simulator_already_running=false
+if cleanup_stale_pid_file "$pid_file" "Simulator service"; then
+  simulator_already_running=true
 fi
 
 if [[ -f "$repo/.env" ]]; then
@@ -84,10 +392,6 @@ fi
 
 if [[ -z "${TYCHO_API_KEY:-}" ]]; then
   echo "Warning: TYCHO_API_KEY not set; server may fail to start." >&2
-fi
-
-if [[ -z "${TYCHO_BROADCASTER_WS_URL:-}" ]]; then
-  echo "Warning: TYCHO_BROADCASTER_WS_URL not set; simulator startup will fail without it." >&2
 fi
 
 if [[ -z "${RUST_LOG:-}" ]]; then
@@ -104,7 +408,12 @@ if [[ -n "$chain_id_arg" ]]; then
   export CHAIN_ID="$chain_id_arg"
 fi
 
-if [[ -z "${CHAIN_ID:-}" ]]; then
+if [[ -z "${TYCHO_BROADCASTER_WS_URL:-}" && "$simulator_already_running" == "false" ]]; then
+  echo "Error: TYCHO_BROADCASTER_WS_URL is required for simulator startup." >&2
+  exit 2
+fi
+
+if [[ -z "${CHAIN_ID:-}" && "$simulator_already_running" == "false" ]]; then
   echo "Error: missing chain id. Pass --chain-id or set CHAIN_ID in env/.env." >&2
   exit 2
 fi
@@ -112,6 +421,16 @@ fi
 if [[ -z "$log_file" ]]; then
   mkdir -p "$repo/logs"
   log_file="$repo/logs/tycho-sim-server.log"
+fi
+
+if [[ -n "${TYCHO_BROADCASTER_WS_URL:-}" ]]; then
+  start_broadcaster_if_local
+elif [[ "$simulator_already_running" == "true" ]]; then
+  echo "TYCHO_BROADCASTER_WS_URL not set; skipping broadcaster startup for running simulator."
+fi
+
+if [[ "$simulator_already_running" == "true" ]]; then
+  exit 0
 fi
 
 (

--- a/scripts/stop_server.sh
+++ b/scripts/stop_server.sh
@@ -5,7 +5,7 @@ usage() {
   cat <<'USAGE'
 Usage: stop_server.sh [--repo <path>] [--force]
 
-Stop the dsolver-simulator-service started by start_server.sh.
+Stop services started by start_server.sh.
 
 Options:
   --repo       Path to repo root (default: current directory)
@@ -41,43 +41,64 @@ done
 
 repo="$(cd "$repo" && pwd)"
 
-pid_file="$repo/.tycho-sim-server.pid"
-if [[ ! -f "$pid_file" ]]; then
-  echo "No pid file found at $pid_file."
-  exit 0
-fi
+stop_process() {
+  local label="$1"
+  local pid_file="$2"
 
-pid="$(cat "$pid_file" 2>/dev/null || true)"
-if [[ -z "$pid" ]]; then
-  echo "Pid file is empty; removing." >&2
-  rm -f "$pid_file"
-  exit 0
-fi
-
-if ! kill -0 "$pid" 2>/dev/null; then
-  echo "Process $pid is not running; removing pid file." >&2
-  rm -f "$pid_file"
-  exit 0
-fi
-
-echo "Stopping server (pid $pid)..."
-kill "$pid"
-
-for _ in {1..20}; do
-  if ! kill -0 "$pid" 2>/dev/null; then
-    rm -f "$pid_file"
-    echo "Stopped."
-    exit 0
+  if [[ ! -f "$pid_file" ]]; then
+    echo "No $label pid file found at $pid_file."
+    return 0
   fi
-  sleep 0.25
-done
 
-if [[ "$force" == "true" ]]; then
-  echo "Process still running; sending SIGKILL." >&2
-  kill -9 "$pid" || true
-  rm -f "$pid_file"
-  exit 0
+  local pid
+  pid="$(cat "$pid_file" 2>/dev/null || true)"
+  if [[ -z "$pid" ]]; then
+    echo "$label pid file is empty; removing." >&2
+    rm -f "$pid_file"
+    return 0
+  fi
+
+  if ! kill -0 "$pid" 2>/dev/null; then
+    echo "$label process $pid is not running; removing pid file." >&2
+    rm -f "$pid_file"
+    return 0
+  fi
+
+  echo "Stopping $label (pid $pid)..."
+  kill "$pid"
+
+  for _ in {1..20}; do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      rm -f "$pid_file"
+      echo "Stopped $label."
+      return 0
+    fi
+    sleep 0.25
+  done
+
+  if [[ "$force" == "true" ]]; then
+    echo "$label still running; sending SIGKILL." >&2
+    kill -9 "$pid" || true
+    rm -f "$pid_file"
+    return 0
+  fi
+
+  echo "$label still running; re-run with --force to SIGKILL." >&2
+  return 1
+}
+
+status=0
+if ! stop_process "simulator service" "$repo/.tycho-sim-server.pid"; then
+  status=1
+  if [[ "$force" != "true" ]]; then
+    echo "Preserving broadcaster service because simulator service did not stop." >&2
+    exit "$status"
+  fi
+fi
+if stop_process "broadcaster service" "$repo/.tycho-broadcaster-service.pid"; then
+  rm -f "$repo/.tycho-broadcaster-service.meta"
+else
+  status=1
 fi
 
-echo "Process still running; re-run with --force to SIGKILL." >&2
-exit 1
+exit "$status"

--- a/skills/simulation-service-analysis/SKILL.md
+++ b/skills/simulation-service-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: simulation-service-analysis
-description: Analyze the local DSolver Simulator service in this repo with a reporting-first Rust CLI. Use when you want to start or reuse the server, wait for /status health and native readiness, exercise representative /simulate and /encode flows, run latency and light stress probes, save standardized JSON/markdown reports, compare against previous local runs, and investigate anomalies without relying on strict pass/fail business assertions.
+description: Analyze the local DSolver Simulator service in this repo with a reporting-first Rust CLI. Use when you want to start or reuse the local broadcaster plus simulator stack, wait for /status health and native readiness, exercise representative /simulate and /encode flows, run latency and light stress probes, save standardized JSON/markdown reports, compare against previous local runs, and investigate anomalies without relying on strict pass/fail business assertions.
 metadata:
   short-description: DSolver Simulator local analysis
 ---
@@ -10,8 +10,9 @@ metadata:
 ## Quick start
 
 1. Confirm the repo root (expect `Cargo.toml` and `crates/`).
-2. Ensure `.env` exists and contains `TYCHO_API_KEY`.
-   RFQ feeds default to off. For RFQ analysis, set `ENABLE_RFQ_POOLS=true`. Ethereum runs need `BEBOP_USER`, `BEBOP_KEY`, `HASHFLOW_USER`, `HASHFLOW_KEY`, `LIQUORICE_USER`, and `LIQUORICE_KEY`. Base runs need the Bebop and Hashflow pairs.
+2. Ensure `.env` exists and contains `TYCHO_API_KEY` plus `TYCHO_BROADCASTER_WS_URL`.
+   The default loopback broadcaster URL lets the lifecycle helper start the broadcaster before the simulator.
+   RFQ feeds default to off. For RFQ analysis, set `ENABLE_RFQ_POOLS=true`. Ethereum and Base currently need the Bebop and Hashflow credential pairs; Liquorice credentials are only needed after `rfq:liquorice` is added to an active chain profile.
 3. Pick a chain context for the run (`--chain-id 1` for Ethereum, `--chain-id 8453` for Base).
 4. Run the analyzer:
    ```bash
@@ -23,13 +24,14 @@ metadata:
 
 ## What the analyzer does
 
-- Reuses the existing local server if it is already responding, otherwise starts it with the repo lifecycle scripts.
+- Reuses the existing local simulator if it is already responding, otherwise starts the local broadcaster plus simulator stack with the repo lifecycle scripts.
+- Starts `dsolver-tycho-broadcaster-service` first when `TYCHO_BROADCASTER_WS_URL` points at local loopback, then starts `dsolver-simulator-service`; non-local broadcaster URLs are treated as externally managed.
 - Waits for `/status` service health, then confirms native readiness first and adds VM and RFQ readiness checks when those pool backends are enabled.
 - Fresh VM-pool or RFQ warmups can take much longer than native readiness. Budget up to 10 minutes before treating either backend as stuck.
 - Runs a balanced `/simulate` sweep across representative pairs.
-- Builds a `/encode` route matrix from live `/simulate` results, covering SimpleSwap, MultiSwap, and MegaSwap shapes.
+- Builds the balanced `/encode` route matrix from live `/simulate` prep hops, covering 3 SimpleSwap routes, 3 MultiSwap routes, and 2 MegaSwap routes per supported chain.
 - Runs latency and light stress sweeps.
-- Saves sampled request/response artifacts plus log excerpts.
+- Saves sampled request/response artifacts plus simulator and broadcaster log excerpts.
 - Optionally compares the current run against the latest compatible saved report.
 - Top-level `/status.status` is service health; nested `backends.*.status` carries backend readiness.
 
@@ -46,7 +48,7 @@ Base run:
 cargo run -p apps --bin sim-analysis -- --chain-id 8453 --stop
 ```
 
-Keep the server running:
+Keep the helper-managed local services running:
 ```bash
 cargo run -p apps --bin sim-analysis -- --chain-id 1
 ```
@@ -89,7 +91,7 @@ After the analyzer runs:
 
 1. Read `summary.md` first for the high-level picture.
 2. Use `report.json` for exact counts, latencies, status/result-quality splits, protocol visibility, and any RFQ readiness or RFQ-visibility findings.
-3. Open the files under `evidence/` for sampled request/response bodies, readiness snapshots, and log excerpts.
+3. Open the files under `evidence/` for sampled request/response bodies, readiness snapshots, and simulator/broadcaster log excerpts.
 4. If the current behavior looks suspicious, compare it with the saved baseline before deciding whether the change is actually novel.
 5. If something still looks off, continue with targeted manual requests, log inspection, or deeper domain research.
 

--- a/skills/simulation-service-analysis/references/encode.md
+++ b/skills/simulation-service-analysis/references/encode.md
@@ -13,7 +13,8 @@ The local analyzer uses a default route matrix:
 
 - resolves chain from `--chain-id` (or `CHAIN_ID`)
 - calls `/simulate` for each route hop to pick a representative candidate pool
-- builds SimpleSwap, MultiSwap, and MegaSwap requests and posts them to `/encode`
+- builds 3 SimpleSwap routes, 3 MultiSwap routes, and 2 MegaSwap routes per supported chain, then posts each assembled route to `/encode`
+- maps one-segment/one-hop routes to SimpleSwap, one-segment/sequential-hop routes to MultiSwap, and multi-segment split routes to MegaSwap
 - records prep `/simulate` hops as separate `encode-prep` scenarios
 - records each `/encode` interaction shape, router-call presence, latency, and oddities without mixing in prep-hop metrics
 - uses chain-specific default routes and amounts, but treats the result as analytical evidence rather than a strict gate

--- a/skills/simulation-service-analysis/references/project.md
+++ b/skills/simulation-service-analysis/references/project.md
@@ -2,17 +2,18 @@
 
 ## What this service does
 - DSolver Simulator is a fast simulation API for DeFi swaps and routing, built on Tycho state.
-- Rust Axum service that ingests Tycho protocol streams, keeps an in-memory pool state, and exposes HTTP endpoints for quote simulation and route encoding.
-- Main binary: `dsolver-simulator-service` (see `crates/apps/src/bin/dsolver-simulator-service.rs`).
+- Rust Axum service that consumes a Tycho broadcaster stream, keeps an in-memory pool state, and exposes HTTP endpoints for quote simulation and route encoding.
+- Main local binaries: `dsolver-tycho-broadcaster-service` feeds the local stream, and `dsolver-simulator-service` exposes `/status`, `/simulate`, and `/encode`.
 
 ## Local run
 - Create `.env` from `.env.example` and set `TYCHO_API_KEY` (required).
-- RFQ feeds default to off. For RFQ analysis, set `ENABLE_RFQ_POOLS=true`. Ethereum runs need `BEBOP_USER`, `BEBOP_KEY`, `HASHFLOW_USER`, `HASHFLOW_KEY`, `LIQUORICE_USER`, and `LIQUORICE_KEY`. Base runs need the Bebop and Hashflow pairs.
+- Keep `TYCHO_BROADCASTER_WS_URL` pointed at the broadcaster websocket. The local default lets the lifecycle helper start the broadcaster on port `3001` before the simulator.
+- RFQ feeds default to off. For RFQ analysis, set `ENABLE_RFQ_POOLS=true`. Ethereum and Base currently need the Bebop and Hashflow credential pairs; Liquorice credentials are only needed after `rfq:liquorice` is added to an active chain profile.
 - Set `CHAIN_ID` (`1` for Ethereum, `8453` for Base) or pass `--chain-id` to the analyzer.
 - Tycho health checks expect `Authorization: <TYCHO_API_KEY>` (no `Bearer` prefix).
-- Start the server:
+- Start the local stack:
   ```bash
-  cargo run -p apps --bin dsolver-simulator-service --release
+  scripts/start_server.sh --repo . --chain-id 1
   ```
 - Default bind: `127.0.0.1:3000` (override with `HOST`/`PORT`).
 
@@ -24,20 +25,21 @@
 - Cold starts can take several minutes (3–5+ mins; VM or RFQ pools can take up to roughly 10 minutes on a fresh warmup).
 - `scripts/wait_ready.sh --expect-chain-id <id>` is still the manual guard if you want the native readiness gate directly.
 - When VM pools matter, prefer `scripts/wait_ready.sh --url http://localhost:3000/status --expect-chain-id <id> --require-vm-ready --timeout 600`.
-- When RFQ pools matter on Ethereum, prefer `scripts/wait_ready.sh --url http://localhost:3000/status --expect-chain-id 1 --require-rfq-ready --timeout 600`.
+- When RFQ pools matter, prefer `scripts/wait_ready.sh --url http://localhost:3000/status --expect-chain-id <id> --require-rfq-ready --timeout 600`.
 - When both VM and RFQ backends matter on Ethereum, prefer `scripts/wait_ready.sh --url http://localhost:3000/status --expect-chain-id 1 --require-vm-ready --require-rfq-ready --timeout 600`.
 
 ## Local analysis workflow (recommended)
 - Run the reporting-first analyzer:
   - `cargo run -p apps --bin sim-analysis -- --chain-id 1 --stop`
   - `cargo run -p apps --bin sim-analysis -- --chain-id 8453 --stop`
-- The analyzer starts or reuses the local server, waits for service health, confirms native readiness first, auto-checks VM and RFQ backends when they are enabled, runs representative `/simulate` and `/encode` probes, executes latency and light stress sweeps, then writes artifacts under `logs/simulation-reports/`.
+- The analyzer starts or reuses the local broadcaster plus simulator stack, waits for service health, confirms native readiness first, auto-checks VM and RFQ backends when they are enabled, runs representative `/simulate` probes and the balanced `/encode` route matrix, executes latency and light stress sweeps, then writes artifacts under `logs/simulation-reports/`.
+- The `/encode` matrix uses live `/simulate` prep hops to assemble 3 SimpleSwap routes, 3 MultiSwap routes, and 2 MegaSwap routes per supported chain. Prep hops are reported separately as `encode-prep` scenarios.
 - Default output root:
   - `logs/simulation-reports/<chain-id>/balanced/<timestamp>/`
 - Main artifacts:
   - `summary.md` for the narrative overview
   - `report.json` for exact metrics and scenario breakdowns
-  - `evidence/` for sampled request/response bodies, readiness snapshots, and log excerpts
+  - `evidence/` for sampled request/response bodies, readiness snapshots, and simulator/broadcaster log excerpts
 - RFQ-enabled Ethereum runs should also surface RFQ readiness and any RFQ-visibility findings in `summary.md` and `report.json`.
 - Baseline comparison is meant to be flexible. Use the latest saved run when it helps, disable it with `--baseline none` when you want a clean one-off read.
 - The analyzer does not act like a branch gate. It reports healthy, degraded, and errored behavior so the agent can investigate.


### PR DESCRIPTION
Update `sim-analysis` to capture separate simulator and broadcaster log excerpts in its reports, with the report schema bumped for the new log format. Refresh the simulation analysis skill notes so agents know the saved evidence now includes both service logs.
