### PR TITLE
feat: Add broadcaster snapshot sessions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,10 +18,13 @@ PORT=3000
 HOST=127.0.0.1
 
 # Broadcaster service settings
-BROADCASTER_SNAPSHOT_CHUNK_SIZE=500
+# 8 MiB cap per serialized snapshot payload; keeps HTTP chunks large enough for throughput
+# without making retries expensive when one chunk fails.
+BROADCASTER_SNAPSHOT_MAX_PAYLOAD_BYTES=8388608
 BROADCASTER_SUBSCRIBER_BUFFER_CAPACITY=128
 BROADCASTER_HEARTBEAT_INTERVAL_SECS=5
 BROADCASTER_TOKEN_MIN_QUALITY=0
+BROADCASTER_SNAPSHOT_SESSION_TTL_SECS=300
 
 # Logging settings
 RUST_LOG=info

--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,15 @@ TVL_THRESHOLD=10
 # Optional: ratio for keep/remove threshold (remove = TVL_THRESHOLD * TVL_KEEP_RATIO)
 TVL_KEEP_RATIO=0.2
 
+# Dynamic slippage defaults
+MIN_DYNAMIC_SLIPPAGE_BPS=1
+MAX_DYNAMIC_SLIPPAGE_BPS=200
+UTILIZATION_COEFFICIENT_BPS=60
+SENSITIVITY_COEFFICIENT_BPS=2500
+SOFT_LADDER_UTILIZATION_CAP_BPS=3500
+CUMULATIVE_DEGRADATION_COEFFICIENT_BPS=300
+SATURATION_RAMP_START_SLIPPAGE_BPS=45
+
 # Server settings
 PORT=3000
 HOST=127.0.0.1
@@ -65,12 +74,6 @@ STREAM_MEM_LOG_MIN_NEW_PAIRS=1000
 STREAM_MEM_LOG_MIN_INTERVAL_SECS=60
 # Emit CloudWatch Embedded Metric Format (EMF) lines for snapshots (Bytes gauges)
 STREAM_MEM_LOG_EMF=true
-
-# Auction-aware cancellation
-# How long (seconds) to suppress late QuoteUpdate for a canceled auction on a WS connection
-CANCELLATION_TTL_SECS=10
-# Feature flag to enable/disable auction cancellation behavior
-ENABLE_AUCTION_CANCELLATION=true
 
 BEBOP_USER=
 BEBOP_KEY=

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,6 +92,20 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Build & push broadcaster image
+        if: matrix.target == 'quoter-base'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.broadcaster-service
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ steps.ecr-login.outputs.registry }}/tycho-broadcaster-${{ matrix.target }}:${{ github.sha }}
+            ${{ steps.ecr-login.outputs.registry }}/tycho-broadcaster-${{ matrix.target }}:latest
+          cache-from: type=gha,scope=broadcaster-service-${{ matrix.target }}
+          cache-to: type=gha,mode=max,scope=broadcaster-service-${{ matrix.target }}
+
       - name: Force deploy ECS service
         env:
           CLUSTER: ${{ matrix.target }}

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Common optional inputs:
 - `BEBOP_USER`, `BEBOP_KEY`, `HASHFLOW_USER`, `HASHFLOW_KEY`, `LIQUORICE_USER`, and `LIQUORICE_KEY` only when `ENABLE_RFQ_POOLS=true` for chains that enable those RFQ providers
 - `HOST` and `PORT` to change the bind address
 - `BROADCASTER_TOKEN_MIN_QUALITY` to tune the broadcaster's startup Tycho token quality floor
+- `BROADCASTER_SNAPSHOT_MAX_PAYLOAD_BYTES` to cap serialized HTTP snapshot payloads
+- `BROADCASTER_SNAPSHOT_SESSION_TTL_SECS` to set how long an unattached snapshot session can wait before cleanup
 - `TOKEN_SNAPSHOT_TIMEOUT_MS` for the simulator's startup load of the full broadcaster token snapshot
 - `TOKEN_REFRESH_TIMEOUT_MS` for later single-token lookup misses
 - timeout and stream-health knobs from `crates/runtime/src/config/mod.rs`

--- a/crates/rpc/src/api/broadcaster.rs
+++ b/crates/rpc/src/api/broadcaster.rs
@@ -5,11 +5,18 @@ use axum::{
 
 use runtime::broadcaster_service::BroadcasterAppState;
 
-use crate::handlers::broadcaster::{status, token_lookup, token_snapshot, ws};
+use crate::handlers::broadcaster::{
+    create_snapshot_session, snapshot_session_payload, status, token_lookup, token_snapshot, ws,
+};
 
 pub fn create_broadcaster_router(app_state: BroadcasterAppState) -> Router {
     Router::new()
         .route("/status", get(status))
+        .route("/snapshot-sessions", post(create_snapshot_session))
+        .route(
+            "/snapshot-sessions/:session_id/payloads/:index",
+            get(snapshot_session_payload),
+        )
         .route("/ws", get(ws))
         .route("/tokens/snapshot", get(token_snapshot))
         .route("/tokens/lookup", post(token_lookup))
@@ -26,13 +33,14 @@ mod tests {
     };
     use std::time::Duration;
 
-    use anyhow::{bail, Result};
+    use anyhow::{anyhow, bail, Result};
     use axum::{
         body::{to_bytes, Body},
         http::{Request, StatusCode},
         routing::post,
         Json, Router,
     };
+    use futures::StreamExt;
     use num_bigint::BigUint;
     use num_traits::Zero;
     use runtime::{
@@ -42,7 +50,11 @@ mod tests {
         services::broadcaster::BroadcasterServiceState,
     };
     use simulator_core::broadcaster::BroadcasterBackend;
-    use tokio::{sync::Barrier, task::JoinHandle, time::sleep};
+    use tokio::{
+        sync::Barrier,
+        task::JoinHandle,
+        time::{sleep, timeout},
+    };
     use tokio_tungstenite::{connect_async, tungstenite};
     use tower::ServiceExt;
     use tycho_simulation::{
@@ -174,27 +186,61 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn websocket_upgrade_is_rejected_until_ready() -> Result<()> {
-        let (url, server_task) = spawn_server(
-            create_broadcaster_router(build_state(SeedMode::WarmingUp).await?),
-            "/ws",
-        )
-        .await?;
-        let result = connect_async(url).await;
-        server_task.abort();
+    async fn snapshot_session_create_rejects_until_ready() -> Result<()> {
+        let app = create_broadcaster_router(build_state(SeedMode::WarmingUp).await?);
+        let (status, body) = post_json(app, "/snapshot-sessions", serde_json::json!({})).await?;
 
-        match result {
-            Err(tungstenite::Error::Http(response)) => {
-                assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
-            }
-            Err(error) => bail!("unexpected websocket error: {error}"),
-            Ok(_) => bail!("expected websocket handshake rejection"),
-        }
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(body["status"], "snapshot_warming_up");
         Ok(())
     }
 
     #[tokio::test]
-    async fn websocket_upgrade_is_admitted_once_ready() -> Result<()> {
+    async fn snapshot_session_create_serves_payload_metadata_and_payloads() -> Result<()> {
+        let app = create_broadcaster_router(build_state(SeedMode::Ready).await?);
+        let (status, body) =
+            post_json(app.clone(), "/snapshot-sessions", serde_json::json!({})).await?;
+
+        assert_eq!(status, StatusCode::CREATED);
+        assert_eq!(body["chainId"], Chain::Ethereum.id());
+        assert_eq!(body["streamId"], "chain-1-stream-1");
+        assert_eq!(body["snapshotId"], "chain-1-snapshot-1");
+        assert_eq!(body["payloadCount"], 3);
+        assert_eq!(body["snapshotChunkCount"], 1);
+        assert_eq!(body["expiresInMs"], 300_000);
+
+        let session_id = body["sessionId"]
+            .as_u64()
+            .ok_or_else(|| anyhow!("expected numeric sessionId"))?;
+        let (status, payload) =
+            get_json(app, &format!("/snapshot-sessions/{session_id}/payloads/0")).await?;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(payload["stream_id"], "chain-1-stream-1");
+        assert_eq!(payload["message_seq"], 1);
+        assert_eq!(payload["kind"], "snapshot_start");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn snapshot_session_payload_reports_out_of_range() -> Result<()> {
+        let app = create_broadcaster_router(build_state(SeedMode::Ready).await?);
+        let (_status, body) =
+            post_json(app.clone(), "/snapshot-sessions", serde_json::json!({})).await?;
+        let session_id = body["sessionId"]
+            .as_u64()
+            .ok_or_else(|| anyhow!("expected numeric sessionId"))?;
+
+        let (status, body) =
+            get_json(app, &format!("/snapshot-sessions/{session_id}/payloads/99")).await?;
+
+        assert_eq!(status, StatusCode::RANGE_NOT_SATISFIABLE);
+        assert_eq!(body["error"], "snapshot payload index out of range");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn websocket_upgrade_requires_session_id() -> Result<()> {
         let (url, server_task) = spawn_server(
             create_broadcaster_router(build_state(SeedMode::Ready).await?),
             "/ws",
@@ -203,11 +249,63 @@ mod tests {
         let result = connect_async(url).await;
         server_task.abort();
 
-        let (_stream, response) = match result {
+        match result {
+            Err(tungstenite::Error::Http(response)) => {
+                assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            }
+            Err(error) => bail!("unexpected websocket error: {error}"),
+            Ok(_) => bail!("expected websocket handshake rejection"),
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn websocket_upgrade_rejects_unknown_session_id() -> Result<()> {
+        let (url, server_task) = spawn_server(
+            create_broadcaster_router(build_state(SeedMode::Ready).await?),
+            "/ws?sessionId=404",
+        )
+        .await?;
+        let result = connect_async(url).await;
+        server_task.abort();
+
+        match result {
+            Err(tungstenite::Error::Http(response)) => {
+                assert_eq!(response.status(), StatusCode::NOT_FOUND);
+            }
+            Err(error) => bail!("unexpected websocket error: {error}"),
+            Ok(_) => bail!("expected websocket handshake rejection"),
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn websocket_upgrade_attaches_snapshot_session_without_replaying_snapshot() -> Result<()>
+    {
+        let state = build_state(SeedMode::Ready).await?;
+        let session = state
+            .create_snapshot_session()
+            .await?
+            .ok_or_else(|| anyhow!("expected ready snapshot session"))?;
+        let (url, server_task) = spawn_server(
+            create_broadcaster_router(state),
+            &format!("/ws?sessionId={}", session.session_id),
+        )
+        .await?;
+        let result = connect_async(url).await;
+
+        let (mut stream, response) = match result {
             Ok(result) => result,
             Err(error) => bail!("expected websocket handshake success: {error}"),
         };
         assert_eq!(response.status(), StatusCode::SWITCHING_PROTOCOLS);
+        assert!(
+            timeout(Duration::from_millis(25), stream.next())
+                .await
+                .is_err(),
+            "websocket attach should wait for live messages instead of replaying snapshot"
+        );
+        server_task.abort();
         Ok(())
     }
 
@@ -460,7 +558,7 @@ mod tests {
     ) -> Result<BroadcasterAppState> {
         let cache = BroadcasterSnapshotCache::new(1, vec![BroadcasterBackend::Native]);
         let upstream = BroadcasterUpstreamState::default();
-        let service = BroadcasterServiceState::new(2, 8, cache, upstream);
+        let service = BroadcasterServiceState::new(8_388_608, 8, cache, upstream);
 
         match mode {
             SeedMode::Disconnected => {}

--- a/crates/rpc/src/handlers/broadcaster.rs
+++ b/crates/rpc/src/handlers/broadcaster.rs
@@ -1,10 +1,10 @@
-use std::collections::VecDeque;
+use std::collections::HashMap;
 
 use axum::{
     extract::{
         rejection::JsonRejection,
         ws::{Message, WebSocket, WebSocketUpgrade},
-        State,
+        Path, Query, State,
     },
     http::StatusCode,
     response::{IntoResponse, Response},
@@ -17,7 +17,9 @@ use futures::{
 use runtime::{
     broadcaster_service::BroadcasterAppState,
     models::broadcaster::BroadcasterReadiness,
-    services::broadcaster_sessions::{BroadcasterSessionRegistration, SessionCloseReason},
+    services::broadcaster_sessions::{
+        BroadcasterAttachedSession, SessionCloseReason, SnapshotSessionError,
+    },
 };
 use serde_json::json;
 use simulator_core::broadcaster::{
@@ -40,30 +42,57 @@ pub async fn status(
     (status_code, Json(BroadcasterStatusPayload::from(snapshot)))
 }
 
-pub async fn ws(ws: WebSocketUpgrade, State(state): State<BroadcasterAppState>) -> Response {
-    let snapshot = state.status_snapshot().await;
-    if snapshot.readiness != BroadcasterReadiness::Ready {
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(BroadcasterStatusPayload::from(snapshot)),
-        )
-            .into_response();
-    }
-
-    let registration = match state.subscribe().await {
-        Ok(Some(registration)) => registration,
+pub async fn create_snapshot_session(State(state): State<BroadcasterAppState>) -> Response {
+    match state.create_snapshot_session().await {
+        Ok(Some(session)) => (StatusCode::CREATED, Json(session)).into_response(),
         Ok(None) => {
             let snapshot = state.status_snapshot().await;
-            return (
+            (
                 StatusCode::SERVICE_UNAVAILABLE,
                 Json(BroadcasterStatusPayload::from(snapshot)),
             )
-                .into_response();
+                .into_response()
         }
         Err(error) => {
-            warn!(error = %error, "Failed to register broadcaster websocket subscriber");
-            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+            warn!(error = %error, "Failed to create broadcaster snapshot session");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
         }
+    }
+}
+
+pub async fn snapshot_session_payload(
+    State(state): State<BroadcasterAppState>,
+    Path((session_id, index)): Path<(u64, u32)>,
+) -> Response {
+    match state.snapshot_session_payload(session_id, index).await {
+        Ok(envelope) => (StatusCode::OK, Json(envelope)).into_response(),
+        Err(error) => snapshot_session_error_response(error, StatusCode::GONE),
+    }
+}
+
+pub async fn ws(
+    ws: WebSocketUpgrade,
+    State(state): State<BroadcasterAppState>,
+    Query(query): Query<HashMap<String, String>>,
+) -> Response {
+    let Some(session_id) = query.get("sessionId") else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "missing sessionId" })),
+        )
+            .into_response();
+    };
+    let Ok(session_id) = session_id.parse::<u64>() else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "invalid sessionId" })),
+        )
+            .into_response();
+    };
+
+    let registration = match state.attach_snapshot_session(session_id).await {
+        Ok(registration) => registration,
+        Err(error) => return snapshot_session_error_response(error, StatusCode::CONFLICT),
     };
 
     ws.on_upgrade(move |socket| handle_session(socket, state, registration))
@@ -129,16 +158,16 @@ pub async fn token_snapshot(State(state): State<BroadcasterAppState>) -> Respons
 async fn handle_session(
     socket: WebSocket,
     state: BroadcasterAppState,
-    registration: BroadcasterSessionRegistration,
+    registration: BroadcasterAttachedSession,
 ) {
-    let BroadcasterSessionRegistration {
+    let BroadcasterAttachedSession {
         session_id,
         stream_id,
-        snapshot_payloads,
+        next_message_seq,
         receiver,
         close_receiver,
     } = registration;
-    let session_stream = BroadcasterSessionStream::new(stream_id, snapshot_payloads, receiver);
+    let session_stream = BroadcasterSessionStream::new(stream_id, next_message_seq, receiver);
     let (sender, receiver) = socket.split();
 
     drive_session(sender, receiver, close_receiver, session_stream).await;
@@ -210,30 +239,23 @@ fn readiness_status_code(readiness: BroadcasterReadiness) -> StatusCode {
 struct BroadcasterSessionStream {
     stream_id: String,
     next_message_seq: u64,
-    snapshot_payloads: VecDeque<BroadcasterPayload>,
     receiver: mpsc::Receiver<BroadcasterPayload>,
 }
 
 impl BroadcasterSessionStream {
     fn new(
         stream_id: String,
-        snapshot_payloads: Vec<BroadcasterPayload>,
+        next_message_seq: u64,
         receiver: mpsc::Receiver<BroadcasterPayload>,
     ) -> Self {
         Self {
             stream_id,
-            next_message_seq: 1,
-            snapshot_payloads: snapshot_payloads.into_iter().collect(),
+            next_message_seq,
             receiver,
         }
     }
 
     async fn next_envelope(&mut self) -> Option<BroadcasterEnvelope> {
-        // New sessions must see the exported snapshot before any live traffic.
-        if let Some(payload) = self.snapshot_payloads.pop_front() {
-            return Some(self.wrap(payload));
-        }
-
         self.receiver.recv().await.map(|payload| self.wrap(payload))
     }
 
@@ -249,6 +271,24 @@ async fn await_join(task: JoinHandle<()>) {
     let _ = task.await;
 }
 
+fn snapshot_session_error_response(
+    error: SnapshotSessionError,
+    already_attached_status: StatusCode,
+) -> Response {
+    let (status, message) = match error {
+        SnapshotSessionError::NotFound => (StatusCode::NOT_FOUND, "snapshot session not found"),
+        SnapshotSessionError::Expired => (StatusCode::GONE, "snapshot session expired"),
+        SnapshotSessionError::AlreadyAttached => {
+            (already_attached_status, "snapshot session already attached")
+        }
+        SnapshotSessionError::PayloadOutOfRange => (
+            StatusCode::RANGE_NOT_SATISFIABLE,
+            "snapshot payload index out of range",
+        ),
+    };
+    (status, Json(json!({ "error": message }))).into_response()
+}
+
 #[cfg(test)]
 mod tests {
     use anyhow::{anyhow, Result};
@@ -256,26 +296,13 @@ mod tests {
 
     use super::BroadcasterSessionStream;
     use simulator_core::broadcaster::{
-        BroadcasterEnvelope, BroadcasterHeartbeat, BroadcasterPayload, BroadcasterSnapshotEnd,
-        BroadcasterSnapshotStart,
+        BroadcasterEnvelope, BroadcasterHeartbeat, BroadcasterPayload,
     };
 
     #[tokio::test]
-    async fn session_stream_sends_snapshot_before_live_payloads() -> Result<()> {
+    async fn session_stream_sends_live_payloads_from_next_sequence() -> Result<()> {
         let (sender, receiver) = mpsc::channel(4);
-        let mut session_stream = BroadcasterSessionStream::new(
-            "stream-7".to_string(),
-            vec![
-                BroadcasterPayload::SnapshotStart(BroadcasterSnapshotStart::new(
-                    "snapshot-7",
-                    1,
-                    vec![],
-                    0,
-                )?),
-                BroadcasterPayload::SnapshotEnd(BroadcasterSnapshotEnd::new("snapshot-7")),
-            ],
-            receiver,
-        );
+        let mut session_stream = BroadcasterSessionStream::new("stream-7".to_string(), 3, receiver);
 
         sender
             .send(BroadcasterPayload::Heartbeat(BroadcasterHeartbeat::new(
@@ -285,27 +312,6 @@ mod tests {
             )?))
             .await?;
 
-        assert_envelope(
-            session_stream.next_envelope().await,
-            BroadcasterEnvelope::new(
-                "stream-7",
-                1,
-                BroadcasterPayload::SnapshotStart(BroadcasterSnapshotStart::new(
-                    "snapshot-7",
-                    1,
-                    vec![],
-                    0,
-                )?),
-            ),
-        )?;
-        assert_envelope(
-            session_stream.next_envelope().await,
-            BroadcasterEnvelope::new(
-                "stream-7",
-                2,
-                BroadcasterPayload::SnapshotEnd(BroadcasterSnapshotEnd::new("snapshot-7")),
-            ),
-        )?;
         assert_envelope(
             session_stream.next_envelope().await,
             BroadcasterEnvelope::new(

--- a/crates/rpc/src/models/broadcaster_rpc.rs
+++ b/crates/rpc/src/models/broadcaster_rpc.rs
@@ -66,7 +66,7 @@ pub struct BroadcasterSnapshotPayload {
     pub snapshot_id: String,
     pub configured_backends: Vec<BroadcasterBackend>,
     pub total_states: usize,
-    pub chunk_size: usize,
+    pub max_payload_bytes: usize,
 }
 
 impl From<BroadcasterSnapshotStatus> for BroadcasterSnapshotPayload {
@@ -77,7 +77,7 @@ impl From<BroadcasterSnapshotStatus> for BroadcasterSnapshotPayload {
             snapshot_id: snapshot.snapshot_id,
             configured_backends: snapshot.configured_backends,
             total_states: snapshot.total_states,
-            chunk_size: snapshot.chunk_size,
+            max_payload_bytes: snapshot.max_payload_bytes,
         }
     }
 }

--- a/crates/runtime/src/broadcaster_service.rs
+++ b/crates/runtime/src/broadcaster_service.rs
@@ -11,12 +11,13 @@ use crate::models::broadcaster::{BroadcasterSnapshotCache, BroadcasterUpstreamSt
 use crate::models::stream_health::StreamHealth;
 use crate::models::tokens::{TokenStore, TokenStoreError};
 use crate::services::broadcaster::BroadcasterServiceState;
-use crate::services::stream_builder::{build_broadcaster_stream, BroadcasterProtocols};
+use crate::services::stream_builder::{build_broadcaster_raw_stream, BroadcasterProtocols};
 use crate::stream::{
-    supervise_broadcaster_stream, BroadcasterStreamControls, StreamSupervisorConfig,
+    supervise_broadcaster_raw_stream, BroadcasterStreamControls, StreamSupervisorConfig,
 };
 use simulator_core::broadcaster::{
-    BroadcasterTokenDto, BroadcasterTokenLookupResponse, BroadcasterTokenSnapshotResponse,
+    BroadcasterEnvelope, BroadcasterSnapshotSessionResponse, BroadcasterTokenDto,
+    BroadcasterTokenLookupResponse, BroadcasterTokenSnapshotResponse,
 };
 use tycho_simulation::tycho_common::Bytes;
 
@@ -25,21 +26,55 @@ pub struct BroadcasterAppState {
     service: BroadcasterServiceState,
     tokens: Arc<TokenStore>,
     chain_id: u64,
+    snapshot_session_ttl: Duration,
 }
 
 impl BroadcasterAppState {
     pub fn new(service: BroadcasterServiceState, tokens: Arc<TokenStore>, chain_id: u64) -> Self {
+        Self::with_snapshot_session_ttl(service, tokens, chain_id, Duration::from_secs(300))
+    }
+
+    pub fn with_snapshot_session_ttl(
+        service: BroadcasterServiceState,
+        tokens: Arc<TokenStore>,
+        chain_id: u64,
+        snapshot_session_ttl: Duration,
+    ) -> Self {
         Self {
             service,
             tokens,
             chain_id,
+            snapshot_session_ttl,
         }
     }
 
-    pub async fn subscribe(
+    pub async fn create_snapshot_session(
         &self,
-    ) -> Result<Option<crate::services::broadcaster_sessions::BroadcasterSessionRegistration>> {
-        self.service.subscribe().await
+    ) -> Result<Option<BroadcasterSnapshotSessionResponse>> {
+        self.service
+            .create_snapshot_session(self.snapshot_session_ttl)
+            .await
+    }
+
+    pub async fn snapshot_session_payload(
+        &self,
+        session_id: u64,
+        index: u32,
+    ) -> Result<BroadcasterEnvelope, crate::services::broadcaster_sessions::SnapshotSessionError>
+    {
+        self.service
+            .snapshot_session_payload(session_id, index)
+            .await
+    }
+
+    pub async fn attach_snapshot_session(
+        &self,
+        session_id: u64,
+    ) -> Result<
+        crate::services::broadcaster_sessions::BroadcasterAttachedSession,
+        crate::services::broadcaster_sessions::SnapshotSessionError,
+    > {
+        self.service.attach_snapshot_session(session_id).await
     }
 
     pub async fn status_snapshot(&self) -> crate::models::broadcaster::BroadcasterStatusSnapshot {
@@ -105,7 +140,7 @@ pub async fn build_broadcaster_service() -> Result<BroadcasterServiceParts> {
     let cache = BroadcasterSnapshotCache::new(chain.id(), configured_backends);
     let upstream_state = BroadcasterUpstreamState::default();
     let service = BroadcasterServiceState::new(
-        config.tuning.snapshot_chunk_size,
+        config.tuning.snapshot_max_payload_bytes,
         config.tuning.subscriber_buffer_capacity,
         cache,
         upstream_state,
@@ -116,7 +151,6 @@ pub async fn build_broadcaster_service() -> Result<BroadcasterServiceParts> {
     spawn_broadcaster_stream_task(
         &config,
         supervisor_cfg,
-        Arc::clone(&tokens),
         Arc::clone(&health),
         service.clone(),
     );
@@ -124,11 +158,14 @@ pub async fn build_broadcaster_service() -> Result<BroadcasterServiceParts> {
         service.clone(),
         Duration::from_secs(config.tuning.heartbeat_interval_secs),
     );
+    let app_state = BroadcasterAppState::with_snapshot_session_ttl(
+        service,
+        tokens,
+        chain.id(),
+        Duration::from_secs(config.tuning.snapshot_session_ttl_secs),
+    );
 
-    Ok(BroadcasterServiceParts {
-        config,
-        app_state: BroadcasterAppState::new(service, tokens, chain.id()),
-    })
+    Ok(BroadcasterServiceParts { config, app_state })
 }
 
 fn log_memory_config(memory: MemoryConfig) {
@@ -199,7 +236,6 @@ fn build_supervisor_config(config: &BroadcasterConfig) -> StreamSupervisorConfig
 fn spawn_broadcaster_stream_task(
     config: &BroadcasterConfig,
     supervisor_cfg: StreamSupervisorConfig,
-    tokens: Arc<TokenStore>,
     health: Arc<StreamHealth>,
     service: BroadcasterServiceState,
 ) {
@@ -215,19 +251,17 @@ fn spawn_broadcaster_stream_task(
 
     tokio::spawn(async move {
         info!("Starting broadcaster upstream supervisor...");
-        supervise_broadcaster_stream(
+        supervise_broadcaster_raw_stream(
             move || {
-                let tokens = Arc::clone(&tokens);
                 let tycho_url = tycho_url.clone();
                 let api_key = api_key.clone();
                 let protocols = protocols.clone();
                 async move {
-                    build_broadcaster_stream(
+                    build_broadcaster_raw_stream(
                         &tycho_url,
                         &api_key,
                         tvl_threshold,
                         tvl_keep_threshold,
-                        tokens,
                         chain,
                         &protocols,
                     )

--- a/crates/runtime/src/config/mod.rs
+++ b/crates/runtime/src/config/mod.rs
@@ -14,6 +14,10 @@ pub use logging::init_logging;
 pub(crate) use manifest::{load_manifest_registries, resolve_chain_config, MANIFEST_PATH};
 pub use memory::MemoryConfig;
 
+// 8 MiB per serialized snapshot payload: big enough for efficient HTTP transfer, small enough
+// that retrying one failed chunk stays cheap.
+const DEFAULT_BROADCASTER_SNAPSHOT_MAX_PAYLOAD_BYTES: &str = "8388608";
+
 /// Per-chain runtime profile resolved from `CHAIN_ID`.
 #[derive(Clone, Debug)]
 pub struct ChainProfile {
@@ -296,10 +300,11 @@ struct StreamConfig {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct BroadcasterTuning {
-    pub snapshot_chunk_size: usize,
+    pub snapshot_max_payload_bytes: usize,
     pub subscriber_buffer_capacity: usize,
     pub heartbeat_interval_secs: u64,
     pub token_min_quality: i32,
+    pub snapshot_session_ttl_secs: u64,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -443,15 +448,20 @@ fn load_stream_config() -> StreamConfig {
 }
 
 fn load_broadcaster_tuning() -> BroadcasterTuning {
-    let snapshot_chunk_size = parse_env_or_default("BROADCASTER_SNAPSHOT_CHUNK_SIZE", "500");
+    let snapshot_max_payload_bytes = parse_env_or_default(
+        "BROADCASTER_SNAPSHOT_MAX_PAYLOAD_BYTES",
+        DEFAULT_BROADCASTER_SNAPSHOT_MAX_PAYLOAD_BYTES,
+    );
     let subscriber_buffer_capacity =
         parse_env_or_default("BROADCASTER_SUBSCRIBER_BUFFER_CAPACITY", "128");
     let heartbeat_interval_secs = parse_env_or_default("BROADCASTER_HEARTBEAT_INTERVAL_SECS", "5");
     let token_min_quality = parse_env_or_default("BROADCASTER_TOKEN_MIN_QUALITY", "0");
+    let snapshot_session_ttl_secs =
+        parse_env_or_default("BROADCASTER_SNAPSHOT_SESSION_TTL_SECS", "300");
 
     assert!(
-        snapshot_chunk_size > 0,
-        "BROADCASTER_SNAPSHOT_CHUNK_SIZE must be > 0"
+        snapshot_max_payload_bytes > 0,
+        "BROADCASTER_SNAPSHOT_MAX_PAYLOAD_BYTES must be > 0"
     );
     assert!(
         subscriber_buffer_capacity > 0,
@@ -465,12 +475,17 @@ fn load_broadcaster_tuning() -> BroadcasterTuning {
         token_min_quality >= 0,
         "BROADCASTER_TOKEN_MIN_QUALITY must be >= 0"
     );
+    assert!(
+        snapshot_session_ttl_secs > 0,
+        "BROADCASTER_SNAPSHOT_SESSION_TTL_SECS must be > 0"
+    );
 
     BroadcasterTuning {
-        snapshot_chunk_size,
+        snapshot_max_payload_bytes,
         subscriber_buffer_capacity,
         heartbeat_interval_secs,
         token_min_quality,
+        snapshot_session_ttl_secs,
     }
 }
 
@@ -657,11 +672,12 @@ mod tests {
         "CUMULATIVE_DEGRADATION_COEFFICIENT_BPS",
         "SATURATION_RAMP_START_SLIPPAGE_BPS",
     ];
-    const BROADCASTER_TUNING_ENV_KEYS: [&str; 4] = [
-        "BROADCASTER_SNAPSHOT_CHUNK_SIZE",
+    const BROADCASTER_TUNING_ENV_KEYS: [&str; 5] = [
+        "BROADCASTER_SNAPSHOT_MAX_PAYLOAD_BYTES",
         "BROADCASTER_SUBSCRIBER_BUFFER_CAPACITY",
         "BROADCASTER_HEARTBEAT_INTERVAL_SECS",
         "BROADCASTER_TOKEN_MIN_QUALITY",
+        "BROADCASTER_SNAPSHOT_SESSION_TTL_SECS",
     ];
     const RFQ_CREDENTIAL_ENV_KEYS: [&str; 6] = [
         "BEBOP_USER",
@@ -1223,10 +1239,11 @@ route_policy = " default "
 
         let tuning = load_broadcaster_tuning();
 
-        assert_eq!(tuning.snapshot_chunk_size, 500);
+        assert_eq!(tuning.snapshot_max_payload_bytes, 8_388_608);
         assert_eq!(tuning.subscriber_buffer_capacity, 128);
         assert_eq!(tuning.heartbeat_interval_secs, 5);
         assert_eq!(tuning.token_min_quality, 0);
+        assert_eq!(tuning.snapshot_session_ttl_secs, 300);
     }
 
     #[test]
@@ -1235,17 +1252,19 @@ route_policy = " default "
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         clear_broadcaster_tuning_env();
-        std::env::set_var("BROADCASTER_SNAPSHOT_CHUNK_SIZE", "64");
+        std::env::set_var("BROADCASTER_SNAPSHOT_MAX_PAYLOAD_BYTES", "64");
         std::env::set_var("BROADCASTER_SUBSCRIBER_BUFFER_CAPACITY", "32");
         std::env::set_var("BROADCASTER_HEARTBEAT_INTERVAL_SECS", "9");
         std::env::set_var("BROADCASTER_TOKEN_MIN_QUALITY", "7");
+        std::env::set_var("BROADCASTER_SNAPSHOT_SESSION_TTL_SECS", "45");
 
         let tuning = load_broadcaster_tuning();
 
-        assert_eq!(tuning.snapshot_chunk_size, 64);
+        assert_eq!(tuning.snapshot_max_payload_bytes, 64);
         assert_eq!(tuning.subscriber_buffer_capacity, 32);
         assert_eq!(tuning.heartbeat_interval_secs, 9);
         assert_eq!(tuning.token_min_quality, 7);
+        assert_eq!(tuning.snapshot_session_ttl_secs, 45);
 
         clear_broadcaster_tuning_env();
     }
@@ -1264,6 +1283,24 @@ route_policy = " default "
         };
 
         assert!(message.contains("BROADCASTER_TOKEN_MIN_QUALITY must be >= 0"));
+
+        clear_broadcaster_tuning_env();
+    }
+
+    #[test]
+    fn load_broadcaster_tuning_rejects_zero_snapshot_session_ttl() {
+        let _guard = ENV_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        clear_broadcaster_tuning_env();
+        std::env::set_var("BROADCASTER_SNAPSHOT_SESSION_TTL_SECS", "0");
+
+        let message = match std::panic::catch_unwind(load_broadcaster_tuning) {
+            Ok(_) => unreachable!("load_broadcaster_tuning should reject zero session ttl"),
+            Err(panic) => panic_message(panic),
+        };
+
+        assert!(message.contains("BROADCASTER_SNAPSHOT_SESSION_TTL_SECS must be > 0"));
 
         clear_broadcaster_tuning_env();
     }

--- a/crates/runtime/src/models/broadcaster.rs
+++ b/crates/runtime/src/models/broadcaster.rs
@@ -1,16 +1,19 @@
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, ensure, Context, Result};
 use tokio::sync::RwLock;
 use tokio::time::Instant;
-use tycho_simulation::protocol::models::Update as TychoUpdate;
+use tycho_simulation::{
+    protocol::models::Update as TychoUpdate,
+    tycho_client::feed::{BlockHeader, FeedMessage},
+};
 
 use simulator_core::broadcaster::{
     BroadcasterBackend, BroadcasterBackendHead, BroadcasterHeartbeat, BroadcasterPayload,
-    BroadcasterProtocolSyncStatus, BroadcasterSnapshotChunk, BroadcasterSnapshotEnd,
-    BroadcasterSnapshotPartition, BroadcasterSnapshotStart, BroadcasterStateDelta,
-    BroadcasterStateEntry, BroadcasterUpdateMessage,
+    BroadcasterProtocolMessage, BroadcasterProtocolSyncStatus, BroadcasterSnapshotChunk,
+    BroadcasterSnapshotEnd, BroadcasterSnapshotPartition, BroadcasterSnapshotStart,
+    BroadcasterStateDelta, BroadcasterStateEntry, BroadcasterUpdateMessage,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -56,7 +59,7 @@ pub struct BroadcasterSnapshotStatus {
     pub snapshot_id: String,
     pub configured_backends: Vec<BroadcasterBackend>,
     pub total_states: usize,
-    pub chunk_size: usize,
+    pub max_payload_bytes: usize,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -76,6 +79,8 @@ pub struct BroadcasterBackendStatus {
 #[derive(Debug, Clone)]
 pub struct BroadcasterSnapshotExport {
     pub stream_id: String,
+    pub snapshot_id: String,
+    pub max_payload_bytes: usize,
     pub payloads: Vec<BroadcasterPayload>,
 }
 
@@ -164,6 +169,7 @@ struct BroadcasterSnapshotCacheData {
 struct BroadcasterPartitionState {
     block_number: Option<u64>,
     sync_statuses: BTreeMap<String, BroadcasterProtocolSyncStatus>,
+    messages: Vec<BroadcasterProtocolMessage>,
     states: BTreeMap<String, BroadcasterStateEntry>,
 }
 
@@ -211,12 +217,32 @@ impl BroadcasterSnapshotCache {
         Ok(message)
     }
 
-    pub async fn export_snapshot(&self, chunk_size: usize) -> Result<BroadcasterSnapshotExport> {
+    pub async fn apply_feed_message(
+        &self,
+        feed: &FeedMessage<BlockHeader>,
+    ) -> Result<BroadcasterUpdateMessage> {
+        let message = BroadcasterUpdateMessage::from_tycho_feed_message(feed)?;
+        let mut guard = self.inner.write().await;
+        apply_raw_update_message(&mut guard, &message);
+        Ok(message)
+    }
+
+    pub async fn export_snapshot(
+        &self,
+        max_payload_bytes: usize,
+    ) -> Result<BroadcasterSnapshotExport> {
         let guard = self.inner.read().await;
         let snapshot_id = guard.snapshot_id.clone();
         let stream_id = guard.stream_id.clone();
-        let total_chunks = count_snapshot_chunks(&guard.partitions, chunk_size);
-        let mut payloads = Vec::new();
+        let chunks = build_snapshot_chunks(
+            &stream_id,
+            &snapshot_id,
+            &self.configured_backends,
+            &guard.partitions,
+            max_payload_bytes,
+        )?;
+        let total_chunks = chunks.len() as u32;
+        let mut payloads = Vec::with_capacity(chunks.len().saturating_add(2));
         payloads.push(BroadcasterPayload::SnapshotStart(
             BroadcasterSnapshotStart::new(
                 snapshot_id.clone(),
@@ -226,49 +252,20 @@ impl BroadcasterSnapshotCache {
             )?,
         ));
 
-        let mut chunk_index = 0;
-        let mut backend_emit_state: BTreeMap<BroadcasterBackend, usize> = BTreeMap::new();
-        let mut chunk_payloads = BTreeMap::new();
-
-        loop {
-            chunk_payloads.clear();
-            for backend in &self.configured_backends {
-                let Some(partition) = guard.partitions.get(backend) else {
-                    continue;
-                };
-                let state_offset = backend_emit_state.entry(*backend).or_insert(0);
-                if *state_offset >= partition.states.len() && (*state_offset > 0 || chunk_index > 0)
-                {
-                    continue;
-                }
-
-                let partition_chunk = partition.snapshot_chunk(*backend, *state_offset, chunk_size);
-                if !partition_chunk.states.is_empty() || *state_offset == 0 {
-                    *state_offset = state_offset.saturating_add(partition_chunk.states.len());
-                    chunk_payloads.insert(*backend, partition_chunk);
-                }
-            }
-
-            if chunk_payloads.is_empty() {
-                break;
-            }
-
-            payloads.push(BroadcasterPayload::SnapshotChunk(
-                BroadcasterSnapshotChunk::new(
-                    snapshot_id.clone(),
-                    chunk_index,
-                    chunk_payloads.values().cloned().collect(),
-                )?,
-            ));
-            chunk_index = chunk_index.saturating_add(1);
-        }
+        payloads.extend(chunks.into_iter().map(BroadcasterPayload::SnapshotChunk));
 
         payloads.push(BroadcasterPayload::SnapshotEnd(
             BroadcasterSnapshotEnd::new(snapshot_id),
         ));
+        for (index, payload) in payloads.iter().enumerate() {
+            ensure_payload_fits(&stream_id, index as u64 + 1, payload, max_payload_bytes)
+                .with_context(|| format!("snapshot payload {index} exceeds byte cap"))?;
+        }
 
         Ok(BroadcasterSnapshotExport {
             stream_id,
+            snapshot_id: guard.snapshot_id.clone(),
+            max_payload_bytes,
             payloads,
         })
     }
@@ -306,7 +303,7 @@ impl BroadcasterSnapshotCache {
 
     pub async fn status_snapshot(
         &self,
-        chunk_size: usize,
+        max_payload_bytes: usize,
         upstream: BroadcasterUpstreamSnapshot,
         subscribers: BroadcasterSubscriberSnapshot,
     ) -> BroadcasterStatusSnapshot {
@@ -329,7 +326,7 @@ impl BroadcasterSnapshotCache {
                     *backend,
                     BroadcasterBackendStatus {
                         block_number: status.block_number,
-                        pool_count: status.states.len(),
+                        pool_count: status.entry_count(),
                         sync_statuses: status.sync_statuses,
                     },
                 )
@@ -348,9 +345,9 @@ impl BroadcasterSnapshotCache {
                 total_states: guard
                     .partitions
                     .values()
-                    .map(|partition| partition.states.len())
+                    .map(BroadcasterPartitionState::entry_count)
                     .sum(),
-                chunk_size,
+                max_payload_bytes,
             },
             subscribers,
             backends,
@@ -369,32 +366,46 @@ impl BroadcasterSnapshotCache {
 }
 
 impl BroadcasterPartitionState {
-    fn snapshot_chunk(
-        &self,
-        backend: BroadcasterBackend,
-        offset: usize,
-        chunk_size: usize,
-    ) -> BroadcasterSnapshotPartition {
-        let states = self
-            .states
-            .values()
-            .skip(offset)
-            .take(chunk_size)
-            .cloned()
-            .collect();
-        let sync_statuses = if offset == 0 {
-            self.sync_statuses.clone()
+    fn entry_count(&self) -> usize {
+        if self.messages.is_empty() {
+            self.states.len()
         } else {
-            BTreeMap::new()
-        };
-
-        BroadcasterSnapshotPartition::new(
-            backend,
-            self.block_number.unwrap_or_default(),
-            states,
-            sync_statuses,
-        )
+            self.messages
+                .iter()
+                .map(|message| message.message.snapshots.states.len())
+                .sum()
+        }
     }
+}
+
+fn apply_raw_update_message(
+    guard: &mut BroadcasterSnapshotCacheData,
+    message: &BroadcasterUpdateMessage,
+) {
+    for partition in &message.partitions {
+        let partition_state = guard.partitions.entry(partition.backend).or_default();
+        partition_state.block_number = Some(partition.block_number);
+        partition_state.sync_statuses = partition.sync_statuses.clone();
+        for message in &partition.messages {
+            merge_raw_message(&mut partition_state.messages, message.clone());
+        }
+    }
+}
+
+fn merge_raw_message(
+    messages: &mut Vec<BroadcasterProtocolMessage>,
+    incoming: BroadcasterProtocolMessage,
+) {
+    if let Some(existing) = messages
+        .iter_mut()
+        .find(|message| message.protocol == incoming.protocol)
+    {
+        existing.sync_state = incoming.sync_state;
+        existing.message = existing.message.clone().merge(incoming.message);
+    } else {
+        messages.push(incoming);
+    }
+    messages.sort_by(|left, right| left.protocol.cmp(&right.protocol));
 }
 
 fn apply_update_message(
@@ -452,38 +463,377 @@ fn apply_state_delta(
     Ok(())
 }
 
-fn count_snapshot_chunks(
+fn build_snapshot_chunks(
+    stream_id: &str,
+    snapshot_id: &str,
+    configured_backends: &[BroadcasterBackend],
     partitions: &BTreeMap<BroadcasterBackend, BroadcasterPartitionState>,
-    chunk_size: usize,
-) -> u32 {
-    let mut remaining = partitions
-        .iter()
-        .map(|(backend, partition)| (*backend, partition.states.len()))
-        .collect::<BTreeMap<_, _>>();
-    let mut total_chunks = 0u32;
+    max_payload_bytes: usize,
+) -> Result<Vec<BroadcasterSnapshotChunk>> {
+    let mut chunks = Vec::new();
+    for backend in configured_backends {
+        let Some(partition) = partitions.get(backend) else {
+            continue;
+        };
+        let partitions = build_partition_snapshot_chunks(
+            &SnapshotChunkBuildContext {
+                stream_id,
+                snapshot_id,
+                backend: *backend,
+                block_number: partition.block_number.unwrap_or_default(),
+                max_payload_bytes,
+            },
+            partition,
+            chunks.len(),
+        )?;
+        chunks.extend(partitions);
+    }
+    Ok(chunks)
+}
 
-    loop {
-        let mut emitted = false;
-        for states_remaining in remaining.values_mut() {
-            if *states_remaining == 0 && emitted {
-                continue;
-            }
-            if *states_remaining > 0 {
-                *states_remaining = states_remaining.saturating_sub(chunk_size);
-                emitted = true;
-            } else if total_chunks == 0 {
-                emitted = true;
+fn build_partition_snapshot_chunks(
+    ctx: &SnapshotChunkBuildContext<'_>,
+    partition: &BroadcasterPartitionState,
+    base_chunk_index: usize,
+) -> Result<Vec<BroadcasterSnapshotChunk>> {
+    let mut chunks = Vec::new();
+    let mut sync_statuses = partition.sync_statuses.clone();
+
+    if !partition.messages.is_empty() {
+        let mut messages = Vec::new();
+        for message in &partition.messages {
+            let fragments = split_protocol_message_for_snapshot(ctx, message, &sync_statuses)?;
+            for fragment in fragments {
+                let mut candidate = messages.clone();
+                candidate.push(fragment.clone());
+                if ctx.messages_fit(
+                    base_chunk_index + chunks.len(),
+                    candidate.clone(),
+                    sync_statuses.clone(),
+                )? {
+                    messages = candidate;
+                    continue;
+                }
+
+                if messages.is_empty() {
+                    return Err(anyhow!(
+                        "broadcaster snapshot message for protocol {} exceeds {} bytes",
+                        fragment.protocol,
+                        ctx.max_payload_bytes
+                    ));
+                }
+                chunks.push(ctx.messages_chunk(
+                    base_chunk_index + chunks.len(),
+                    std::mem::take(&mut messages),
+                    std::mem::take(&mut sync_statuses),
+                )?);
+                messages.push(fragment);
             }
         }
-
-        if !emitted {
-            break;
+        if !messages.is_empty() || !sync_statuses.is_empty() {
+            chunks.push(ctx.messages_chunk(
+                base_chunk_index + chunks.len(),
+                messages,
+                sync_statuses,
+            )?);
         }
-
-        total_chunks = total_chunks.saturating_add(1);
+        return Ok(chunks);
     }
 
-    total_chunks
+    let mut states = Vec::new();
+    for state in partition.states.values() {
+        let mut candidate = states.clone();
+        candidate.push(state.clone());
+        if ctx.states_fit(
+            base_chunk_index + chunks.len(),
+            candidate.clone(),
+            sync_statuses.clone(),
+        )? {
+            states = candidate;
+            continue;
+        }
+
+        if states.is_empty() {
+            return Err(anyhow!(
+                "broadcaster snapshot state {} exceeds {} bytes",
+                state.component_id,
+                ctx.max_payload_bytes
+            ));
+        }
+        chunks.push(ctx.states_chunk(
+            base_chunk_index + chunks.len(),
+            std::mem::take(&mut states),
+            std::mem::take(&mut sync_statuses),
+        )?);
+        states.push(state.clone());
+    }
+    if !states.is_empty() || !sync_statuses.is_empty() {
+        chunks.push(ctx.states_chunk(base_chunk_index + chunks.len(), states, sync_statuses)?);
+    }
+    Ok(chunks)
+}
+
+#[expect(
+    clippy::too_many_lines,
+    reason = "raw Tycho fragments share one packing state"
+)]
+fn split_protocol_message_for_snapshot(
+    ctx: &SnapshotChunkBuildContext<'_>,
+    message: &BroadcasterProtocolMessage,
+    sync_statuses: &BTreeMap<String, BroadcasterProtocolSyncStatus>,
+) -> Result<Vec<BroadcasterProtocolMessage>> {
+    if ctx.messages_fit(0, vec![message.clone()], sync_statuses.clone())? {
+        return Ok(vec![message.clone()]);
+    }
+
+    let mut states = message
+        .message
+        .snapshots
+        .states
+        .iter()
+        .map(|(component_id, state)| (component_id.clone(), state.clone()))
+        .collect::<Vec<_>>();
+    states.sort_by(|left, right| left.0.cmp(&right.0));
+    let mut vm_storage = message
+        .message
+        .snapshots
+        .vm_storage
+        .iter()
+        .map(|(address, account)| (address.clone(), account.clone()))
+        .collect::<Vec<_>>();
+    vm_storage.sort_by(|left, right| left.0.cmp(&right.0));
+
+    let mut fragments = Vec::new();
+    let mut current = empty_protocol_fragment(message, false);
+    let mut current_has_payload = false;
+
+    for (component_id, state) in states {
+        let mut candidate = current.clone();
+        candidate
+            .message
+            .snapshots
+            .states
+            .insert(component_id.clone(), state.clone());
+        if ctx.raw_fragment_fits(candidate.clone(), sync_statuses, fragments.is_empty())? {
+            current = candidate;
+            current_has_payload = true;
+            continue;
+        }
+        ensure!(
+            current_has_payload,
+            "broadcaster snapshot state fragment for protocol {} exceeds {} bytes",
+            message.protocol,
+            ctx.max_payload_bytes
+        );
+        fragments.push(current);
+        current = empty_protocol_fragment(message, false);
+        current.message.snapshots.states.insert(component_id, state);
+        ensure!(
+            ctx.raw_fragment_fits(current.clone(), sync_statuses, fragments.is_empty(),)?,
+            "broadcaster snapshot state fragment for protocol {} exceeds {} bytes",
+            message.protocol,
+            ctx.max_payload_bytes
+        );
+        current_has_payload = true;
+    }
+
+    for (address, account) in vm_storage {
+        let mut candidate = current.clone();
+        candidate
+            .message
+            .snapshots
+            .vm_storage
+            .insert(address.clone(), account.clone());
+        if ctx.raw_fragment_fits(candidate.clone(), sync_statuses, fragments.is_empty())? {
+            current = candidate;
+            current_has_payload = true;
+            continue;
+        }
+        ensure!(
+            current_has_payload,
+            "broadcaster snapshot VM storage fragment for protocol {} exceeds {} bytes",
+            message.protocol,
+            ctx.max_payload_bytes
+        );
+        fragments.push(current);
+        current = empty_protocol_fragment(message, false);
+        current
+            .message
+            .snapshots
+            .vm_storage
+            .insert(address, account);
+        ensure!(
+            ctx.raw_fragment_fits(current.clone(), sync_statuses, fragments.is_empty(),)?,
+            "broadcaster snapshot VM storage fragment for protocol {} exceeds {} bytes",
+            message.protocol,
+            ctx.max_payload_bytes
+        );
+        current_has_payload = true;
+    }
+
+    let mut final_fragment = if current_has_payload {
+        current.clone()
+    } else {
+        empty_protocol_fragment(message, false)
+    };
+    final_fragment.message.deltas = message.message.deltas.clone();
+    final_fragment.message.removed_components = message.message.removed_components.clone();
+    if ctx.raw_fragment_fits(final_fragment.clone(), sync_statuses, fragments.is_empty())? {
+        fragments.push(final_fragment);
+    } else {
+        if current_has_payload {
+            fragments.push(current);
+        }
+        let tail = empty_protocol_fragment(message, true);
+        ensure!(
+            ctx.raw_fragment_fits(tail.clone(), sync_statuses, fragments.is_empty(),)?,
+            "broadcaster snapshot delta/removal fragment for protocol {} exceeds {} bytes",
+            message.protocol,
+            ctx.max_payload_bytes
+        );
+        fragments.push(tail);
+    }
+
+    Ok(fragments)
+}
+
+fn empty_protocol_fragment(
+    message: &BroadcasterProtocolMessage,
+    include_tail: bool,
+) -> BroadcasterProtocolMessage {
+    let mut fragment = message.clone();
+    fragment.message.snapshots.states.clear();
+    fragment.message.snapshots.vm_storage.clear();
+    if !include_tail {
+        fragment.message.deltas = None;
+        fragment.message.removed_components.clear();
+    }
+    fragment
+}
+
+struct SnapshotChunkBuildContext<'a> {
+    stream_id: &'a str,
+    snapshot_id: &'a str,
+    backend: BroadcasterBackend,
+    block_number: u64,
+    max_payload_bytes: usize,
+}
+
+impl SnapshotChunkBuildContext<'_> {
+    fn raw_fragment_fits(
+        &self,
+        message: BroadcasterProtocolMessage,
+        sync_statuses: &BTreeMap<String, BroadcasterProtocolSyncStatus>,
+        include_sync_statuses: bool,
+    ) -> Result<bool> {
+        self.messages_fit(
+            0,
+            vec![message],
+            if include_sync_statuses {
+                sync_statuses.clone()
+            } else {
+                BTreeMap::new()
+            },
+        )
+    }
+
+    fn messages_fit(
+        &self,
+        chunk_index: usize,
+        messages: Vec<BroadcasterProtocolMessage>,
+        sync_statuses: BTreeMap<String, BroadcasterProtocolSyncStatus>,
+    ) -> Result<bool> {
+        self.chunk_fits(self.messages_chunk(chunk_index, messages, sync_statuses)?)
+    }
+
+    fn states_fit(
+        &self,
+        chunk_index: usize,
+        states: Vec<BroadcasterStateEntry>,
+        sync_statuses: BTreeMap<String, BroadcasterProtocolSyncStatus>,
+    ) -> Result<bool> {
+        self.chunk_fits(self.states_chunk(chunk_index, states, sync_statuses)?)
+    }
+
+    fn messages_chunk(
+        &self,
+        chunk_index: usize,
+        messages: Vec<BroadcasterProtocolMessage>,
+        sync_statuses: BTreeMap<String, BroadcasterProtocolSyncStatus>,
+    ) -> Result<BroadcasterSnapshotChunk> {
+        self.snapshot_chunk(
+            chunk_index,
+            BroadcasterSnapshotPartition::with_messages(
+                self.backend,
+                self.block_number,
+                messages,
+                sync_statuses,
+            ),
+        )
+    }
+
+    fn states_chunk(
+        &self,
+        chunk_index: usize,
+        states: Vec<BroadcasterStateEntry>,
+        sync_statuses: BTreeMap<String, BroadcasterProtocolSyncStatus>,
+    ) -> Result<BroadcasterSnapshotChunk> {
+        self.snapshot_chunk(
+            chunk_index,
+            BroadcasterSnapshotPartition::new(
+                self.backend,
+                self.block_number,
+                states,
+                sync_statuses,
+            ),
+        )
+    }
+
+    fn snapshot_chunk(
+        &self,
+        chunk_index: usize,
+        partition: BroadcasterSnapshotPartition,
+    ) -> Result<BroadcasterSnapshotChunk> {
+        BroadcasterSnapshotChunk::new(
+            self.snapshot_id.to_string(),
+            chunk_index as u32,
+            vec![partition],
+        )
+        .map_err(Into::into)
+    }
+
+    fn chunk_fits(&self, chunk: BroadcasterSnapshotChunk) -> Result<bool> {
+        payload_size(self.stream_id, &BroadcasterPayload::SnapshotChunk(chunk))
+            .map(|size| size <= self.max_payload_bytes)
+    }
+}
+
+fn ensure_payload_fits(
+    stream_id: &str,
+    message_seq: u64,
+    payload: &BroadcasterPayload,
+    max_payload_bytes: usize,
+) -> Result<()> {
+    let envelope = simulator_core::broadcaster::BroadcasterEnvelope::new(
+        stream_id.to_string(),
+        message_seq,
+        payload.clone(),
+    );
+    let size = serde_json::to_vec(&envelope)?.len();
+    ensure!(
+        size <= max_payload_bytes,
+        "serialized broadcaster snapshot payload is {size} bytes, above configured max {max_payload_bytes}"
+    );
+    Ok(())
+}
+
+fn payload_size(stream_id: &str, payload: &BroadcasterPayload) -> Result<usize> {
+    let envelope = simulator_core::broadcaster::BroadcasterEnvelope::new(
+        stream_id.to_string(),
+        u64::MAX,
+        payload.clone(),
+    );
+    Ok(serde_json::to_vec(&envelope)?.len())
 }
 
 fn format_stream_id(chain_id: u64, generation: u64) -> String {
@@ -496,24 +846,32 @@ fn format_snapshot_id(chain_id: u64, generation: u64) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{BTreeMap, HashMap};
+    use std::collections::HashMap;
 
     use super::{
-        count_snapshot_chunks, BroadcasterPartitionState, BroadcasterReadiness,
-        BroadcasterSnapshotCache, BroadcasterSubscriberSnapshot, BroadcasterUpstreamState,
+        BroadcasterReadiness, BroadcasterSnapshotCache, BroadcasterSnapshotExport,
+        BroadcasterSubscriberSnapshot, BroadcasterUpstreamState,
     };
     use anyhow::{anyhow, Result};
     use num_bigint::BigUint;
     use simulator_core::broadcaster::{
         BroadcasterBackend, BroadcasterEnvelope, BroadcasterPayload, BroadcasterProtocolSyncStatus,
-        BroadcasterProtocolSyncStatusKind, BroadcasterStateEntry, BroadcasterSubscriptionEvent,
+        BroadcasterProtocolSyncStatusKind, BroadcasterSnapshotChunk, BroadcasterSubscriptionEvent,
         BroadcasterSubscriptionTracker,
+    };
+    use tycho_common::{
+        dto::{ProtocolComponent as DtoProtocolComponent, ResponseProtocolState},
+        models::Chain as DtoChain,
+        Bytes as DtoBytes,
     };
     use tycho_simulation::tycho_common::dto::ProtocolStateDelta;
     use tycho_simulation::tycho_common::simulation::errors::{SimulationError, TransitionError};
     use tycho_simulation::{
         protocol::models::{ProtocolComponent, Update},
-        tycho_client::feed::{BlockHeader, SynchronizerState},
+        tycho_client::feed::{
+            synchronizer::{ComponentWithState, Snapshot, StateSyncMessage},
+            BlockHeader, FeedMessage, SynchronizerState,
+        },
         tycho_common::{
             models::{token::Token, Chain},
             simulation::protocol_sim::{Balances, GetAmountOutResult, ProtocolSim},
@@ -596,31 +954,43 @@ mod tests {
         }
     }
 
-    #[test]
-    fn count_snapshot_chunks_handles_partition_spread() {
-        let mut partitions = BTreeMap::new();
-        partitions.insert(
-            BroadcasterBackend::Native,
-            BroadcasterPartitionState {
-                block_number: Some(10),
-                sync_statuses: BTreeMap::new(),
-                states: (0..3)
-                    .map(|index| (format!("native-{index}"), dummy_state(index)))
-                    .collect(),
-            },
-        );
-        partitions.insert(
-            BroadcasterBackend::Vm,
-            BroadcasterPartitionState {
-                block_number: Some(11),
-                sync_statuses: BTreeMap::new(),
-                states: (0..1)
-                    .map(|index| (format!("vm-{index}"), dummy_state(index + 10)))
-                    .collect(),
-            },
-        );
+    fn snapshot_chunks(export: &BroadcasterSnapshotExport) -> Vec<&BroadcasterSnapshotChunk> {
+        export
+            .payloads
+            .iter()
+            .filter_map(|payload| match payload {
+                BroadcasterPayload::SnapshotChunk(chunk) => Some(chunk),
+                _ => None,
+            })
+            .collect()
+    }
 
-        assert_eq!(count_snapshot_chunks(&partitions, 2), 2);
+    fn first_snapshot_chunk_size(export: &BroadcasterSnapshotExport) -> Result<usize> {
+        snapshot_chunks(export)
+            .first()
+            .map(|chunk| {
+                super::payload_size(
+                    &export.stream_id,
+                    &BroadcasterPayload::SnapshotChunk((*chunk).clone()),
+                )
+            })
+            .ok_or_else(|| anyhow!("expected snapshot chunk"))?
+    }
+
+    fn assert_payloads_smaller_than(
+        export: &BroadcasterSnapshotExport,
+        max_size: usize,
+    ) -> Result<()> {
+        for (message_seq, payload) in export.payloads.iter().cloned().enumerate() {
+            let size = serde_json::to_vec(&BroadcasterEnvelope::new(
+                export.stream_id.clone(),
+                message_seq as u64 + 1,
+                payload,
+            ))?
+            .len();
+            assert!(size < max_size);
+        }
+        Ok(())
     }
 
     #[tokio::test]
@@ -632,7 +1002,7 @@ mod tests {
         let update = mixed_update();
         cache.apply_update(&update).await?;
 
-        let export = cache.export_snapshot(1).await?;
+        let export = cache.export_snapshot(8_388_608).await?;
         assert_eq!(export.stream_id, "chain-1-stream-1");
         assert!(matches!(
             export.payloads.first(),
@@ -648,11 +1018,80 @@ mod tests {
                 .iter()
                 .filter(|payload| matches!(payload, BroadcasterPayload::SnapshotChunk(_)))
                 .count(),
-            1
+            2
         );
 
         let heartbeat = cache.heartbeat().await?;
         assert!(matches!(heartbeat, Some(BroadcasterPayload::Heartbeat(_))));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn cache_exports_decoded_snapshot_by_serialized_payload_bytes() -> Result<()> {
+        let cache = BroadcasterSnapshotCache::new(1, vec![BroadcasterBackend::Native]);
+        cache.apply_update(&multi_native_update()).await?;
+
+        let full_export = cache.export_snapshot(8_388_608).await?;
+        let full_chunk_size = first_snapshot_chunk_size(&full_export)?;
+
+        let export = cache.export_snapshot(full_chunk_size - 1).await?;
+        let chunks = snapshot_chunks(&export);
+
+        assert!(chunks.len() > 1);
+        assert_eq!(
+            chunks
+                .iter()
+                .map(|chunk| chunk.partitions[0].states.len())
+                .sum::<usize>(),
+            3
+        );
+        assert_payloads_smaller_than(&export, full_chunk_size)?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn cache_splits_raw_snapshot_message_by_serialized_payload_bytes() -> Result<()> {
+        let cache = BroadcasterSnapshotCache::new(1, vec![BroadcasterBackend::Native]);
+        let feed = FeedMessage {
+            state_msgs: HashMap::from([(
+                "uniswap_v2".to_string(),
+                StateSyncMessage {
+                    header: block_header(10, 1),
+                    snapshots: Snapshot {
+                        states: HashMap::from([
+                            ("raw-1".to_string(), raw_component_with_state("raw-1", 1)),
+                            ("raw-2".to_string(), raw_component_with_state("raw-2", 2)),
+                        ]),
+                        vm_storage: HashMap::new(),
+                    },
+                    deltas: None,
+                    removed_components: HashMap::new(),
+                },
+            )]),
+            sync_states: HashMap::from([(
+                "uniswap_v2".to_string(),
+                SynchronizerState::Ready(block_header(10, 1)),
+            )]),
+        };
+        cache.apply_feed_message(&feed).await?;
+
+        let full_export = cache.export_snapshot(8_388_608).await?;
+        let full_chunk_size = first_snapshot_chunk_size(&full_export)?;
+
+        let export = cache.export_snapshot(full_chunk_size - 1).await?;
+        let chunks = snapshot_chunks(&export);
+
+        assert!(chunks.len() > 1);
+        assert_eq!(
+            chunks
+                .iter()
+                .flat_map(|chunk| &chunk.partitions)
+                .flat_map(|partition| &partition.messages)
+                .map(|message| message.message.snapshots.states.len())
+                .sum::<usize>(),
+            2
+        );
+        assert_payloads_smaller_than(&export, full_chunk_size)?;
         Ok(())
     }
 
@@ -665,13 +1104,20 @@ mod tests {
         cache.apply_update(&mixed_update()).await?;
         cache.apply_update(&vm_sync_only_update()).await?;
 
-        let export = cache.export_snapshot(1).await?;
-        let Some(BroadcasterPayload::SnapshotChunk(chunk)) = export
-            .payloads
-            .iter()
-            .find(|payload| matches!(payload, BroadcasterPayload::SnapshotChunk(_)))
+        let export = cache.export_snapshot(8_388_608).await?;
+        let Some(BroadcasterPayload::SnapshotChunk(chunk)) =
+            export.payloads.iter().find(|payload| {
+                matches!(
+                    payload,
+                    BroadcasterPayload::SnapshotChunk(chunk)
+                        if chunk
+                            .partitions
+                            .iter()
+                            .any(|partition| partition.backend == BroadcasterBackend::Vm)
+                )
+            })
         else {
-            return Err(anyhow!("expected snapshot_chunk payload"));
+            return Err(anyhow!("expected vm snapshot_chunk payload"));
         };
 
         let Some(vm_partition) = chunk
@@ -704,6 +1150,10 @@ mod tests {
                 BroadcasterSubscriptionEvent::SnapshotChunkAccepted {
                     snapshot_id: "chain-1-snapshot-1".to_string(),
                     chunk_index: 0,
+                },
+                BroadcasterSubscriptionEvent::SnapshotChunkAccepted {
+                    snapshot_id: "chain-1-snapshot-1".to_string(),
+                    chunk_index: 1,
                 },
                 BroadcasterSubscriptionEvent::SnapshotCompleted {
                     snapshot_id: "chain-1-snapshot-1".to_string(),
@@ -816,6 +1266,27 @@ mod tests {
         )]))
     }
 
+    fn multi_native_update() -> Update {
+        let mut new_pairs = HashMap::new();
+        let mut states = HashMap::new();
+        for index in 0u8..3 {
+            let component_id = format!("native-{index}");
+            new_pairs.insert(
+                component_id.clone(),
+                native_component(&component_id, "uniswap_v2"),
+            );
+            states.insert(
+                component_id,
+                Box::new(DummySim(index)) as Box<dyn ProtocolSim>,
+            );
+        }
+
+        Update::new(10, states, new_pairs).set_sync_states(HashMap::from([(
+            "uniswap_v2".to_string(),
+            SynchronizerState::Ready(block_header(10, 1)),
+        )]))
+    }
+
     fn vm_sync_only_update() -> Update {
         Update::new(11, HashMap::new(), HashMap::new())
             .set_removed_pairs(HashMap::from([(
@@ -860,12 +1331,37 @@ mod tests {
         )
     }
 
-    fn dummy_state(seed: usize) -> BroadcasterStateEntry {
-        BroadcasterStateEntry::new(
-            format!("component-{seed}"),
-            native_component(&format!("component-{seed}"), "uniswap_v2"),
-            Box::new(DummySim(seed as u8)),
-        )
+    fn raw_component_with_state(component_id: &str, seed: u8) -> ComponentWithState {
+        ComponentWithState {
+            state: ResponseProtocolState {
+                component_id: component_id.to_string(),
+                attributes: HashMap::from([(
+                    "large".to_string(),
+                    DtoBytes::from(vec![seed; 1024]),
+                )]),
+                balances: HashMap::new(),
+            },
+            component: raw_component(component_id, "uniswap_v2", seed),
+            component_tvl: Some(seed as f64),
+            entrypoints: Vec::new(),
+        }
+    }
+
+    fn raw_component(component_id: &str, protocol: &str, seed: u8) -> DtoProtocolComponent {
+        DtoProtocolComponent {
+            id: component_id.to_string(),
+            protocol_system: protocol.to_string(),
+            protocol_type_name: protocol.to_string(),
+            chain: DtoChain::Ethereum.into(),
+            tokens: vec![DtoBytes::from([seed; 20]), DtoBytes::from([seed + 1; 20])],
+            contract_ids: Vec::new(),
+            static_attributes: HashMap::new(),
+            change: Default::default(),
+            creation_tx: DtoBytes::from([seed; 32]),
+            created_at: chrono::DateTime::<chrono::Utc>::from_timestamp(0, 0)
+                .unwrap_or_else(|| unreachable!("unix epoch"))
+                .naive_utc(),
+        }
     }
 
     fn dummy_token(seed: u8, symbol: &str) -> Token {

--- a/crates/runtime/src/models/broadcaster.rs
+++ b/crates/runtime/src/models/broadcaster.rs
@@ -6,7 +6,11 @@ use tokio::sync::RwLock;
 use tokio::time::Instant;
 use tycho_simulation::{
     protocol::models::Update as TychoUpdate,
-    tycho_client::feed::{BlockHeader, FeedMessage},
+    tycho_client::feed::{
+        synchronizer::{Snapshot, StateSyncMessage},
+        BlockHeader, FeedMessage,
+    },
+    tycho_common::{dto::ResponseAccount, Bytes},
 };
 
 use simulator_core::broadcaster::{
@@ -573,16 +577,18 @@ fn build_partition_snapshot_chunks(
     Ok(chunks)
 }
 
-#[expect(
-    clippy::too_many_lines,
-    reason = "raw Tycho fragments share one packing state"
-)]
 fn split_protocol_message_for_snapshot(
     ctx: &SnapshotChunkBuildContext<'_>,
     message: &BroadcasterProtocolMessage,
     sync_statuses: &BTreeMap<String, BroadcasterProtocolSyncStatus>,
 ) -> Result<Vec<BroadcasterProtocolMessage>> {
-    if ctx.messages_fit(0, vec![message.clone()], sync_statuses.clone())? {
+    if message.message.snapshots.vm_storage.is_empty()
+        && ctx.messages_fit(
+            WORST_CASE_SNAPSHOT_CHUNK_INDEX,
+            vec![message.clone()],
+            sync_statuses.clone(),
+        )?
+    {
         return Ok(vec![message.clone()]);
     }
 
@@ -599,9 +605,8 @@ fn split_protocol_message_for_snapshot(
         .snapshots
         .vm_storage
         .iter()
-        .map(|(address, account)| (address.clone(), account.clone()))
         .collect::<Vec<_>>();
-    vm_storage.sort_by(|left, right| left.0.cmp(&right.0));
+    vm_storage.sort_by(|left, right| left.0.cmp(right.0));
 
     let mut fragments = Vec::new();
     let mut current = empty_protocol_fragment(message, false);
@@ -638,37 +643,26 @@ fn split_protocol_message_for_snapshot(
     }
 
     for (address, account) in vm_storage {
-        let mut candidate = current.clone();
-        candidate
-            .message
-            .snapshots
-            .vm_storage
-            .insert(address.clone(), account.clone());
-        if ctx.raw_fragment_fits(candidate.clone(), sync_statuses, fragments.is_empty())? {
-            current = candidate;
-            current_has_payload = true;
-            continue;
+        if current_has_payload {
+            fragments.push(current);
+            current = empty_protocol_fragment(message, false);
+            current_has_payload = false;
         }
-        ensure!(
-            current_has_payload,
-            "broadcaster snapshot VM storage fragment for protocol {} exceeds {} bytes",
-            message.protocol,
-            ctx.max_payload_bytes
-        );
-        fragments.push(current);
-        current = empty_protocol_fragment(message, false);
-        current
-            .message
-            .snapshots
-            .vm_storage
-            .insert(address, account);
-        ensure!(
-            ctx.raw_fragment_fits(current.clone(), sync_statuses, fragments.is_empty(),)?,
-            "broadcaster snapshot VM storage fragment for protocol {} exceeds {} bytes",
-            message.protocol,
-            ctx.max_payload_bytes
-        );
-        current_has_payload = true;
+        let account_fragments = split_vm_storage_account_for_snapshot(
+            ctx,
+            message,
+            sync_statuses,
+            address.clone(),
+            account,
+            fragments.is_empty(),
+        )?;
+        fragments.extend(account_fragments);
+    }
+
+    let has_tail =
+        message.message.deltas.is_some() || !message.message.removed_components.is_empty();
+    if !current_has_payload && !has_tail {
+        return Ok(fragments);
     }
 
     let mut final_fragment = if current_has_payload {
@@ -701,15 +695,183 @@ fn empty_protocol_fragment(
     message: &BroadcasterProtocolMessage,
     include_tail: bool,
 ) -> BroadcasterProtocolMessage {
-    let mut fragment = message.clone();
-    fragment.message.snapshots.states.clear();
-    fragment.message.snapshots.vm_storage.clear();
-    if !include_tail {
-        fragment.message.deltas = None;
-        fragment.message.removed_components.clear();
+    let (deltas, removed_components) = if include_tail {
+        (
+            message.message.deltas.clone(),
+            message.message.removed_components.clone(),
+        )
+    } else {
+        (None, HashMap::new())
+    };
+
+    // Build this structurally so large raw snapshots are never cloned just to be cleared.
+    BroadcasterProtocolMessage::new(
+        message.protocol.clone(),
+        message.sync_state.clone(),
+        StateSyncMessage {
+            header: message.message.header.clone(),
+            snapshots: Snapshot::default(),
+            deltas,
+            removed_components,
+        },
+    )
+}
+
+fn split_vm_storage_account_for_snapshot(
+    ctx: &SnapshotChunkBuildContext<'_>,
+    message: &BroadcasterProtocolMessage,
+    sync_statuses: &BTreeMap<String, BroadcasterProtocolSyncStatus>,
+    address: Bytes,
+    account: &ResponseAccount,
+    include_sync_statuses: bool,
+) -> Result<Vec<BroadcasterProtocolMessage>> {
+    let mut slots = account
+        .slots
+        .iter()
+        .map(|(slot, value)| (slot.clone(), value.clone()))
+        .collect::<Vec<_>>();
+    slots.sort_by(|left, right| left.0.cmp(&right.0));
+
+    let mut fragments = Vec::new();
+    if slots.is_empty() {
+        let fragment =
+            vm_storage_account_fragment_for_slot_range(message, address.clone(), account, &[]);
+        ensure!(
+            ctx.raw_fragment_fits(fragment.clone(), sync_statuses, include_sync_statuses)?,
+            "broadcaster snapshot VM storage account metadata for protocol {} account {} exceeds {} bytes",
+            message.protocol,
+            address,
+            ctx.max_payload_bytes
+        );
+        return Ok(vec![fragment]);
     }
+
+    let mut start = 0usize;
+    let mut include_sync_for_fragment = include_sync_statuses;
+    while start < slots.len() {
+        let metadata_fragment =
+            vm_storage_account_fragment_for_slot_range(message, address.clone(), account, &[]);
+        let metadata_size =
+            ctx.raw_fragment_size(metadata_fragment, sync_statuses, include_sync_for_fragment)?;
+        ensure!(
+            metadata_size < ctx.max_payload_bytes,
+            "broadcaster snapshot VM storage account metadata for protocol {} account {} exceeds {} bytes",
+            message.protocol,
+            address,
+            ctx.max_payload_bytes
+        );
+
+        let mut estimated_size = metadata_size;
+        let mut end = start;
+        while end < slots.len() {
+            let next_size = estimated_size.saturating_add(estimated_slot_entry_size(&slots[end]));
+            if next_size > ctx.max_payload_bytes {
+                break;
+            }
+            estimated_size = next_size;
+            end += 1;
+        }
+
+        if end == start {
+            return Err(anyhow!(
+                "broadcaster snapshot VM storage slot fragment for protocol {} account {} exceeds {} bytes",
+                message.protocol,
+                address,
+                ctx.max_payload_bytes
+            ));
+        }
+
+        let mut fragment = vm_storage_account_fragment_for_slot_range(
+            message,
+            address.clone(),
+            account,
+            &slots[start..end],
+        );
+        while !ctx.raw_fragment_fits(fragment.clone(), sync_statuses, include_sync_for_fragment)? {
+            end = end.saturating_sub(1);
+            if end == start {
+                return Err(anyhow!(
+                    "broadcaster snapshot VM storage slot fragment for protocol {} account {} exceeds {} bytes",
+                    message.protocol,
+                    address,
+                    ctx.max_payload_bytes
+                ));
+            }
+            fragment = vm_storage_account_fragment_for_slot_range(
+                message,
+                address.clone(),
+                account,
+                &slots[start..end],
+            );
+        }
+        fragments.push(fragment);
+        include_sync_for_fragment = false;
+        start = end;
+    }
+
+    Ok(fragments)
+}
+
+fn estimated_slot_entry_size((slot, value): &(Bytes, Bytes)) -> usize {
+    // Pessimistic JSON size for one `"0x...":"0x..."` storage entry plus a comma.
+    hex_json_string_size(slot)
+        .saturating_add(1)
+        .saturating_add(hex_json_string_size(value))
+        .saturating_add(1)
+}
+
+fn hex_json_string_size(bytes: &Bytes) -> usize {
+    4usize.saturating_add(bytes.len().saturating_mul(2))
+}
+
+fn vm_storage_account_fragment_for_slot_range(
+    message: &BroadcasterProtocolMessage,
+    address: Bytes,
+    account: &ResponseAccount,
+    slots: &[(Bytes, Bytes)],
+) -> BroadcasterProtocolMessage {
+    let account = response_account_with_slots(account, slots.iter().cloned().collect());
+    vm_storage_account_fragment(message, address, account)
+}
+
+#[expect(
+    deprecated,
+    reason = "creation_tx is deprecated but still part of the broadcaster wire DTO"
+)]
+fn response_account_with_slots(
+    account: &ResponseAccount,
+    slots: HashMap<Bytes, Bytes>,
+) -> ResponseAccount {
+    ResponseAccount::new(
+        account.chain,
+        account.address.clone(),
+        account.title.clone(),
+        slots,
+        account.native_balance.clone(),
+        account.token_balances.clone(),
+        account.code.clone(),
+        account.code_hash.clone(),
+        account.balance_modify_tx.clone(),
+        account.code_modify_tx.clone(),
+        account.creation_tx.clone(),
+    )
+}
+
+fn vm_storage_account_fragment(
+    message: &BroadcasterProtocolMessage,
+    address: Bytes,
+    account: ResponseAccount,
+) -> BroadcasterProtocolMessage {
+    let mut fragment = empty_protocol_fragment(message, false);
+    fragment
+        .message
+        .snapshots
+        .vm_storage
+        .insert(address, account);
     fragment
 }
+
+const WORST_CASE_SNAPSHOT_CHUNK_INDEX: usize = u32::MAX as usize;
 
 struct SnapshotChunkBuildContext<'a> {
     stream_id: &'a str,
@@ -726,8 +888,18 @@ impl SnapshotChunkBuildContext<'_> {
         sync_statuses: &BTreeMap<String, BroadcasterProtocolSyncStatus>,
         include_sync_statuses: bool,
     ) -> Result<bool> {
-        self.messages_fit(
-            0,
+        self.raw_fragment_size(message, sync_statuses, include_sync_statuses)
+            .map(|size| size <= self.max_payload_bytes)
+    }
+
+    fn raw_fragment_size(
+        &self,
+        message: BroadcasterProtocolMessage,
+        sync_statuses: &BTreeMap<String, BroadcasterProtocolSyncStatus>,
+        include_sync_statuses: bool,
+    ) -> Result<usize> {
+        self.messages_size(
+            WORST_CASE_SNAPSHOT_CHUNK_INDEX,
             vec![message],
             if include_sync_statuses {
                 sync_statuses.clone()
@@ -743,7 +915,17 @@ impl SnapshotChunkBuildContext<'_> {
         messages: Vec<BroadcasterProtocolMessage>,
         sync_statuses: BTreeMap<String, BroadcasterProtocolSyncStatus>,
     ) -> Result<bool> {
-        self.chunk_fits(self.messages_chunk(chunk_index, messages, sync_statuses)?)
+        self.messages_size(chunk_index, messages, sync_statuses)
+            .map(|size| size <= self.max_payload_bytes)
+    }
+
+    fn messages_size(
+        &self,
+        chunk_index: usize,
+        messages: Vec<BroadcasterProtocolMessage>,
+        sync_statuses: BTreeMap<String, BroadcasterProtocolSyncStatus>,
+    ) -> Result<usize> {
+        self.chunk_size(self.messages_chunk(chunk_index, messages, sync_statuses)?)
     }
 
     fn states_fit(
@@ -794,17 +976,19 @@ impl SnapshotChunkBuildContext<'_> {
         chunk_index: usize,
         partition: BroadcasterSnapshotPartition,
     ) -> Result<BroadcasterSnapshotChunk> {
-        BroadcasterSnapshotChunk::new(
-            self.snapshot_id.to_string(),
-            chunk_index as u32,
-            vec![partition],
-        )
-        .map_err(Into::into)
+        let chunk_index =
+            u32::try_from(chunk_index).context("snapshot chunk index exceeds u32 range")?;
+        BroadcasterSnapshotChunk::new(self.snapshot_id.to_string(), chunk_index, vec![partition])
+            .map_err(Into::into)
     }
 
     fn chunk_fits(&self, chunk: BroadcasterSnapshotChunk) -> Result<bool> {
-        payload_size(self.stream_id, &BroadcasterPayload::SnapshotChunk(chunk))
+        self.chunk_size(chunk)
             .map(|size| size <= self.max_payload_bytes)
+    }
+
+    fn chunk_size(&self, chunk: BroadcasterSnapshotChunk) -> Result<usize> {
+        payload_size(self.stream_id, &BroadcasterPayload::SnapshotChunk(chunk))
     }
 }
 
@@ -846,7 +1030,7 @@ fn format_snapshot_id(chain_id: u64, generation: u64) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::{BTreeMap, HashMap};
 
     use super::{
         BroadcasterReadiness, BroadcasterSnapshotCache, BroadcasterSnapshotExport,
@@ -855,12 +1039,12 @@ mod tests {
     use anyhow::{anyhow, Result};
     use num_bigint::BigUint;
     use simulator_core::broadcaster::{
-        BroadcasterBackend, BroadcasterEnvelope, BroadcasterPayload, BroadcasterProtocolSyncStatus,
-        BroadcasterProtocolSyncStatusKind, BroadcasterSnapshotChunk, BroadcasterSubscriptionEvent,
-        BroadcasterSubscriptionTracker,
+        BroadcasterBackend, BroadcasterEnvelope, BroadcasterPayload, BroadcasterProtocolMessage,
+        BroadcasterProtocolSyncStatus, BroadcasterProtocolSyncStatusKind, BroadcasterSnapshotChunk,
+        BroadcasterSubscriptionEvent, BroadcasterSubscriptionTracker,
     };
     use tycho_common::{
-        dto::{ProtocolComponent as DtoProtocolComponent, ResponseProtocolState},
+        dto::{ProtocolComponent as DtoProtocolComponent, ResponseAccount, ResponseProtocolState},
         models::Chain as DtoChain,
         Bytes as DtoBytes,
     };
@@ -954,6 +1138,25 @@ mod tests {
         }
     }
 
+    fn snapshot_chunk_build_context(
+        max_payload_bytes: usize,
+    ) -> super::SnapshotChunkBuildContext<'static> {
+        snapshot_chunk_build_context_for_backend(max_payload_bytes, BroadcasterBackend::Native)
+    }
+
+    fn snapshot_chunk_build_context_for_backend(
+        max_payload_bytes: usize,
+        backend: BroadcasterBackend,
+    ) -> super::SnapshotChunkBuildContext<'static> {
+        super::SnapshotChunkBuildContext {
+            stream_id: "chain-1-stream-1",
+            snapshot_id: "chain-1-snapshot-1",
+            backend,
+            block_number: 10,
+            max_payload_bytes,
+        }
+    }
+
     fn snapshot_chunks(export: &BroadcasterSnapshotExport) -> Vec<&BroadcasterSnapshotChunk> {
         export
             .payloads
@@ -991,6 +1194,83 @@ mod tests {
             assert!(size < max_size);
         }
         Ok(())
+    }
+
+    fn assert_payloads_at_most(export: &BroadcasterSnapshotExport, max_size: usize) -> Result<()> {
+        for (message_seq, payload) in export.payloads.iter().cloned().enumerate() {
+            let size = serde_json::to_vec(&BroadcasterEnvelope::new(
+                export.stream_id.clone(),
+                message_seq as u64 + 1,
+                payload,
+            ))?
+            .len();
+            assert!(size <= max_size);
+        }
+        Ok(())
+    }
+
+    fn vm_account_fragments<'a>(
+        export: &'a BroadcasterSnapshotExport,
+        account_address: &DtoBytes,
+    ) -> Vec<&'a ResponseAccount> {
+        snapshot_chunks(export)
+            .into_iter()
+            .flat_map(|chunk| &chunk.partitions)
+            .flat_map(|partition| &partition.messages)
+            .filter_map(|message| message.message.snapshots.vm_storage.get(account_address))
+            .collect()
+    }
+
+    fn vm_account_slot_key_batches(
+        export: &BroadcasterSnapshotExport,
+        account_address: &DtoBytes,
+    ) -> Vec<Vec<DtoBytes>> {
+        vm_account_fragments(export, account_address)
+            .into_iter()
+            .map(|account| {
+                let mut slot_keys = account.slots.keys().cloned().collect::<Vec<_>>();
+                slot_keys.sort();
+                slot_keys
+            })
+            .collect()
+    }
+
+    fn account_metadata_without_slots(account: &ResponseAccount) -> ResponseAccount {
+        let mut metadata = account.clone();
+        metadata.slots.clear();
+        metadata
+    }
+
+    fn assert_vm_storage_account_fragments_match(
+        export: &BroadcasterSnapshotExport,
+        account_address: &DtoBytes,
+        expected_account: &ResponseAccount,
+    ) {
+        let fragments = vm_account_fragments(export, account_address);
+        assert!(fragments.len() > 1);
+
+        let expected_metadata = account_metadata_without_slots(expected_account);
+        let mut observed_slots = HashMap::new();
+        let mut emitted_slot_count = 0usize;
+
+        for fragment in fragments {
+            assert_eq!(
+                account_metadata_without_slots(fragment),
+                expected_metadata,
+                "VM account fragment metadata changed"
+            );
+            emitted_slot_count += fragment.slots.len();
+
+            for (slot, value) in &fragment.slots {
+                assert!(
+                    observed_slots.insert(slot.clone(), value.clone()).is_none(),
+                    "duplicate VM storage slot emitted: {slot:?}"
+                );
+            }
+        }
+
+        assert_eq!(emitted_slot_count, expected_account.slots.len());
+        assert_eq!(observed_slots, expected_account.slots);
     }
 
     #[tokio::test]
@@ -1092,6 +1372,199 @@ mod tests {
             2
         );
         assert_payloads_smaller_than(&export, full_chunk_size)?;
+        Ok(())
+    }
+
+    #[test]
+    fn raw_fragment_sizing_reserves_chunk_index_digit_growth() -> Result<()> {
+        let message = raw_protocol_message_with_states(HashMap::from([(
+            "raw-1".to_string(),
+            raw_component_with_state("raw-1", 1),
+        )]));
+        let sync_statuses = BTreeMap::new();
+        let ctx = snapshot_chunk_build_context(usize::MAX);
+        let size_at_zero = ctx.messages_size(0, vec![message.clone()], sync_statuses.clone())?;
+        let size_at_worst = ctx.messages_size(
+            super::WORST_CASE_SNAPSHOT_CHUNK_INDEX,
+            vec![message.clone()],
+            sync_statuses.clone(),
+        )?;
+        assert!(size_at_worst > size_at_zero);
+
+        let capped_ctx = snapshot_chunk_build_context(size_at_zero);
+        assert!(capped_ctx.messages_fit(0, vec![message.clone()], BTreeMap::new())?);
+        assert!(!capped_ctx.raw_fragment_fits(message, &sync_statuses, false)?);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn raw_vm_slot_split_handles_chunk_index_digit_boundary() -> Result<()> {
+        let cache = BroadcasterSnapshotCache::new(1, vec![BroadcasterBackend::Vm]);
+        let account_address = DtoBytes::from([44u8; 20]);
+        let account = raw_response_account(account_address.clone(), 12, 256);
+        let message = raw_vm_protocol_message(account_address.clone(), account.clone());
+        let mut slots = account.slots.iter().collect::<Vec<_>>();
+        slots.sort_by(|left, right| left.0.cmp(right.0));
+        let first_slot = vec![((*slots[0].0).clone(), (*slots[0].1).clone())];
+        let ctx = snapshot_chunk_build_context_for_backend(usize::MAX, BroadcasterBackend::Vm);
+        let metadata_fragment = super::vm_storage_account_fragment_for_slot_range(
+            &message,
+            account_address.clone(),
+            &account,
+            &[],
+        );
+        let single_slot_fragment = super::vm_storage_account_fragment_for_slot_range(
+            &message,
+            account_address,
+            &account,
+            &first_slot,
+        );
+        let metadata_size = ctx.raw_fragment_size(metadata_fragment, &BTreeMap::new(), false)?;
+        let max_payload_bytes =
+            metadata_size.saturating_add(super::estimated_slot_entry_size(&first_slot[0]));
+        assert!(
+            ctx.raw_fragment_size(single_slot_fragment, &BTreeMap::new(), false)?
+                <= max_payload_bytes
+        );
+
+        let feed = FeedMessage {
+            state_msgs: HashMap::from([("vm:balancer_v2".to_string(), message.message)]),
+            sync_states: HashMap::new(),
+        };
+        cache.apply_feed_message(&feed).await?;
+
+        let export = cache.export_snapshot(max_payload_bytes).await?;
+        let chunks = snapshot_chunks(&export);
+        assert!(chunks.iter().any(|chunk| chunk.chunk_index == 9));
+        assert!(chunks.iter().any(|chunk| chunk.chunk_index == 10));
+        assert_payloads_at_most(&export, max_payload_bytes)?;
+        Ok(())
+    }
+
+    #[test]
+    fn empty_protocol_fragment_preserves_metadata_and_tail() {
+        let account_address = DtoBytes::from([42u8; 20]);
+        let message = BroadcasterProtocolMessage::new(
+            "vm:balancer_v2",
+            SynchronizerState::Ready(block_header(20, 2)),
+            StateSyncMessage {
+                header: block_header(20, 2),
+                snapshots: Snapshot {
+                    states: HashMap::from([(
+                        "raw-1".to_string(),
+                        raw_component_with_state("raw-1", 1),
+                    )]),
+                    vm_storage: HashMap::from([(
+                        account_address.clone(),
+                        raw_response_account(account_address, 1, 32),
+                    )]),
+                },
+                deltas: Some(Default::default()),
+                removed_components: HashMap::from([(
+                    "removed-1".to_string(),
+                    raw_component("removed-1", "uniswap_v2", 3),
+                )]),
+            },
+        );
+
+        let without_tail = super::empty_protocol_fragment(&message, false);
+        assert_eq!(without_tail.protocol, message.protocol);
+        assert_eq!(without_tail.sync_state, message.sync_state);
+        assert_eq!(without_tail.message.header, message.message.header);
+        assert!(without_tail.message.snapshots.states.is_empty());
+        assert!(without_tail.message.snapshots.vm_storage.is_empty());
+        assert!(without_tail.message.deltas.is_none());
+        assert!(without_tail.message.removed_components.is_empty());
+
+        let with_tail = super::empty_protocol_fragment(&message, true);
+        assert_eq!(with_tail.protocol, message.protocol);
+        assert_eq!(with_tail.sync_state, message.sync_state);
+        assert_eq!(with_tail.message.header, message.message.header);
+        assert!(with_tail.message.snapshots.states.is_empty());
+        assert!(with_tail.message.snapshots.vm_storage.is_empty());
+        assert_eq!(with_tail.message.deltas, message.message.deltas);
+        assert_eq!(
+            with_tail.message.removed_components,
+            message.message.removed_components
+        );
+    }
+
+    #[tokio::test]
+    async fn cache_splits_oversized_raw_vm_account_by_storage_slots() -> Result<()> {
+        let cache = BroadcasterSnapshotCache::new(1, vec![BroadcasterBackend::Vm]);
+        let account_address = DtoBytes::from([42u8; 20]);
+        let account = raw_response_account(account_address.clone(), 8, 512);
+        let expected_account = account.clone();
+        let feed = FeedMessage {
+            state_msgs: HashMap::from([(
+                "vm:balancer_v2".to_string(),
+                StateSyncMessage {
+                    header: block_header(10, 1),
+                    snapshots: Snapshot {
+                        states: HashMap::new(),
+                        vm_storage: HashMap::from([(account_address.clone(), account)]),
+                    },
+                    deltas: None,
+                    removed_components: HashMap::new(),
+                },
+            )]),
+            sync_states: HashMap::from([(
+                "vm:balancer_v2".to_string(),
+                SynchronizerState::Ready(block_header(10, 1)),
+            )]),
+        };
+        cache.apply_feed_message(&feed).await?;
+
+        let full_export = cache.export_snapshot(8_388_608).await?;
+        let full_chunk_size = first_snapshot_chunk_size(&full_export)?;
+        let max_payload_bytes = full_chunk_size / 2;
+        let export = cache.export_snapshot(max_payload_bytes).await?;
+        let slot_key_batches = vm_account_slot_key_batches(&export, &account_address);
+        let repeated_export = cache.export_snapshot(max_payload_bytes).await?;
+
+        assert_eq!(
+            slot_key_batches,
+            vm_account_slot_key_batches(&repeated_export, &account_address)
+        );
+        assert_vm_storage_account_fragments_match(&export, &account_address, &expected_account);
+        assert_payloads_at_most(&export, max_payload_bytes)?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn cache_splits_raw_vm_account_above_default_payload_cap() -> Result<()> {
+        const MAX_PAYLOAD_BYTES: usize = 8_388_608;
+
+        let cache = BroadcasterSnapshotCache::new(1, vec![BroadcasterBackend::Vm]);
+        let account_address = DtoBytes::from([43u8; 20]);
+        let account = raw_response_account(account_address.clone(), 10_000, 1_000);
+        let expected_account = account.clone();
+        let feed = FeedMessage {
+            state_msgs: HashMap::from([(
+                "vm:balancer_v2".to_string(),
+                StateSyncMessage {
+                    header: block_header(10, 1),
+                    snapshots: Snapshot {
+                        states: HashMap::new(),
+                        vm_storage: HashMap::from([(account_address.clone(), account)]),
+                    },
+                    deltas: None,
+                    removed_components: HashMap::new(),
+                },
+            )]),
+            sync_states: HashMap::from([(
+                "vm:balancer_v2".to_string(),
+                SynchronizerState::Ready(block_header(10, 1)),
+            )]),
+        };
+        cache.apply_feed_message(&feed).await?;
+
+        let unsplit_export = cache.export_snapshot(usize::MAX).await?;
+        assert!(first_snapshot_chunk_size(&unsplit_export)? > MAX_PAYLOAD_BYTES);
+
+        let export = cache.export_snapshot(MAX_PAYLOAD_BYTES).await?;
+        assert_vm_storage_account_fragments_match(&export, &account_address, &expected_account);
+        assert_payloads_at_most(&export, MAX_PAYLOAD_BYTES)?;
         Ok(())
     }
 
@@ -1299,6 +1772,43 @@ mod tests {
             )]))
     }
 
+    fn raw_protocol_message_with_states(
+        states: HashMap<String, ComponentWithState>,
+    ) -> BroadcasterProtocolMessage {
+        BroadcasterProtocolMessage::new(
+            "uniswap_v2",
+            SynchronizerState::Started,
+            StateSyncMessage {
+                header: block_header(10, 1),
+                snapshots: Snapshot {
+                    states,
+                    vm_storage: HashMap::new(),
+                },
+                deltas: None,
+                removed_components: HashMap::new(),
+            },
+        )
+    }
+
+    fn raw_vm_protocol_message(
+        account_address: DtoBytes,
+        account: ResponseAccount,
+    ) -> BroadcasterProtocolMessage {
+        BroadcasterProtocolMessage::new(
+            "vm:balancer_v2",
+            SynchronizerState::Started,
+            StateSyncMessage {
+                header: block_header(10, 1),
+                snapshots: Snapshot {
+                    states: HashMap::new(),
+                    vm_storage: HashMap::from([(account_address, account)]),
+                },
+                deltas: None,
+                removed_components: HashMap::new(),
+            },
+        )
+    }
+
     fn native_component(_id: &str, protocol: &str) -> ProtocolComponent {
         ProtocolComponent::new(
             Bytes::from([3u8; 20]),
@@ -1362,6 +1872,37 @@ mod tests {
                 .unwrap_or_else(|| unreachable!("unix epoch"))
                 .naive_utc(),
         }
+    }
+
+    fn raw_response_account(
+        address: DtoBytes,
+        slot_count: usize,
+        slot_value_size: usize,
+    ) -> ResponseAccount {
+        let mut slots = HashMap::new();
+        for index in 0..slot_count {
+            let seed = index as u8;
+            let mut slot_key = vec![0u8; 32];
+            slot_key[24..].copy_from_slice(&(index as u64).to_be_bytes());
+            slots.insert(
+                DtoBytes::from(slot_key),
+                DtoBytes::from(vec![seed.saturating_add(1); slot_value_size]),
+            );
+        }
+
+        ResponseAccount::new(
+            DtoChain::Ethereum.into(),
+            address,
+            "vm-account".to_string(),
+            slots,
+            DtoBytes::from([0u8; 32]),
+            HashMap::new(),
+            DtoBytes::from(vec![7u8; 128]),
+            DtoBytes::from([8u8; 32]),
+            DtoBytes::from([9u8; 32]),
+            DtoBytes::from([10u8; 32]),
+            None,
+        )
     }
 
     fn dummy_token(seed: u8, symbol: &str) -> Token {

--- a/crates/runtime/src/models/broadcaster_urls.rs
+++ b/crates/runtime/src/models/broadcaster_urls.rs
@@ -1,0 +1,129 @@
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BroadcasterUrlError {
+    message: String,
+}
+
+impl BroadcasterUrlError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for BroadcasterUrlError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for BroadcasterUrlError {}
+
+pub fn derive_broadcaster_http_url(
+    ws_url: &str,
+    relative_path: &str,
+) -> Result<String, BroadcasterUrlError> {
+    let mut url = parse_broadcaster_ws_url(ws_url)?;
+    let scheme = match url.scheme() {
+        "ws" => "http",
+        "wss" => "https",
+        other => {
+            return Err(BroadcasterUrlError::new(format!(
+                "TYCHO_BROADCASTER_WS_URL must use ws or wss, got {other}"
+            )))
+        }
+    };
+    let prefix = websocket_path_prefix(&url)?;
+    let http_path = if prefix.is_empty() {
+        format!("/{relative_path}")
+    } else {
+        format!("{prefix}/{relative_path}")
+    };
+
+    url.set_scheme(scheme)
+        .map_err(|_| BroadcasterUrlError::new("invalid broadcaster URL scheme"))?;
+    url.set_path(&http_path);
+    url.set_query(None);
+    Ok(url.to_string())
+}
+
+pub fn derive_broadcaster_session_ws_url(
+    ws_url: &str,
+    session_id: u64,
+) -> Result<String, BroadcasterUrlError> {
+    let mut url = parse_broadcaster_ws_url(ws_url)?;
+    websocket_path_prefix(&url)?;
+    url.query_pairs_mut()
+        .clear()
+        .append_pair("sessionId", &session_id.to_string());
+    Ok(url.to_string())
+}
+
+fn parse_broadcaster_ws_url(ws_url: &str) -> Result<reqwest::Url, BroadcasterUrlError> {
+    reqwest::Url::parse(ws_url)
+        .map_err(|err| BroadcasterUrlError::new(format!("invalid TYCHO_BROADCASTER_WS_URL: {err}")))
+}
+
+fn websocket_path_prefix(url: &reqwest::Url) -> Result<&str, BroadcasterUrlError> {
+    url.path()
+        .strip_suffix("/ws")
+        .ok_or_else(|| BroadcasterUrlError::new("TYCHO_BROADCASTER_WS_URL must end with /ws"))
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+
+    use super::{derive_broadcaster_http_url, derive_broadcaster_session_ws_url};
+
+    #[test]
+    fn derives_http_url_from_broadcaster_websocket_url() -> Result<()> {
+        assert_eq!(
+            derive_broadcaster_http_url("ws://127.0.0.1:3001/ws", "snapshot-sessions")?,
+            "http://127.0.0.1:3001/snapshot-sessions"
+        );
+        assert_eq!(
+            derive_broadcaster_http_url(
+                "wss://broadcaster.example/prod/base/ws",
+                "snapshot-sessions/7/payloads/2"
+            )?,
+            "https://broadcaster.example/prod/base/snapshot-sessions/7/payloads/2"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn derives_session_websocket_url_from_broadcaster_websocket_url() -> Result<()> {
+        assert_eq!(
+            derive_broadcaster_session_ws_url("ws://127.0.0.1:3001/ws", 42)?,
+            "ws://127.0.0.1:3001/ws?sessionId=42"
+        );
+        assert_eq!(
+            derive_broadcaster_session_ws_url("wss://broadcaster.example/prod/base/ws", 9)?,
+            "wss://broadcaster.example/prod/base/ws?sessionId=9"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_non_websocket_url() {
+        let Err(error) =
+            derive_broadcaster_http_url("http://127.0.0.1:3001/ws", "snapshot-sessions")
+        else {
+            unreachable!("non-websocket URL should fail");
+        };
+
+        assert!(error.to_string().contains("must use ws or wss"));
+    }
+
+    #[test]
+    fn rejects_urls_without_ws_suffix() {
+        let Err(error) = derive_broadcaster_session_ws_url("ws://127.0.0.1:3001/socket", 1) else {
+            unreachable!("non-/ws URL should fail");
+        };
+
+        assert!(error.to_string().contains("must end with /ws"));
+    }
+}

--- a/crates/runtime/src/models/mod.rs
+++ b/crates/runtime/src/models/mod.rs
@@ -1,6 +1,7 @@
 pub use simulator_core::models::{factories, messages, protocol};
 
 pub mod broadcaster;
+pub mod broadcaster_urls;
 pub mod erc4626;
 pub mod rfq;
 pub mod state;

--- a/crates/runtime/src/models/tokens.rs
+++ b/crates/runtime/src/models/tokens.rs
@@ -12,6 +12,8 @@ use tycho_simulation::tycho_common::{
     Bytes,
 };
 
+use crate::models::broadcaster_urls::derive_broadcaster_http_url;
+
 /// In-memory token metadata cache. The fetch source is explicit so simulator request
 /// paths can be broadcaster-backed while the broadcaster remains the Tycho authority.
 type InflightRx = watch::Receiver<Option<Result<Option<Token>, TokenStoreError>>>;
@@ -461,29 +463,8 @@ pub fn derive_broadcaster_token_snapshot_url(ws_url: &str) -> Result<String, Tok
 }
 
 fn derive_broadcaster_token_url(ws_url: &str, endpoint: &str) -> Result<String, TokenStoreError> {
-    let mut url = reqwest::Url::parse(ws_url).map_err(|err| {
-        TokenStoreError::RequestFailed(format!("invalid TYCHO_BROADCASTER_WS_URL: {err}"))
-    })?;
-    let scheme = match url.scheme() {
-        "ws" => "http",
-        "wss" => "https",
-        other => {
-            return Err(TokenStoreError::RequestFailed(format!(
-                "TYCHO_BROADCASTER_WS_URL must use ws or wss, got {other}"
-            )))
-        }
-    };
-    let Some(prefix) = url.path().strip_suffix("/ws") else {
-        return Err(TokenStoreError::RequestFailed(
-            "TYCHO_BROADCASTER_WS_URL must end with /ws".to_string(),
-        ));
-    };
-    let lookup_path = format!("{prefix}/tokens/{endpoint}");
-    url.set_scheme(scheme).map_err(|_| {
-        TokenStoreError::RequestFailed("invalid broadcaster URL scheme".to_string())
-    })?;
-    url.set_path(&lookup_path);
-    Ok(url.to_string())
+    derive_broadcaster_http_url(ws_url, &format!("tokens/{endpoint}"))
+        .map_err(|error| TokenStoreError::RequestFailed(error.to_string()))
 }
 
 #[cfg(test)]

--- a/crates/runtime/src/services/broadcaster.rs
+++ b/crates/runtime/src/services/broadcaster.rs
@@ -1,19 +1,27 @@
+use std::time::Duration;
+
 use anyhow::Result;
 use tokio::sync::Mutex;
-use tycho_simulation::protocol::models::Update as TychoUpdate;
+use tycho_simulation::{
+    protocol::models::Update as TychoUpdate,
+    tycho_client::feed::{BlockHeader, FeedMessage},
+};
 
 use crate::models::broadcaster::{
     BroadcasterLiveState, BroadcasterReadiness, BroadcasterSnapshotCache,
     BroadcasterStatusSnapshot, BroadcasterUpstreamState,
 };
 use crate::services::broadcaster_sessions::{
-    BroadcasterSessionRegistration, BroadcasterSubscriberRegistry, SessionCloseReason,
+    BroadcasterAttachedSession, BroadcasterSubscriberRegistry, SessionCloseReason,
+    SnapshotSessionError,
 };
-use simulator_core::broadcaster::BroadcasterPayload;
+use simulator_core::broadcaster::{
+    BroadcasterEnvelope, BroadcasterPayload, BroadcasterSnapshotSessionResponse,
+};
 
 #[derive(Debug, Clone)]
 pub struct BroadcasterServiceState {
-    snapshot_chunk_size: usize,
+    snapshot_max_payload_bytes: usize,
     cache: BroadcasterSnapshotCache,
     upstream: BroadcasterUpstreamState,
     subscribers: BroadcasterSubscriberRegistry,
@@ -24,13 +32,13 @@ pub struct BroadcasterServiceState {
 
 impl BroadcasterServiceState {
     pub fn new(
-        snapshot_chunk_size: usize,
+        snapshot_max_payload_bytes: usize,
         subscriber_buffer_capacity: usize,
         cache: BroadcasterSnapshotCache,
         upstream: BroadcasterUpstreamState,
     ) -> Self {
         Self {
-            snapshot_chunk_size,
+            snapshot_max_payload_bytes,
             cache,
             upstream,
             subscribers: BroadcasterSubscriberRegistry::new(subscriber_buffer_capacity),
@@ -69,23 +77,58 @@ impl BroadcasterServiceState {
         Ok(())
     }
 
+    pub async fn apply_feed_message(&self, feed: &FeedMessage<BlockHeader>) -> Result<()> {
+        let _gate = self.lifecycle_gate.lock().await;
+        let message = self.cache.apply_feed_message(feed).await?;
+        self.upstream.record_update().await;
+        self.subscribers
+            .broadcast(BroadcasterPayload::Update(message))
+            .await;
+        Ok(())
+    }
+
     pub async fn broadcast_heartbeat(&self) -> Result<()> {
         let _gate = self.lifecycle_gate.lock().await;
         if let Some(heartbeat) = self.cache.heartbeat().await? {
             self.subscribers.broadcast(heartbeat).await;
         }
+        self.subscribers.cleanup_expired_snapshot_sessions().await;
         Ok(())
     }
 
-    pub async fn subscribe(&self) -> Result<Option<BroadcasterSessionRegistration>> {
+    pub async fn create_snapshot_session(
+        &self,
+        ttl: Duration,
+    ) -> Result<Option<BroadcasterSnapshotSessionResponse>> {
         let _gate = self.lifecycle_gate.lock().await;
         let status = self.status_snapshot().await;
         if status.readiness != BroadcasterReadiness::Ready {
             return Ok(None);
         }
 
-        let snapshot = self.cache.export_snapshot(self.snapshot_chunk_size).await?;
-        Ok(Some(self.subscribers.register(snapshot).await))
+        let snapshot = self
+            .cache
+            .export_snapshot(self.snapshot_max_payload_bytes)
+            .await?;
+        self.subscribers
+            .create_snapshot_session(snapshot, status.chain_id, ttl)
+            .await
+            .map(Some)
+    }
+
+    pub async fn snapshot_session_payload(
+        &self,
+        session_id: u64,
+        index: u32,
+    ) -> Result<BroadcasterEnvelope, SnapshotSessionError> {
+        self.subscribers.snapshot_payload(session_id, index).await
+    }
+
+    pub async fn attach_snapshot_session(
+        &self,
+        session_id: u64,
+    ) -> Result<BroadcasterAttachedSession, SnapshotSessionError> {
+        self.subscribers.attach_snapshot_session(session_id).await
     }
 
     pub async fn remove_subscriber(&self, session_id: u64) {
@@ -101,7 +144,7 @@ impl BroadcasterServiceState {
     pub async fn status_snapshot(&self) -> BroadcasterStatusSnapshot {
         self.cache
             .status_snapshot(
-                self.snapshot_chunk_size,
+                self.snapshot_max_payload_bytes,
                 self.upstream.snapshot().await,
                 self.subscribers.snapshot().await,
             )
@@ -208,7 +251,11 @@ mod tests {
 
         let mut subscribe_task = tokio::spawn({
             let service = service.clone();
-            async move { service.subscribe().await }
+            async move {
+                service
+                    .create_snapshot_session(Duration::from_secs(300))
+                    .await
+            }
         });
         tokio::task::yield_now().await;
 
@@ -226,7 +273,7 @@ mod tests {
             .is_err());
         drop(gate);
 
-        let mut registration = subscribe_task
+        let session = subscribe_task
             .await
             .map_err(|error| anyhow!("subscribe task failed: {error}"))??
             .ok_or_else(|| anyhow!("expected ready broadcaster subscriber"))?;
@@ -234,6 +281,11 @@ mod tests {
         update_task
             .await
             .map_err(|error| anyhow!("update task failed: {error}"))??;
+
+        let mut registration = service
+            .attach_snapshot_session(session.session_id)
+            .await
+            .map_err(|error| anyhow!("failed to attach snapshot session: {error:?}"))?;
 
         let live_payload = registration
             .receiver
@@ -245,16 +297,34 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn subscribe_is_disconnected_by_queued_generation_reset() -> Result<()> {
+    async fn attached_session_is_disconnected_by_generation_reset() -> Result<()> {
         let service = ready_service().await?;
         let gate = service.lock_lifecycle_gate_for_test().await;
 
         let mut subscribe_task = tokio::spawn({
             let service = service.clone();
-            async move { service.subscribe().await }
+            async move {
+                service
+                    .create_snapshot_session(Duration::from_secs(300))
+                    .await
+            }
         });
         tokio::task::yield_now().await;
 
+        assert!(timeout(Duration::from_millis(25), &mut subscribe_task)
+            .await
+            .is_err());
+        drop(gate);
+
+        let session = subscribe_task
+            .await
+            .map_err(|error| anyhow!("subscribe task failed: {error}"))??
+            .ok_or_else(|| anyhow!("expected ready broadcaster subscriber"))?;
+
+        let registration = service
+            .attach_snapshot_session(session.session_id)
+            .await
+            .map_err(|error| anyhow!("failed to attach snapshot session: {error:?}"))?;
         let reset_task = tokio::spawn({
             let service = service.clone();
             async move {
@@ -263,16 +333,6 @@ mod tests {
                     .await
             }
         });
-
-        assert!(timeout(Duration::from_millis(25), &mut subscribe_task)
-            .await
-            .is_err());
-        drop(gate);
-
-        let registration = subscribe_task
-            .await
-            .map_err(|error| anyhow!("subscribe task failed: {error}"))??
-            .ok_or_else(|| anyhow!("expected ready broadcaster subscriber"))?;
         let reason = registration
             .close_receiver
             .await
@@ -292,7 +352,7 @@ mod tests {
     async fn ready_service() -> Result<BroadcasterServiceState> {
         let cache = BroadcasterSnapshotCache::new(1, vec![BroadcasterBackend::Native]);
         let upstream = BroadcasterUpstreamState::default();
-        let service = BroadcasterServiceState::new(2, 8, cache, upstream);
+        let service = BroadcasterServiceState::new(8_388_608, 8, cache, upstream);
         service.mark_upstream_connected().await;
         service
             .apply_update(&native_only_update(10, "native-1"))

--- a/crates/runtime/src/services/broadcaster_sessions.rs
+++ b/crates/runtime/src/services/broadcaster_sessions.rs
@@ -1,15 +1,21 @@
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
+use anyhow::{Context, Result};
 use tokio::sync::{mpsc, oneshot, Mutex};
+use tokio::time::Instant;
 
 use crate::models::broadcaster::{BroadcasterSnapshotExport, BroadcasterSubscriberSnapshot};
-use simulator_core::broadcaster::BroadcasterPayload;
+use simulator_core::broadcaster::{
+    BroadcasterEnvelope, BroadcasterPayload, BroadcasterSnapshotSessionResponse,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SessionCloseReason {
     Lagged,
+    Expired,
     GenerationReset,
     Shutdown,
 }
@@ -18,18 +24,27 @@ impl SessionCloseReason {
     const fn label(self) -> &'static str {
         match self {
             Self::Lagged => "lagged",
+            Self::Expired => "expired",
             Self::GenerationReset => "generation_reset",
             Self::Shutdown => "shutdown",
         }
     }
 }
 
-pub struct BroadcasterSessionRegistration {
+pub struct BroadcasterAttachedSession {
     pub session_id: u64,
     pub stream_id: String,
-    pub snapshot_payloads: Vec<BroadcasterPayload>,
+    pub next_message_seq: u64,
     pub receiver: mpsc::Receiver<BroadcasterPayload>,
     pub close_receiver: oneshot::Receiver<SessionCloseReason>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotSessionError {
+    NotFound,
+    Expired,
+    AlreadyAttached,
+    PayloadOutOfRange,
 }
 
 #[derive(Debug, Clone)]
@@ -39,12 +54,37 @@ pub struct BroadcasterSubscriberRegistry {
     lag_disconnects: Arc<AtomicU64>,
     last_error: Arc<Mutex<Option<String>>>,
     inner: Arc<Mutex<HashMap<u64, SubscriberHandle>>>,
+    pending_sessions: Arc<Mutex<HashMap<u64, PendingSnapshotSession>>>,
 }
 
 #[derive(Debug)]
 struct SubscriberHandle {
     sender: mpsc::Sender<BroadcasterPayload>,
     close_tx: Option<oneshot::Sender<SessionCloseReason>>,
+}
+
+#[derive(Debug)]
+struct PendingSnapshotSession {
+    stream_id: String,
+    snapshot_payloads: Vec<BroadcasterEnvelope>,
+    receiver: Option<mpsc::Receiver<BroadcasterPayload>>,
+    close_receiver: Option<oneshot::Receiver<SessionCloseReason>>,
+    expires_at: Instant,
+    attached: bool,
+}
+
+impl PendingSnapshotSession {
+    fn is_expired(&self, now: Instant) -> bool {
+        !self.attached && now >= self.expires_at
+    }
+
+    fn next_message_seq(&self) -> u64 {
+        self.snapshot_payloads
+            .len()
+            .saturating_add(1)
+            .try_into()
+            .unwrap_or(u64::MAX)
+    }
 }
 
 impl BroadcasterSubscriberRegistry {
@@ -55,16 +95,49 @@ impl BroadcasterSubscriberRegistry {
             lag_disconnects: Arc::new(AtomicU64::new(0)),
             last_error: Arc::new(Mutex::new(None)),
             inner: Arc::new(Mutex::new(HashMap::new())),
+            pending_sessions: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
-    pub async fn register(
+    pub async fn create_snapshot_session(
         &self,
         snapshot: BroadcasterSnapshotExport,
-    ) -> BroadcasterSessionRegistration {
+        chain_id: u64,
+        ttl: Duration,
+    ) -> Result<BroadcasterSnapshotSessionResponse> {
         let session_id = self.next_session_id.fetch_add(1, Ordering::Relaxed);
         let (sender, receiver) = mpsc::channel(self.buffer_capacity);
         let (close_tx, close_receiver) = oneshot::channel();
+        let stream_id = snapshot.stream_id;
+        let snapshot_id = snapshot.snapshot_id;
+        let max_payload_bytes = snapshot.max_payload_bytes;
+        let snapshot_chunk_count = snapshot
+            .payloads
+            .iter()
+            .filter(|payload| matches!(payload, BroadcasterPayload::SnapshotChunk(_)))
+            .count() as u32;
+        let mut message_seq = 1u64;
+        let snapshot_payloads = snapshot
+            .payloads
+            .into_iter()
+            .map(|payload| {
+                let envelope = BroadcasterEnvelope::new(stream_id.clone(), message_seq, payload);
+                message_seq = message_seq.saturating_add(1);
+                envelope
+            })
+            .collect::<Vec<_>>();
+        for (index, envelope) in snapshot_payloads.iter().enumerate() {
+            let bytes = serde_json::to_vec(envelope)
+                .with_context(|| format!("snapshot payload {index} is not JSON-serializable"))?;
+            anyhow::ensure!(
+                bytes.len() <= max_payload_bytes,
+                "snapshot payload {index} is {} bytes, above configured max {max_payload_bytes}",
+                bytes.len()
+            );
+        }
+        let payload_count = snapshot_payloads.len() as u32;
+        let expires_in_ms = ttl.as_millis().try_into().unwrap_or(u64::MAX);
+        let expires_at = Instant::now() + ttl;
 
         self.inner.lock().await.insert(
             session_id,
@@ -73,14 +146,102 @@ impl BroadcasterSubscriberRegistry {
                 close_tx: Some(close_tx),
             },
         );
-
-        BroadcasterSessionRegistration {
+        self.pending_sessions.lock().await.insert(
             session_id,
-            stream_id: snapshot.stream_id,
-            snapshot_payloads: snapshot.payloads,
-            receiver,
-            close_receiver,
+            PendingSnapshotSession {
+                stream_id: stream_id.clone(),
+                snapshot_payloads,
+                receiver: Some(receiver),
+                close_receiver: Some(close_receiver),
+                expires_at,
+                attached: false,
+            },
+        );
+
+        Ok(BroadcasterSnapshotSessionResponse {
+            chain_id,
+            session_id,
+            stream_id,
+            snapshot_id,
+            payload_count,
+            snapshot_chunk_count,
+            expires_in_ms,
+        })
+    }
+
+    pub async fn snapshot_payload(
+        &self,
+        session_id: u64,
+        index: u32,
+    ) -> Result<BroadcasterEnvelope, SnapshotSessionError> {
+        let expired = {
+            let now = Instant::now();
+            let mut guard = self.pending_sessions.lock().await;
+            let Some(session) = guard.get(&session_id) else {
+                return Err(SnapshotSessionError::NotFound);
+            };
+            if session.is_expired(now) {
+                guard.remove(&session_id);
+                true
+            } else if session.attached {
+                return Err(SnapshotSessionError::AlreadyAttached);
+            } else {
+                let Some(envelope) = session.snapshot_payloads.get(index as usize).cloned() else {
+                    return Err(SnapshotSessionError::PayloadOutOfRange);
+                };
+                return Ok(envelope);
+            }
+        };
+
+        if expired {
+            self.disconnect_subscriber(session_id, SessionCloseReason::Expired)
+                .await;
+            return Err(SnapshotSessionError::Expired);
         }
+
+        Err(SnapshotSessionError::NotFound)
+    }
+
+    pub async fn attach_snapshot_session(
+        &self,
+        session_id: u64,
+    ) -> Result<BroadcasterAttachedSession, SnapshotSessionError> {
+        let expired = {
+            let now = Instant::now();
+            let mut guard = self.pending_sessions.lock().await;
+            let Some(session) = guard.get_mut(&session_id) else {
+                return Err(SnapshotSessionError::NotFound);
+            };
+            if session.is_expired(now) {
+                guard.remove(&session_id);
+                true
+            } else if session.attached {
+                return Err(SnapshotSessionError::AlreadyAttached);
+            } else {
+                let Some(receiver) = session.receiver.take() else {
+                    return Err(SnapshotSessionError::AlreadyAttached);
+                };
+                let Some(close_receiver) = session.close_receiver.take() else {
+                    return Err(SnapshotSessionError::AlreadyAttached);
+                };
+                session.attached = true;
+                return Ok(BroadcasterAttachedSession {
+                    session_id,
+                    stream_id: session.stream_id.clone(),
+                    next_message_seq: session.next_message_seq(),
+                    receiver,
+                    close_receiver,
+                });
+            }
+        };
+
+        if expired {
+            self.disconnect_subscriber(session_id, SessionCloseReason::Expired)
+                .await;
+            return Err(SnapshotSessionError::Expired);
+        }
+
+        Err(SnapshotSessionError::NotFound)
     }
 
     pub async fn broadcast(&self, payload: BroadcasterPayload) {
@@ -112,10 +273,19 @@ impl BroadcasterSubscriberRegistry {
             }
         }
 
-        for session_id in lagged.into_iter().chain(closed) {
-            guard.remove(&session_id);
+        let removed_sessions = lagged
+            .iter()
+            .chain(closed.iter())
+            .copied()
+            .collect::<Vec<_>>();
+        for session_id in &removed_sessions {
+            guard.remove(session_id);
         }
         drop(guard);
+
+        if !removed_sessions.is_empty() {
+            self.remove_pending_sessions(&removed_sessions).await;
+        }
 
         if let Some(last_error) = last_error {
             self.record_last_error(last_error).await;
@@ -124,6 +294,27 @@ impl BroadcasterSubscriberRegistry {
 
     pub async fn remove(&self, session_id: u64) {
         self.inner.lock().await.remove(&session_id);
+        self.pending_sessions.lock().await.remove(&session_id);
+    }
+
+    pub async fn cleanup_expired_snapshot_sessions(&self) {
+        let now = Instant::now();
+        let expired = {
+            let mut guard = self.pending_sessions.lock().await;
+            let expired = guard
+                .iter()
+                .filter_map(|(session_id, session)| session.is_expired(now).then_some(*session_id))
+                .collect::<Vec<_>>();
+            for session_id in &expired {
+                guard.remove(session_id);
+            }
+            expired
+        };
+
+        for session_id in expired {
+            self.disconnect_subscriber(session_id, SessionCloseReason::Expired)
+                .await;
+        }
     }
 
     pub async fn disconnect_all(&self, reason: SessionCloseReason) {
@@ -135,6 +326,7 @@ impl BroadcasterSubscriberRegistry {
         }
         guard.clear();
         drop(guard);
+        self.pending_sessions.lock().await.clear();
 
         self.record_last_error(format!("all subscribers disconnected: {}", reason.label()))
             .await;
@@ -151,13 +343,37 @@ impl BroadcasterSubscriberRegistry {
     async fn record_last_error(&self, message: String) {
         *self.last_error.lock().await = Some(message);
     }
+
+    async fn disconnect_subscriber(&self, session_id: u64, reason: SessionCloseReason) {
+        let mut guard = self.inner.lock().await;
+        if let Some(mut handle) = guard.remove(&session_id) {
+            if let Some(close_tx) = handle.close_tx.take() {
+                let _ = close_tx.send(reason);
+            }
+        }
+        drop(guard);
+        self.record_last_error(format!(
+            "subscriber {session_id} disconnected: {}",
+            reason.label()
+        ))
+        .await;
+    }
+
+    async fn remove_pending_sessions(&self, session_ids: &[u64]) {
+        let mut guard = self.pending_sessions.lock().await;
+        for session_id in session_ids {
+            guard.remove(session_id);
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use anyhow::Result;
+    use std::time::Duration;
 
-    use super::{BroadcasterSubscriberRegistry, SessionCloseReason};
+    use anyhow::{anyhow, Result};
+
+    use super::{BroadcasterSubscriberRegistry, SessionCloseReason, SnapshotSessionError};
     use crate::models::broadcaster::BroadcasterSnapshotExport;
     use simulator_core::broadcaster::{
         BroadcasterPayload, BroadcasterSnapshotEnd, BroadcasterSnapshotStart,
@@ -166,6 +382,8 @@ mod tests {
     fn snapshot_export() -> BroadcasterSnapshotExport {
         BroadcasterSnapshotExport {
             stream_id: "stream-1".to_string(),
+            snapshot_id: "snapshot-1".to_string(),
+            max_payload_bytes: 8_388_608,
             payloads: vec![
                 BroadcasterPayload::SnapshotStart(
                     BroadcasterSnapshotStart::new("snapshot-1", 1, vec![], 0)
@@ -179,8 +397,20 @@ mod tests {
     #[tokio::test]
     async fn lagged_subscriber_is_disconnected_without_affecting_fast_peer() -> Result<()> {
         let registry = BroadcasterSubscriberRegistry::new(1);
-        let lagged = registry.register(snapshot_export()).await;
-        let mut fast = registry.register(snapshot_export()).await;
+        let lagged_session = registry
+            .create_snapshot_session(snapshot_export(), 1, Duration::from_secs(300))
+            .await?;
+        let fast_session = registry
+            .create_snapshot_session(snapshot_export(), 1, Duration::from_secs(300))
+            .await?;
+        let lagged = registry
+            .attach_snapshot_session(lagged_session.session_id)
+            .await
+            .map_err(|error| anyhow!("lagged attach failed: {error:?}"))?;
+        let mut fast = registry
+            .attach_snapshot_session(fast_session.session_id)
+            .await
+            .map_err(|error| anyhow!("fast attach failed: {error:?}"))?;
 
         registry
             .broadcast(BroadcasterPayload::SnapshotEnd(
@@ -210,7 +440,13 @@ mod tests {
     #[tokio::test]
     async fn disconnect_all_clears_registry() -> Result<()> {
         let registry = BroadcasterSubscriberRegistry::new(2);
-        let session = registry.register(snapshot_export()).await;
+        let session = registry
+            .create_snapshot_session(snapshot_export(), 1, Duration::from_secs(300))
+            .await?;
+        let session = registry
+            .attach_snapshot_session(session.session_id)
+            .await
+            .map_err(|error| anyhow!("attach failed: {error:?}"))?;
 
         registry
             .disconnect_all(SessionCloseReason::GenerationReset)
@@ -223,6 +459,57 @@ mod tests {
         assert_eq!(
             snapshot.last_error.as_deref(),
             Some("all subscribers disconnected: generation_reset")
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn pending_session_serves_payloads_then_attaches_once() -> Result<()> {
+        let registry = BroadcasterSubscriberRegistry::new(2);
+        let session = registry
+            .create_snapshot_session(snapshot_export(), 1, Duration::from_secs(300))
+            .await?;
+
+        let first = registry
+            .snapshot_payload(session.session_id, 0)
+            .await
+            .map_err(|error| anyhow!("payload fetch failed: {error:?}"))?;
+        assert_eq!(first.stream_id, "stream-1");
+        assert_eq!(first.message_seq, 1);
+        let attached = registry
+            .attach_snapshot_session(session.session_id)
+            .await
+            .map_err(|error| anyhow!("attach failed: {error:?}"))?;
+        assert_eq!(attached.next_message_seq, 3);
+
+        let Err(error) = registry.snapshot_payload(session.session_id, 0).await else {
+            unreachable!("attached session should not serve HTTP snapshot payloads");
+        };
+        assert_eq!(error, SnapshotSessionError::AlreadyAttached);
+        let Err(error) = registry.attach_snapshot_session(session.session_id).await else {
+            unreachable!("attached session should not attach twice");
+        };
+        assert_eq!(error, SnapshotSessionError::AlreadyAttached);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn expired_pending_session_disconnects_subscriber() -> Result<()> {
+        let registry = BroadcasterSubscriberRegistry::new(2);
+        let session = registry
+            .create_snapshot_session(snapshot_export(), 1, Duration::from_millis(1))
+            .await?;
+        tokio::time::sleep(Duration::from_millis(5)).await;
+
+        let Err(error) = registry.snapshot_payload(session.session_id, 0).await else {
+            unreachable!("expired session should fail payload fetch");
+        };
+        assert_eq!(error, SnapshotSessionError::Expired);
+        let snapshot = registry.snapshot().await;
+        assert_eq!(snapshot.active, 0);
+        assert_eq!(
+            snapshot.last_error.as_deref(),
+            Some("subscriber 1 disconnected: expired")
         );
         Ok(())
     }

--- a/crates/runtime/src/services/broadcaster_sessions.rs
+++ b/crates/runtime/src/services/broadcaster_sessions.rs
@@ -224,11 +224,13 @@ impl BroadcasterSubscriberRegistry {
                 let Some(close_receiver) = session.close_receiver.take() else {
                     return Err(SnapshotSessionError::AlreadyAttached);
                 };
+                let next_message_seq = session.next_message_seq();
+                drop(std::mem::take(&mut session.snapshot_payloads));
                 session.attached = true;
                 return Ok(BroadcasterAttachedSession {
                     session_id,
                     stream_id: session.stream_id.clone(),
-                    next_message_seq: session.next_message_seq(),
+                    next_message_seq,
                     receiver,
                     close_receiver,
                 });
@@ -490,6 +492,29 @@ mod tests {
             unreachable!("attached session should not attach twice");
         };
         assert_eq!(error, SnapshotSessionError::AlreadyAttached);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn attached_session_drops_http_snapshot_payloads() -> Result<()> {
+        let registry = BroadcasterSubscriberRegistry::new(2);
+        let session = registry
+            .create_snapshot_session(snapshot_export(), 1, Duration::from_secs(300))
+            .await?;
+
+        let attached = registry
+            .attach_snapshot_session(session.session_id)
+            .await
+            .map_err(|error| anyhow!("attach failed: {error:?}"))?;
+        assert_eq!(attached.next_message_seq, 3);
+
+        let guard = registry.pending_sessions.lock().await;
+        let pending = guard
+            .get(&session.session_id)
+            .ok_or_else(|| anyhow!("attached session should remain registered"))?;
+        assert!(pending.attached);
+        assert_eq!(pending.snapshot_payloads.len(), 0);
+        assert_eq!(pending.snapshot_payloads.capacity(), 0);
         Ok(())
     }
 

--- a/crates/runtime/src/services/broadcaster_subscription.rs
+++ b/crates/runtime/src/services/broadcaster_subscription.rs
@@ -1,4 +1,6 @@
-use std::collections::HashMap;
+use std::collections::{
+    btree_map::Entry as BTreeEntry, hash_map::Entry as HashEntry, BTreeMap, HashMap,
+};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -18,7 +20,7 @@ use tycho_simulation::{
     evm::engine_db::SHARED_TYCHO_DB,
     protocol::models::{ProtocolComponent, Update},
     tycho_client::feed::{BlockHeader, FeedMessage},
-    tycho_common::simulation::protocol_sim::ProtocolSim,
+    tycho_common::{dto::ResponseAccount, simulation::protocol_sim::ProtocolSim, Bytes},
 };
 
 use simulator_core::broadcaster::{
@@ -334,11 +336,247 @@ async fn restart_after_subscription_exit(
     (vm_rebuild, next_backoff(backoff, cfg.restart_backoff_max))
 }
 
+#[derive(Default)]
+struct RawSnapshotReassembly {
+    messages: BTreeMap<String, BroadcasterProtocolMessage>,
+}
+
+impl RawSnapshotReassembly {
+    fn reset(&mut self) {
+        self.messages.clear();
+    }
+
+    fn push(&mut self, message: BroadcasterProtocolMessage) -> Result<()> {
+        match self.messages.entry(message.protocol.clone()) {
+            BTreeEntry::Vacant(entry) => {
+                entry.insert(message);
+            }
+            BTreeEntry::Occupied(mut entry) => {
+                merge_snapshot_protocol_message(entry.get_mut(), message)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn take_messages(&mut self) -> Vec<BroadcasterProtocolMessage> {
+        std::mem::take(&mut self.messages).into_values().collect()
+    }
+}
+
+fn merge_snapshot_protocol_message(
+    existing: &mut BroadcasterProtocolMessage,
+    incoming: BroadcasterProtocolMessage,
+) -> Result<()> {
+    if existing.protocol != incoming.protocol {
+        return Err(anyhow!(
+            "broadcaster snapshot protocol mismatch: expected {}, got {}",
+            existing.protocol,
+            incoming.protocol
+        ));
+    }
+
+    ensure_raw_snapshot_fragment_identity(existing, &incoming)?;
+    ensure_raw_snapshot_fragment_conflicts(existing, &incoming)?;
+
+    let mut merged_vm_storage = std::mem::take(&mut existing.message.snapshots.vm_storage);
+    let mut incoming_message = incoming.message;
+    let incoming_vm_storage = std::mem::take(&mut incoming_message.snapshots.vm_storage);
+    merge_vm_storage(&mut merged_vm_storage, incoming_vm_storage)?;
+
+    let mut merged_message = existing.message.clone().merge(incoming_message);
+    merged_message.snapshots.vm_storage = merged_vm_storage;
+    existing.message = merged_message;
+    Ok(())
+}
+
+fn ensure_raw_snapshot_fragment_identity(
+    existing: &BroadcasterProtocolMessage,
+    incoming: &BroadcasterProtocolMessage,
+) -> Result<()> {
+    if existing.message.header != incoming.message.header {
+        return Err(anyhow!(
+            "broadcaster snapshot raw fragment header mismatch for protocol {}: expected {:?}, got {:?}",
+            existing.protocol,
+            existing.message.header,
+            incoming.message.header
+        ));
+    }
+
+    if existing.sync_state != incoming.sync_state {
+        return Err(anyhow!(
+            "broadcaster snapshot raw fragment sync_state mismatch for protocol {}: expected {:?}, got {:?}",
+            existing.protocol,
+            existing.sync_state,
+            incoming.sync_state
+        ));
+    }
+
+    Ok(())
+}
+
+fn ensure_raw_snapshot_fragment_conflicts(
+    existing: &BroadcasterProtocolMessage,
+    incoming: &BroadcasterProtocolMessage,
+) -> Result<()> {
+    ensure_no_duplicate_ids(
+        &existing.protocol,
+        &existing.message.snapshots.states,
+        &incoming.message.snapshots.states,
+        "snapshot state",
+    )?;
+    ensure_no_duplicate_ids(
+        &existing.protocol,
+        &existing.message.removed_components,
+        &incoming.message.removed_components,
+        "removed component",
+    )?;
+    ensure_no_snapshot_removal_overlap(
+        &existing.protocol,
+        &existing.message.snapshots.states,
+        &existing.message.removed_components,
+    )?;
+    ensure_no_snapshot_removal_overlap(
+        &existing.protocol,
+        &incoming.message.snapshots.states,
+        &incoming.message.removed_components,
+    )?;
+    ensure_no_snapshot_removal_overlap(
+        &existing.protocol,
+        &existing.message.snapshots.states,
+        &incoming.message.removed_components,
+    )?;
+    ensure_no_snapshot_removal_overlap(
+        &existing.protocol,
+        &incoming.message.snapshots.states,
+        &existing.message.removed_components,
+    )?;
+
+    Ok(())
+}
+
+fn ensure_no_duplicate_ids<Existing, Incoming>(
+    protocol: &str,
+    existing: &HashMap<String, Existing>,
+    incoming: &HashMap<String, Incoming>,
+    kind: &str,
+) -> Result<()> {
+    for component_id in incoming.keys() {
+        if existing.contains_key(component_id) {
+            return Err(anyhow!(
+                "broadcaster snapshot raw fragment duplicate {kind} for protocol {protocol}: {component_id}"
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn ensure_no_snapshot_removal_overlap<State, Removed>(
+    protocol: &str,
+    snapshots: &HashMap<String, State>,
+    removals: &HashMap<String, Removed>,
+) -> Result<()> {
+    for component_id in snapshots.keys() {
+        if removals.contains_key(component_id) {
+            return Err(anyhow!(
+                "broadcaster snapshot raw fragment snapshot/removal overlap for protocol {protocol}: {component_id}"
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn merge_vm_storage(
+    existing: &mut HashMap<Bytes, ResponseAccount>,
+    incoming: HashMap<Bytes, ResponseAccount>,
+) -> Result<()> {
+    for (address, account) in incoming {
+        match existing.entry(address.clone()) {
+            HashEntry::Vacant(entry) => {
+                entry.insert(account);
+            }
+            HashEntry::Occupied(mut entry) => {
+                merge_vm_storage_account(&address, entry.get_mut(), account)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn merge_vm_storage_account(
+    address: &Bytes,
+    existing: &mut ResponseAccount,
+    incoming: ResponseAccount,
+) -> Result<()> {
+    ensure_vm_account_metadata_matches(address, existing, &incoming)?;
+    for (slot, value) in incoming.slots {
+        match existing.slots.entry(slot.clone()) {
+            HashEntry::Vacant(entry) => {
+                entry.insert(value);
+            }
+            HashEntry::Occupied(entry) if entry.get() == &value => {}
+            HashEntry::Occupied(_) => {
+                return Err(anyhow!(
+                    "broadcaster snapshot VM storage slot mismatch for account {} slot {}",
+                    address,
+                    slot
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[expect(
+    deprecated,
+    reason = "creation_tx is deprecated but still part of the broadcaster wire DTO"
+)]
+fn ensure_vm_account_metadata_matches(
+    address: &Bytes,
+    existing: &ResponseAccount,
+    incoming: &ResponseAccount,
+) -> Result<()> {
+    let mismatch = if existing.chain != incoming.chain {
+        Some("chain")
+    } else if existing.address != incoming.address {
+        Some("address")
+    } else if existing.title != incoming.title {
+        Some("title")
+    } else if existing.native_balance != incoming.native_balance {
+        Some("native_balance")
+    } else if existing.token_balances != incoming.token_balances {
+        Some("token_balances")
+    } else if existing.code != incoming.code {
+        Some("code")
+    } else if existing.code_hash != incoming.code_hash {
+        Some("code_hash")
+    } else if existing.balance_modify_tx != incoming.balance_modify_tx {
+        Some("balance_modify_tx")
+    } else if existing.code_modify_tx != incoming.code_modify_tx {
+        Some("code_modify_tx")
+    } else if existing.creation_tx != incoming.creation_tx {
+        Some("creation_tx")
+    } else {
+        None
+    };
+
+    if let Some(field) = mismatch {
+        return Err(anyhow!(
+            "broadcaster snapshot VM storage metadata mismatch for account {} field {}",
+            address,
+            field
+        ));
+    }
+    Ok(())
+}
+
 struct BroadcasterSubscriptionProcessor {
     expected_chain_id: u64,
     controls: BroadcasterSubscriptionControls,
     decoder: Arc<TychoStreamDecoder<BlockHeader>>,
     tracker: BroadcasterSubscriptionTracker,
+    raw_snapshot: RawSnapshotReassembly,
     bootstrap_block: Option<u64>,
     vm_rebuild: Option<VmSubscriptionRebuildState>,
 }
@@ -369,6 +607,7 @@ impl BroadcasterSubscriptionProcessor {
             controls,
             decoder,
             tracker: BroadcasterSubscriptionTracker::new(),
+            raw_snapshot: RawSnapshotReassembly::default(),
             bootstrap_block: None,
             vm_rebuild,
         }
@@ -393,6 +632,7 @@ impl BroadcasterSubscriptionProcessor {
         match envelope.payload {
             BroadcasterPayload::SnapshotStart(start) => {
                 self.bootstrap_block = None;
+                self.raw_snapshot.reset();
                 self.controls
                     .broadcaster_subscription()
                     .mark_snapshot_started(envelope.stream_id, start.snapshot_id)
@@ -402,11 +642,12 @@ impl BroadcasterSubscriptionProcessor {
                 for partition in chunk.partitions {
                     if partition.backend == self.controls.backend() {
                         self.bootstrap_block = Some(partition.block_number);
-                        self.apply_snapshot_partition(partition).await?;
+                        self.buffer_snapshot_partition(partition).await?;
                     }
                 }
             }
             BroadcasterPayload::SnapshotEnd(_end) => {
+                self.apply_reassembled_snapshot_messages().await?;
                 self.refresh_bootstrap_health().await;
                 self.controls
                     .broadcaster_subscription()
@@ -464,12 +705,33 @@ impl BroadcasterSubscriptionProcessor {
         partition: BroadcasterSnapshotPartition,
     ) -> Result<()> {
         if !partition.messages.is_empty() {
-            return self.apply_protocol_messages(partition.messages).await;
+            return Err(anyhow!(
+                "raw broadcaster snapshot messages cannot be applied without reassembly"
+            ));
         }
 
         let update = snapshot_partition_update(partition);
         self.controls.state_store().apply_update(update).await;
         Ok(())
+    }
+
+    async fn buffer_snapshot_partition(
+        &mut self,
+        partition: BroadcasterSnapshotPartition,
+    ) -> Result<()> {
+        if partition.messages.is_empty() {
+            return self.apply_snapshot_partition(partition).await;
+        }
+
+        for message in partition.messages {
+            self.raw_snapshot.push(message)?;
+        }
+        Ok(())
+    }
+
+    async fn apply_reassembled_snapshot_messages(&mut self) -> Result<()> {
+        let messages = self.raw_snapshot.take_messages();
+        self.apply_protocol_messages(messages).await
     }
 
     async fn apply_live_update_partition(
@@ -874,7 +1136,7 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use anyhow::Result;
+    use anyhow::{anyhow, Result};
     use num_bigint::BigUint;
     use reqwest::Client;
     use tokio::{
@@ -886,8 +1148,20 @@ mod tests {
     use tycho_simulation::tycho_common::dto::ProtocolStateDelta;
     use tycho_simulation::tycho_common::simulation::errors::{SimulationError, TransitionError};
     use tycho_simulation::{
-        protocol::models::ProtocolComponent,
+        evm::decoder::TychoStreamDecoder,
+        protocol::{
+            errors::InvalidSnapshotError,
+            models::{DecoderContext, ProtocolComponent, TryFromWithBlock},
+        },
+        tycho_client::feed::{
+            synchronizer::{ComponentWithState, Snapshot, StateSyncMessage},
+            BlockHeader, SynchronizerState,
+        },
         tycho_common::{
+            dto::{
+                Chain as DtoChain, ProtocolComponent as DtoProtocolComponent, ResponseAccount,
+                ResponseProtocolState,
+            },
             models::{token::Token, Chain},
             simulation::protocol_sim::{Balances, GetAmountOutResult, ProtocolSim},
             Bytes,
@@ -897,7 +1171,7 @@ mod tests {
     use super::{
         bootstrap_broadcaster_snapshot, handle_subscription_reset, BroadcasterSubscriptionControls,
         BroadcasterSubscriptionProcessor, NativeBroadcasterSubscriptionControls,
-        VmBroadcasterSubscriptionControls,
+        RawSnapshotReassembly, VmBroadcasterSubscriptionControls,
     };
     use crate::config::MemoryConfig;
     use crate::models::state::{BroadcasterSubscriptionStatus, StateStore, VmStreamStatus};
@@ -906,9 +1180,10 @@ mod tests {
     use crate::stream::StreamSupervisorConfig;
     use simulator_core::broadcaster::{
         BroadcasterBackend, BroadcasterBackendHead, BroadcasterEnvelope, BroadcasterHeartbeat,
-        BroadcasterPayload, BroadcasterSnapshotChunk, BroadcasterSnapshotEnd,
-        BroadcasterSnapshotPartition, BroadcasterSnapshotStart, BroadcasterStateDelta,
-        BroadcasterStateEntry, BroadcasterUpdateMessage, BroadcasterUpdatePartition,
+        BroadcasterPayload, BroadcasterProtocolMessage, BroadcasterSnapshotChunk,
+        BroadcasterSnapshotEnd, BroadcasterSnapshotPartition, BroadcasterSnapshotStart,
+        BroadcasterStateDelta, BroadcasterStateEntry, BroadcasterUpdateMessage,
+        BroadcasterUpdatePartition,
     };
 
     #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
@@ -972,6 +1247,20 @@ mod tests {
                 .downcast_ref::<DummySim>()
                 .map(|value| value.0 == self.0)
                 .unwrap_or(false)
+        }
+    }
+
+    impl TryFromWithBlock<ComponentWithState, BlockHeader> for DummySim {
+        type Error = InvalidSnapshotError;
+
+        async fn try_from_with_header(
+            _snapshot: ComponentWithState,
+            _block: BlockHeader,
+            _account_balances: &HashMap<Bytes, HashMap<Bytes, Bytes>>,
+            _all_tokens: &HashMap<Bytes, Token>,
+            _decoder_context: &DecoderContext,
+        ) -> std::result::Result<Self, Self::Error> {
+            Ok(Self(0))
         }
     }
 
@@ -1196,6 +1485,49 @@ mod tests {
         ))
     }
 
+    fn vm_only_snapshot_start_envelope(total_chunks: u32) -> Result<BroadcasterEnvelope> {
+        Ok(BroadcasterEnvelope::new(
+            "stream-1",
+            1,
+            BroadcasterPayload::SnapshotStart(BroadcasterSnapshotStart::new(
+                "snapshot-1",
+                Chain::Ethereum.id(),
+                vec![BroadcasterBackend::Vm],
+                total_chunks,
+            )?),
+        ))
+    }
+
+    fn raw_snapshot_chunk_envelope(
+        message_seq: u64,
+        chunk_index: u32,
+        block_number: u64,
+        messages: Vec<BroadcasterProtocolMessage>,
+    ) -> Result<BroadcasterEnvelope> {
+        Ok(BroadcasterEnvelope::new(
+            "stream-1",
+            message_seq,
+            BroadcasterPayload::SnapshotChunk(BroadcasterSnapshotChunk::new(
+                "snapshot-1",
+                chunk_index,
+                vec![BroadcasterSnapshotPartition::with_messages(
+                    BroadcasterBackend::Vm,
+                    block_number,
+                    messages,
+                    BTreeMap::new(),
+                )],
+            )?),
+        ))
+    }
+
+    fn snapshot_end_envelope_at(message_seq: u64) -> BroadcasterEnvelope {
+        BroadcasterEnvelope::new(
+            "stream-1",
+            message_seq,
+            BroadcasterPayload::SnapshotEnd(BroadcasterSnapshotEnd::new("snapshot-1")),
+        )
+    }
+
     async fn spawn_snapshot_session_server(
         payloads: Vec<BroadcasterEnvelope>,
     ) -> Result<(String, String, JoinHandle<()>)> {
@@ -1304,6 +1636,180 @@ mod tests {
         }
     }
 
+    fn raw_decoder() -> Arc<TychoStreamDecoder<BlockHeader>> {
+        let mut decoder = TychoStreamDecoder::new();
+        decoder.register_decoder::<DummySim>("vm:curve");
+        Arc::new(decoder)
+    }
+
+    #[test]
+    fn raw_snapshot_reassembly_merges_split_vm_storage_account() -> Result<()> {
+        let account_address = Bytes::from([42u8; 20]);
+        let mut reassembly = RawSnapshotReassembly::default();
+        reassembly.push(raw_protocol_message(
+            account_address.clone(),
+            raw_response_account(account_address.clone(), "vm-account", &[(1, 11)]),
+        ))?;
+        reassembly.push(raw_protocol_message(
+            account_address.clone(),
+            raw_response_account(account_address.clone(), "vm-account", &[(2, 22), (3, 33)]),
+        ))?;
+
+        let messages = reassembly.take_messages();
+        assert_eq!(messages.len(), 1);
+        let account = messages[0]
+            .message
+            .snapshots
+            .vm_storage
+            .get(&account_address)
+            .ok_or_else(|| anyhow!("expected reassembled VM account"))?;
+        assert_eq!(account.slots.len(), 3);
+        assert_eq!(
+            account.slots[&Bytes::from([1u8; 32])],
+            Bytes::from([11u8; 32])
+        );
+        assert_eq!(
+            account.slots[&Bytes::from([2u8; 32])],
+            Bytes::from([22u8; 32])
+        );
+        assert_eq!(
+            account.slots[&Bytes::from([3u8; 32])],
+            Bytes::from([33u8; 32])
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn raw_snapshot_reassembly_rejects_metadata_mismatch() -> Result<()> {
+        let account_address = Bytes::from([42u8; 20]);
+        let mut reassembly = RawSnapshotReassembly::default();
+        reassembly.push(raw_protocol_message(
+            account_address.clone(),
+            raw_response_account(account_address.clone(), "vm-account", &[(1, 11)]),
+        ))?;
+
+        let Err(error) = reassembly.push(raw_protocol_message(
+            account_address.clone(),
+            raw_response_account(account_address, "changed-title", &[(2, 22)]),
+        )) else {
+            return Err(anyhow!("metadata mismatch should fail"));
+        };
+
+        assert!(error
+            .to_string()
+            .contains("broadcaster snapshot VM storage metadata mismatch"));
+        Ok(())
+    }
+
+    #[test]
+    fn raw_snapshot_reassembly_rejects_header_mismatch() -> Result<()> {
+        let mut reassembly = RawSnapshotReassembly::default();
+        let sync_header = raw_block_header(10, 1);
+        reassembly.push(raw_protocol_message_with_header(
+            sync_header.clone(),
+            SynchronizerState::Ready(sync_header.clone()),
+        ))?;
+
+        let Err(error) = reassembly.push(raw_protocol_message_with_header(
+            raw_block_header(11, 2),
+            SynchronizerState::Ready(sync_header),
+        )) else {
+            return Err(anyhow!("header mismatch should fail"));
+        };
+
+        assert!(error.to_string().contains("header mismatch"));
+        Ok(())
+    }
+
+    #[test]
+    fn raw_snapshot_reassembly_rejects_sync_state_mismatch() -> Result<()> {
+        let mut reassembly = RawSnapshotReassembly::default();
+        let header = raw_block_header(10, 1);
+        reassembly.push(raw_protocol_message_with_header(
+            header.clone(),
+            SynchronizerState::Ready(header.clone()),
+        ))?;
+
+        let Err(error) = reassembly.push(raw_protocol_message_with_header(
+            header.clone(),
+            SynchronizerState::Delayed(header),
+        )) else {
+            return Err(anyhow!("sync_state mismatch should fail"));
+        };
+
+        assert!(error.to_string().contains("sync_state mismatch"));
+        Ok(())
+    }
+
+    #[test]
+    fn raw_snapshot_reassembly_rejects_duplicate_snapshot_state_conflict() -> Result<()> {
+        let mut reassembly = RawSnapshotReassembly::default();
+        reassembly.push(raw_protocol_message_with_ids(&["pool-a"], &[]))?;
+
+        let Err(error) = reassembly.push(raw_protocol_message_with_ids(&["pool-a"], &[])) else {
+            return Err(anyhow!("duplicate snapshot state should fail"));
+        };
+
+        assert!(error.to_string().contains("duplicate snapshot state"));
+        Ok(())
+    }
+
+    #[test]
+    fn raw_snapshot_reassembly_rejects_duplicate_removal_conflict() -> Result<()> {
+        let mut reassembly = RawSnapshotReassembly::default();
+        reassembly.push(raw_protocol_message_with_ids(&[], &["pool-a"]))?;
+
+        let Err(error) = reassembly.push(raw_protocol_message_with_ids(&[], &["pool-a"])) else {
+            return Err(anyhow!("duplicate removal should fail"));
+        };
+
+        assert!(error.to_string().contains("duplicate removed component"));
+        Ok(())
+    }
+
+    #[test]
+    fn raw_snapshot_reassembly_rejects_snapshot_removal_overlap() -> Result<()> {
+        let mut reassembly = RawSnapshotReassembly::default();
+        reassembly.push(raw_protocol_message_with_ids(&["pool-a"], &[]))?;
+
+        let Err(error) = reassembly.push(raw_protocol_message_with_ids(&[], &["pool-a"])) else {
+            return Err(anyhow!("snapshot/removal overlap should fail"));
+        };
+
+        assert!(error.to_string().contains("snapshot/removal overlap"));
+        Ok(())
+    }
+
+    #[test]
+    fn raw_snapshot_reassembly_happy_path_preserves_header_and_sync_state() -> Result<()> {
+        let header = raw_block_header(10, 1);
+        let sync_state = SynchronizerState::Ready(header.clone());
+        let mut reassembly = RawSnapshotReassembly::default();
+        reassembly.push(raw_protocol_message_with_parts(
+            header.clone(),
+            sync_state.clone(),
+            &["pool-a"],
+            &[],
+            HashMap::new(),
+        ))?;
+        reassembly.push(raw_protocol_message_with_parts(
+            header.clone(),
+            sync_state.clone(),
+            &[],
+            &["pool-b"],
+            HashMap::new(),
+        ))?;
+
+        let messages = reassembly.take_messages();
+        assert_eq!(messages.len(), 1);
+        let message = &messages[0];
+        assert_eq!(message.message.header, header);
+        assert_eq!(message.sync_state, sync_state);
+        assert!(message.message.snapshots.states.contains_key("pool-a"));
+        assert!(message.message.removed_components.contains_key("pool-b"));
+        Ok(())
+    }
+
     #[tokio::test]
     async fn snapshot_bootstrap_populates_native_and_vm_separately() -> Result<()> {
         let controls = TestControls::new();
@@ -1388,6 +1894,166 @@ mod tests {
         assert!(!controls.native_state_store.has_pool("pool-native").await);
         assert!(!controls.native_state_store.has_pool("pool-vm").await);
         let snapshot = controls.native_subscription.snapshot().await;
+        assert!(snapshot.connected);
+        assert!(snapshot.bootstrap_complete);
+        assert_eq!(snapshot.stream_id.as_deref(), Some("stream-1"));
+        assert_eq!(snapshot.snapshot_id.as_deref(), Some("snapshot-1"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn raw_snapshot_bootstrap_buffers_split_messages_until_snapshot_end() -> Result<()> {
+        let controls = TestControls::new();
+        let vm_controls = controls.vm();
+        let mut processor = BroadcasterSubscriptionProcessor::with_decoder(
+            Chain::Ethereum.id(),
+            vm_controls,
+            raw_decoder(),
+            None,
+        );
+        let header = raw_block_header(21, 9);
+        let sync_state = SynchronizerState::Ready(header.clone());
+
+        processor
+            .observe(vm_only_snapshot_start_envelope(2)?)
+            .await?;
+        processor
+            .observe(raw_snapshot_chunk_envelope(
+                2,
+                0,
+                21,
+                vec![raw_protocol_message_with_parts(
+                    header.clone(),
+                    sync_state.clone(),
+                    &["0x1111111111111111111111111111111111111111"],
+                    &[],
+                    HashMap::new(),
+                )],
+            )?)
+            .await?;
+
+        assert!(!processor.bootstrap_complete());
+        assert!(
+            !controls
+                .vm_state_store
+                .has_pool("0x1111111111111111111111111111111111111111")
+                .await
+        );
+        assert_eq!(controls.vm_state_store.current_block().await, 0);
+        assert_eq!(controls.vm_stream_health.last_block().await, 0);
+
+        processor
+            .observe(raw_snapshot_chunk_envelope(
+                3,
+                1,
+                21,
+                vec![raw_protocol_message_with_parts(
+                    header,
+                    sync_state,
+                    &["0x2222222222222222222222222222222222222222"],
+                    &[],
+                    HashMap::new(),
+                )],
+            )?)
+            .await?;
+
+        assert!(!processor.bootstrap_complete());
+        assert!(
+            !controls
+                .vm_state_store
+                .has_pool("0x1111111111111111111111111111111111111111")
+                .await
+        );
+        assert!(
+            !controls
+                .vm_state_store
+                .has_pool("0x2222222222222222222222222222222222222222")
+                .await
+        );
+        assert_eq!(controls.vm_state_store.current_block().await, 0);
+        assert_eq!(controls.vm_stream_health.last_block().await, 0);
+
+        processor.observe(snapshot_end_envelope_at(4)).await?;
+
+        let snapshot = controls.vm_subscription.snapshot().await;
+        assert!(snapshot.connected);
+        assert!(snapshot.bootstrap_complete);
+        assert!(processor.bootstrap_complete());
+        assert!(
+            controls
+                .vm_state_store
+                .has_pool("0x1111111111111111111111111111111111111111")
+                .await
+        );
+        assert!(
+            controls
+                .vm_state_store
+                .has_pool("0x2222222222222222222222222222222222222222")
+                .await
+        );
+        assert_eq!(controls.vm_state_store.current_block().await, 21);
+        assert_eq!(controls.vm_stream_health.last_block().await, 21);
+        assert!(controls
+            .vm_stream_health
+            .last_update_age_ms()
+            .await
+            .is_some());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn http_snapshot_bootstrap_decodes_unsplit_raw_message() -> Result<()> {
+        let controls = TestControls::new();
+        let vm_controls = controls.vm();
+        let mut processor = BroadcasterSubscriptionProcessor::with_decoder(
+            Chain::Ethereum.id(),
+            vm_controls.clone(),
+            raw_decoder(),
+            None,
+        );
+        let header = raw_block_header(30, 10);
+        let payloads = vec![
+            vm_only_snapshot_start_envelope(1)?,
+            raw_snapshot_chunk_envelope(
+                2,
+                0,
+                30,
+                vec![raw_protocol_message_with_parts(
+                    header.clone(),
+                    SynchronizerState::Ready(header),
+                    &["0x3333333333333333333333333333333333333333"],
+                    &[],
+                    HashMap::new(),
+                )],
+            )?,
+            snapshot_end_envelope_at(3),
+        ];
+        let (ws_url, snapshot_sessions_url, server_task) =
+            spawn_snapshot_session_server(payloads).await?;
+
+        let session = bootstrap_broadcaster_snapshot(
+            &Client::new(),
+            &ws_url,
+            &snapshot_sessions_url,
+            &mut processor,
+            &vm_controls,
+            &test_supervisor_config(),
+        )
+        .await?;
+        server_task.abort();
+
+        assert_eq!(session.session_id, 7);
+        assert!(processor.bootstrap_complete());
+        assert!(
+            controls
+                .vm_state_store
+                .has_pool("0x3333333333333333333333333333333333333333")
+                .await
+        );
+        assert_eq!(controls.vm_state_store.current_block().await, 30);
+        assert_eq!(controls.vm_stream_health.last_block().await, 30);
+
+        let snapshot = controls.vm_subscription.snapshot().await;
         assert!(snapshot.connected);
         assert!(snapshot.bootstrap_complete);
         assert_eq!(snapshot.stream_id.as_deref(), Some("stream-1"));
@@ -1608,5 +2274,146 @@ mod tests {
             .await
             .is_some());
         Ok(())
+    }
+
+    fn raw_protocol_message(
+        account_address: Bytes,
+        account: ResponseAccount,
+    ) -> BroadcasterProtocolMessage {
+        let header = raw_block_header(10, 1);
+        raw_protocol_message_with_parts(
+            header.clone(),
+            SynchronizerState::Ready(header),
+            &[],
+            &[],
+            HashMap::from([(account_address, account)]),
+        )
+    }
+
+    fn raw_protocol_message_with_ids(
+        state_ids: &[&str],
+        removal_ids: &[&str],
+    ) -> BroadcasterProtocolMessage {
+        let header = raw_block_header(10, 1);
+        raw_protocol_message_with_parts(
+            header.clone(),
+            SynchronizerState::Ready(header),
+            state_ids,
+            removal_ids,
+            HashMap::new(),
+        )
+    }
+
+    fn raw_protocol_message_with_header(
+        header: BlockHeader,
+        sync_state: SynchronizerState,
+    ) -> BroadcasterProtocolMessage {
+        raw_protocol_message_with_parts(header, sync_state, &[], &[], HashMap::new())
+    }
+
+    fn raw_protocol_message_with_parts(
+        header: BlockHeader,
+        sync_state: SynchronizerState,
+        state_ids: &[&str],
+        removal_ids: &[&str],
+        vm_storage: HashMap<Bytes, ResponseAccount>,
+    ) -> BroadcasterProtocolMessage {
+        BroadcasterProtocolMessage::new(
+            "vm:curve",
+            sync_state,
+            StateSyncMessage {
+                header,
+                snapshots: Snapshot {
+                    states: state_ids
+                        .iter()
+                        .map(|component_id| {
+                            (
+                                (*component_id).to_string(),
+                                raw_component_with_state(component_id),
+                            )
+                        })
+                        .collect(),
+                    vm_storage,
+                },
+                deltas: None,
+                removed_components: removal_ids
+                    .iter()
+                    .map(|component_id| {
+                        (
+                            (*component_id).to_string(),
+                            raw_dto_protocol_component(component_id),
+                        )
+                    })
+                    .collect(),
+            },
+        )
+    }
+
+    fn raw_component_with_state(component_id: &str) -> ComponentWithState {
+        ComponentWithState {
+            state: ResponseProtocolState {
+                component_id: component_id.to_string(),
+                attributes: HashMap::new(),
+                balances: HashMap::new(),
+            },
+            component: raw_dto_protocol_component(component_id),
+            component_tvl: None,
+            entrypoints: Vec::new(),
+        }
+    }
+
+    fn raw_dto_protocol_component(component_id: &str) -> DtoProtocolComponent {
+        DtoProtocolComponent {
+            id: component_id.to_string(),
+            protocol_system: "vm:curve".to_string(),
+            protocol_type_name: "curve_pool".to_string(),
+            chain: DtoChain::Ethereum,
+            tokens: Vec::new(),
+            contract_ids: Vec::new(),
+            static_attributes: HashMap::new(),
+            change: Default::default(),
+            creation_tx: Bytes::from([0u8; 32]),
+            created_at: chrono::NaiveDateTime::default(),
+        }
+    }
+
+    fn raw_block_header(number: u64, seed: u8) -> BlockHeader {
+        BlockHeader {
+            hash: Bytes::from(vec![seed; 32]),
+            number,
+            parent_hash: Bytes::from(vec![seed.saturating_add(1); 32]),
+            revert: false,
+            timestamp: number * 10,
+            partial_block_index: None,
+        }
+    }
+
+    fn raw_response_account(
+        address: Bytes,
+        title: &str,
+        slot_values: &[(u8, u8)],
+    ) -> ResponseAccount {
+        let slots = slot_values
+            .iter()
+            .map(|(slot_seed, value_seed)| {
+                (
+                    Bytes::from([*slot_seed; 32]),
+                    Bytes::from([*value_seed; 32]),
+                )
+            })
+            .collect();
+        ResponseAccount::new(
+            DtoChain::Ethereum,
+            address,
+            title.to_string(),
+            slots,
+            Bytes::from([0u8; 32]),
+            HashMap::new(),
+            Bytes::from([7u8; 32]),
+            Bytes::from([8u8; 32]),
+            Bytes::from([9u8; 32]),
+            Bytes::from([10u8; 32]),
+            None,
+        )
     }
 }

--- a/crates/runtime/src/services/broadcaster_subscription.rs
+++ b/crates/runtime/src/services/broadcaster_subscription.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use anyhow::{anyhow, Result};
 use futures::StreamExt;
 use rand::Rng;
+use reqwest::{Client, StatusCode};
 use tokio::sync::{OwnedRwLockWriteGuard, RwLock};
 use tokio::time::{timeout, Instant};
 use tokio_tungstenite::{
@@ -13,20 +14,30 @@ use tokio_tungstenite::{
 };
 use tracing::{info, warn};
 use tycho_simulation::{
+    evm::decoder::TychoStreamDecoder,
     evm::engine_db::SHARED_TYCHO_DB,
     protocol::models::{ProtocolComponent, Update},
+    tycho_client::feed::{BlockHeader, FeedMessage},
     tycho_common::simulation::protocol_sim::ProtocolSim,
 };
 
 use simulator_core::broadcaster::{
     BroadcasterBackend, BroadcasterBackendHead, BroadcasterEnvelope, BroadcasterPayload,
-    BroadcasterSnapshotPartition, BroadcasterSubscriptionTracker, BroadcasterUpdatePartition,
+    BroadcasterProtocolMessage, BroadcasterSnapshotPartition, BroadcasterSnapshotSessionResponse,
+    BroadcasterSubscriptionTracker, BroadcasterUpdatePartition,
 };
 
 use crate::memory::maybe_purge_allocator;
+use crate::models::broadcaster_urls::{
+    derive_broadcaster_http_url, derive_broadcaster_session_ws_url,
+};
 use crate::models::state::{BroadcasterSubscriptionStatus, StateStore, VmStreamStatus};
 use crate::models::stream_health::StreamHealth;
+use crate::models::tokens::TokenStore;
+use crate::services::stream_builder::build_broadcaster_subscription_decoder;
 use crate::stream::StreamSupervisorConfig;
+
+const SNAPSHOT_DOWNLOAD_CONCURRENCY: usize = 4;
 
 #[derive(Clone)]
 pub enum BroadcasterSubscriptionControls {
@@ -39,6 +50,8 @@ pub struct NativeBroadcasterSubscriptionControls {
     pub broadcaster_subscription: BroadcasterSubscriptionStatus,
     pub state_store: Arc<StateStore>,
     pub stream_health: Arc<StreamHealth>,
+    pub tokens: Arc<TokenStore>,
+    pub protocols: Vec<String>,
 }
 
 #[derive(Clone)]
@@ -46,6 +59,8 @@ pub struct VmBroadcasterSubscriptionControls {
     pub broadcaster_subscription: BroadcasterSubscriptionStatus,
     pub state_store: Arc<StateStore>,
     pub stream_health: Arc<StreamHealth>,
+    pub tokens: Arc<TokenStore>,
+    pub protocols: Vec<String>,
     pub vm_stream: Arc<RwLock<VmStreamStatus>>,
     pub simulation_rebuild_gate: Arc<RwLock<()>>,
 }
@@ -82,6 +97,20 @@ impl BroadcasterSubscriptionControls {
             Self::Vm(controls) => &controls.stream_health,
         }
     }
+
+    fn tokens(&self) -> Arc<TokenStore> {
+        match self {
+            Self::Native(controls) => Arc::clone(&controls.tokens),
+            Self::Vm(controls) => Arc::clone(&controls.tokens),
+        }
+    }
+
+    fn protocols(&self) -> &[String] {
+        match self {
+            Self::Native(controls) => &controls.protocols,
+            Self::Vm(controls) => &controls.protocols,
+        }
+    }
 }
 
 pub async fn supervise_broadcaster_subscription(
@@ -92,78 +121,253 @@ pub async fn supervise_broadcaster_subscription(
 ) {
     let mut backoff = cfg.restart_backoff_min;
     let mut vm_rebuild = None;
+    let client = Client::new();
 
     loop {
-        let stream = match connect_async(ws_url.as_str()).await {
-            Ok((stream, _response)) => {
-                controls.broadcaster_subscription().mark_connected().await;
-                controls.stream_health().mark_started().await;
-                stream
+        let bootstrap = match prepare_broadcaster_subscription(
+            &client,
+            &ws_url,
+            expected_chain_id,
+            &cfg,
+            &controls,
+            vm_rebuild,
+        )
+        .await
+        {
+            Ok(bootstrap) => bootstrap,
+            Err(error) => {
+                (vm_rebuild, backoff) = reset_subscription_after_error(
+                    &controls,
+                    &cfg,
+                    backoff,
+                    error.vm_rebuild,
+                    error.message,
+                    error.event,
+                    error.detail,
+                )
+                .await;
+                continue;
             }
+        };
+
+        let stream = match connect_async(bootstrap.session_ws_url.as_str()).await {
+            Ok((stream, _response)) => stream,
             Err(error) => {
                 let message = format!("Failed to connect to broadcaster websocket: {error}");
-                vm_rebuild =
-                    handle_subscription_reset(&controls, Some(message.clone()), vm_rebuild).await;
-                warn!(
-                    event = "broadcaster_subscription_connect_failed",
-                    backend = controls.backend_label(),
-                    error = %message,
-                    "Failed to connect to broadcaster subscription"
-                );
-                let backoff_ms = jittered_backoff_ms(backoff, cfg.restart_backoff_jitter_pct);
-                sleep_backoff(backoff_ms, cfg.memory).await;
-                backoff = next_backoff(backoff, cfg.restart_backoff_max);
+                (vm_rebuild, backoff) = reset_subscription_after_error(
+                    &controls,
+                    &cfg,
+                    backoff,
+                    bootstrap.processor.vm_rebuild,
+                    message,
+                    "broadcaster_subscription_connect_failed",
+                    "Failed to connect to broadcaster subscription",
+                )
+                .await;
                 continue;
             }
         };
 
         info!(
-            ws_url,
+            ws_url = bootstrap.session_ws_url,
+            session_id = bootstrap.session.session_id,
             backend = controls.backend_label(),
             "Connected to broadcaster subscription"
         );
-        let (exit, next_vm_rebuild) = process_broadcaster_subscription(
-            stream,
-            expected_chain_id,
-            &controls,
-            &cfg,
-            vm_rebuild,
-        )
-        .await;
-        vm_rebuild =
-            handle_subscription_reset(&controls, exit.last_error.clone(), next_vm_rebuild).await;
-
-        let backoff_ms = jittered_backoff_ms(backoff, cfg.restart_backoff_jitter_pct);
-        warn!(
-            event = "broadcaster_subscription_restart",
-            backend = controls.backend_label(),
-            reason = exit.reason,
-            backoff_ms,
-            last_error = exit.last_error.as_deref(),
-            "Restarting broadcaster subscription"
-        );
-        sleep_backoff(backoff_ms, cfg.memory).await;
-        backoff = next_backoff(backoff, cfg.restart_backoff_max);
+        let (exit, next_vm_rebuild) =
+            process_broadcaster_subscription(stream, bootstrap.processor, &cfg).await;
+        (vm_rebuild, backoff) =
+            restart_after_subscription_exit(&controls, &cfg, backoff, exit, next_vm_rebuild).await;
     }
+}
+
+struct PreparedBroadcasterSubscription {
+    processor: BroadcasterSubscriptionProcessor,
+    session: BroadcasterSnapshotSessionResponse,
+    session_ws_url: String,
+}
+
+struct PrepareBroadcasterSubscriptionError {
+    message: String,
+    event: &'static str,
+    detail: &'static str,
+    vm_rebuild: Option<VmSubscriptionRebuildState>,
+}
+
+impl PrepareBroadcasterSubscriptionError {
+    fn new(
+        message: String,
+        event: &'static str,
+        detail: &'static str,
+        vm_rebuild: Option<VmSubscriptionRebuildState>,
+    ) -> Self {
+        Self {
+            message,
+            event,
+            detail,
+            vm_rebuild,
+        }
+    }
+}
+
+async fn prepare_broadcaster_subscription(
+    client: &Client,
+    ws_url: &str,
+    expected_chain_id: u64,
+    cfg: &StreamSupervisorConfig,
+    controls: &BroadcasterSubscriptionControls,
+    vm_rebuild: Option<VmSubscriptionRebuildState>,
+) -> std::result::Result<PreparedBroadcasterSubscription, PrepareBroadcasterSubscriptionError> {
+    let snapshot_sessions_url = match derive_broadcaster_http_url(ws_url, "snapshot-sessions") {
+        Ok(url) => url,
+        Err(error) => {
+            return Err(PrepareBroadcasterSubscriptionError::new(
+                format!("Invalid broadcaster websocket URL: {error}"),
+                "broadcaster_subscription_url_invalid",
+                "Failed to derive broadcaster snapshot session URL",
+                vm_rebuild,
+            ));
+        }
+    };
+    let decoder = match build_broadcaster_subscription_decoder(
+        controls.tokens(),
+        controls.backend(),
+        controls.protocols(),
+    )
+    .await
+    {
+        Ok(decoder) => decoder,
+        Err(error) => {
+            return Err(PrepareBroadcasterSubscriptionError::new(
+                error.to_string(),
+                "broadcaster_subscription_decoder_failed",
+                "Failed to build broadcaster subscription decoder",
+                vm_rebuild,
+            ));
+        }
+    };
+    let mut processor = BroadcasterSubscriptionProcessor::with_decoder(
+        expected_chain_id,
+        controls.clone(),
+        decoder,
+        vm_rebuild,
+    );
+    let session = match bootstrap_broadcaster_snapshot(
+        client,
+        ws_url,
+        &snapshot_sessions_url,
+        &mut processor,
+        controls,
+        cfg,
+    )
+    .await
+    {
+        Ok(session) => session,
+        Err(error) => {
+            return Err(PrepareBroadcasterSubscriptionError::new(
+                error.to_string(),
+                "broadcaster_subscription_bootstrap_failed",
+                "Failed to bootstrap broadcaster subscription from HTTP snapshot",
+                processor.vm_rebuild,
+            ));
+        }
+    };
+    let session_ws_url = match derive_broadcaster_session_ws_url(ws_url, session.session_id) {
+        Ok(url) => url,
+        Err(error) => {
+            return Err(PrepareBroadcasterSubscriptionError::new(
+                format!("Invalid broadcaster websocket URL: {error}"),
+                "broadcaster_subscription_url_invalid",
+                "Failed to derive broadcaster session websocket URL",
+                processor.vm_rebuild,
+            ));
+        }
+    };
+
+    Ok(PreparedBroadcasterSubscription {
+        processor,
+        session,
+        session_ws_url,
+    })
+}
+
+async fn reset_subscription_after_error(
+    controls: &BroadcasterSubscriptionControls,
+    cfg: &StreamSupervisorConfig,
+    backoff: Duration,
+    vm_rebuild: Option<VmSubscriptionRebuildState>,
+    message: String,
+    event: &'static str,
+    detail: &'static str,
+) -> (Option<VmSubscriptionRebuildState>, Duration) {
+    let vm_rebuild = handle_subscription_reset(controls, Some(message.clone()), vm_rebuild).await;
+    let backoff_ms = jittered_backoff_ms(backoff, cfg.restart_backoff_jitter_pct);
+    warn!(
+        event = event,
+        backend = controls.backend_label(),
+        backoff_ms,
+        error = %message,
+        "{detail}"
+    );
+    sleep_backoff(backoff_ms, cfg.memory).await;
+    (vm_rebuild, next_backoff(backoff, cfg.restart_backoff_max))
+}
+
+async fn restart_after_subscription_exit(
+    controls: &BroadcasterSubscriptionControls,
+    cfg: &StreamSupervisorConfig,
+    backoff: Duration,
+    exit: SubscriptionExit,
+    vm_rebuild: Option<VmSubscriptionRebuildState>,
+) -> (Option<VmSubscriptionRebuildState>, Duration) {
+    let vm_rebuild = handle_subscription_reset(controls, exit.last_error.clone(), vm_rebuild).await;
+    let backoff_ms = jittered_backoff_ms(backoff, cfg.restart_backoff_jitter_pct);
+    warn!(
+        event = "broadcaster_subscription_restart",
+        backend = controls.backend_label(),
+        reason = exit.reason,
+        backoff_ms,
+        last_error = exit.last_error.as_deref(),
+        "Restarting broadcaster subscription"
+    );
+    sleep_backoff(backoff_ms, cfg.memory).await;
+    (vm_rebuild, next_backoff(backoff, cfg.restart_backoff_max))
 }
 
 struct BroadcasterSubscriptionProcessor {
     expected_chain_id: u64,
     controls: BroadcasterSubscriptionControls,
+    decoder: Arc<TychoStreamDecoder<BlockHeader>>,
     tracker: BroadcasterSubscriptionTracker,
     bootstrap_block: Option<u64>,
     vm_rebuild: Option<VmSubscriptionRebuildState>,
 }
 
 impl BroadcasterSubscriptionProcessor {
+    #[cfg(test)]
     fn new(
         expected_chain_id: u64,
         controls: BroadcasterSubscriptionControls,
         vm_rebuild: Option<VmSubscriptionRebuildState>,
     ) -> Self {
+        Self::with_decoder(
+            expected_chain_id,
+            controls,
+            Arc::new(TychoStreamDecoder::new()),
+            vm_rebuild,
+        )
+    }
+
+    fn with_decoder(
+        expected_chain_id: u64,
+        controls: BroadcasterSubscriptionControls,
+        decoder: Arc<TychoStreamDecoder<BlockHeader>>,
+        vm_rebuild: Option<VmSubscriptionRebuildState>,
+    ) -> Self {
         Self {
             expected_chain_id,
             controls,
+            decoder,
             tracker: BroadcasterSubscriptionTracker::new(),
             bootstrap_block: None,
             vm_rebuild,
@@ -198,7 +402,7 @@ impl BroadcasterSubscriptionProcessor {
                 for partition in chunk.partitions {
                     if partition.backend == self.controls.backend() {
                         self.bootstrap_block = Some(partition.block_number);
-                        self.apply_snapshot_partition(partition).await;
+                        self.apply_snapshot_partition(partition).await?;
                     }
                 }
             }
@@ -213,7 +417,7 @@ impl BroadcasterSubscriptionProcessor {
             BroadcasterPayload::Update(update) => {
                 for partition in update.partitions {
                     if partition.backend == self.controls.backend() {
-                        self.apply_live_update_partition(partition).await;
+                        self.apply_live_update_partition(partition).await?;
                     }
                 }
             }
@@ -255,19 +459,68 @@ impl BroadcasterSubscriptionProcessor {
         }
     }
 
-    async fn apply_snapshot_partition(&self, partition: BroadcasterSnapshotPartition) {
+    async fn apply_snapshot_partition(
+        &self,
+        partition: BroadcasterSnapshotPartition,
+    ) -> Result<()> {
+        if !partition.messages.is_empty() {
+            return self.apply_protocol_messages(partition.messages).await;
+        }
+
         let update = snapshot_partition_update(partition);
         self.controls.state_store().apply_update(update).await;
+        Ok(())
     }
 
-    async fn apply_live_update_partition(&self, partition: BroadcasterUpdatePartition) {
+    async fn apply_live_update_partition(
+        &self,
+        partition: BroadcasterUpdatePartition,
+    ) -> Result<()> {
         let block_number = partition.block_number;
+        if !partition.messages.is_empty() {
+            self.apply_protocol_messages(partition.messages).await?;
+            self.controls
+                .stream_health()
+                .record_update(block_number)
+                .await;
+            return Ok(());
+        }
+
         let update = live_partition_update(partition);
         self.controls.state_store().apply_update(update).await;
         self.controls
             .stream_health()
             .record_update(block_number)
             .await;
+        Ok(())
+    }
+
+    async fn apply_protocol_messages(
+        &self,
+        messages: Vec<BroadcasterProtocolMessage>,
+    ) -> Result<()> {
+        for message in messages {
+            self.apply_protocol_message(message).await?;
+        }
+        Ok(())
+    }
+
+    async fn apply_protocol_message(&self, raw: BroadcasterProtocolMessage) -> Result<()> {
+        let mut state_msgs = HashMap::new();
+        state_msgs.insert(raw.protocol.clone(), raw.message);
+        let mut sync_states = HashMap::new();
+        sync_states.insert(raw.protocol, raw.sync_state);
+        let feed = FeedMessage {
+            state_msgs,
+            sync_states,
+        };
+        let update = self
+            .decoder
+            .decode(&feed)
+            .await
+            .map_err(|error| anyhow!("failed to decode broadcaster raw payload: {error}"))?;
+        self.controls.state_store().apply_update(update).await;
+        Ok(())
     }
 
     async fn apply_heartbeat(&self, head: BroadcasterBackendHead) {
@@ -295,16 +548,128 @@ impl BroadcasterSubscriptionProcessor {
     }
 }
 
-async fn process_broadcaster_subscription(
-    mut stream: impl futures::Stream<Item = Result<Message, WsError>> + Unpin,
-    expected_chain_id: u64,
+async fn bootstrap_broadcaster_snapshot(
+    client: &Client,
+    ws_url: &str,
+    snapshot_sessions_url: &str,
+    processor: &mut BroadcasterSubscriptionProcessor,
     controls: &BroadcasterSubscriptionControls,
     cfg: &StreamSupervisorConfig,
-    vm_rebuild: Option<VmSubscriptionRebuildState>,
-) -> (SubscriptionExit, Option<VmSubscriptionRebuildState>) {
-    let mut processor =
-        BroadcasterSubscriptionProcessor::new(expected_chain_id, controls.clone(), vm_rebuild);
+) -> Result<BroadcasterSnapshotSessionResponse> {
+    let session =
+        create_broadcaster_snapshot_session(client, snapshot_sessions_url, cfg.readiness_stale)
+            .await?;
+    controls.stream_health().mark_started().await;
 
+    {
+        let mut payloads = futures::stream::iter(0..session.payload_count)
+            .map(|index| {
+                let session = session.clone();
+                async move {
+                    fetch_broadcaster_snapshot_payload(
+                        client,
+                        ws_url,
+                        &session,
+                        index,
+                        cfg.readiness_stale,
+                    )
+                    .await
+                }
+            })
+            .buffered(SNAPSHOT_DOWNLOAD_CONCURRENCY);
+
+        while let Some(envelope) = payloads.next().await {
+            processor.observe(envelope?).await?;
+        }
+    }
+
+    if !processor.bootstrap_complete() {
+        return Err(anyhow!(
+            "broadcaster HTTP snapshot session {} ended before bootstrap completed",
+            session.session_id
+        ));
+    }
+
+    Ok(session)
+}
+
+async fn create_broadcaster_snapshot_session(
+    client: &Client,
+    snapshot_sessions_url: &str,
+    request_timeout: Duration,
+) -> Result<BroadcasterSnapshotSessionResponse> {
+    let response = client
+        .post(snapshot_sessions_url)
+        .timeout(request_timeout)
+        .send()
+        .await
+        .map_err(|error| {
+            anyhow!(
+                "failed to create broadcaster snapshot session at {snapshot_sessions_url}: {error}"
+            )
+        })?;
+    decode_success_json(
+        response,
+        snapshot_sessions_url,
+        "create broadcaster snapshot session",
+    )
+    .await
+}
+
+async fn fetch_broadcaster_snapshot_payload(
+    client: &Client,
+    ws_url: &str,
+    session: &BroadcasterSnapshotSessionResponse,
+    index: u32,
+    request_timeout: Duration,
+) -> Result<BroadcasterEnvelope> {
+    let payload_url = derive_broadcaster_http_url(
+        ws_url,
+        &format!("snapshot-sessions/{}/payloads/{index}", session.session_id),
+    )
+    .map_err(|error| anyhow!("failed to derive broadcaster snapshot payload URL: {error}"))?;
+    let response = client
+        .get(&payload_url)
+        .timeout(request_timeout)
+        .send()
+        .await
+        .map_err(|error| {
+            anyhow!(
+                "failed to fetch broadcaster snapshot payload {index} from {payload_url}: {error}"
+            )
+        })?;
+    decode_success_json(response, &payload_url, "fetch broadcaster snapshot payload").await
+}
+
+async fn decode_success_json<T>(
+    response: reqwest::Response,
+    url: &str,
+    operation: &str,
+) -> Result<T>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let status = response.status();
+    if !status.is_success() {
+        return Err(http_status_error(operation, url, status));
+    }
+    let body = response
+        .bytes()
+        .await
+        .map_err(|error| anyhow!("failed to read {operation} response from {url}: {error}"))?;
+    serde_json::from_slice(&body)
+        .map_err(|error| anyhow!("failed to decode {operation} response from {url}: {error}"))
+}
+
+fn http_status_error(operation: &str, url: &str, status: StatusCode) -> anyhow::Error {
+    anyhow!("{operation} at {url} failed with HTTP {status}")
+}
+
+async fn process_broadcaster_subscription(
+    mut stream: impl futures::Stream<Item = Result<Message, WsError>> + Unpin,
+    mut processor: BroadcasterSubscriptionProcessor,
+    cfg: &StreamSupervisorConfig,
+) -> (SubscriptionExit, Option<VmSubscriptionRebuildState>) {
     loop {
         let next_timeout = if processor.bootstrap_complete() {
             cfg.stream_stale
@@ -511,7 +876,13 @@ mod tests {
 
     use anyhow::Result;
     use num_bigint::BigUint;
-    use tokio::sync::RwLock;
+    use reqwest::Client;
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::TcpListener,
+        sync::RwLock,
+        task::JoinHandle,
+    };
     use tycho_simulation::tycho_common::dto::ProtocolStateDelta;
     use tycho_simulation::tycho_common::simulation::errors::{SimulationError, TransitionError};
     use tycho_simulation::{
@@ -524,13 +895,15 @@ mod tests {
     };
 
     use super::{
-        handle_subscription_reset, BroadcasterSubscriptionControls,
+        bootstrap_broadcaster_snapshot, handle_subscription_reset, BroadcasterSubscriptionControls,
         BroadcasterSubscriptionProcessor, NativeBroadcasterSubscriptionControls,
         VmBroadcasterSubscriptionControls,
     };
+    use crate::config::MemoryConfig;
     use crate::models::state::{BroadcasterSubscriptionStatus, StateStore, VmStreamStatus};
     use crate::models::stream_health::StreamHealth;
     use crate::models::tokens::TokenStore;
+    use crate::stream::StreamSupervisorConfig;
     use simulator_core::broadcaster::{
         BroadcasterBackend, BroadcasterBackendHead, BroadcasterEnvelope, BroadcasterHeartbeat,
         BroadcasterPayload, BroadcasterSnapshotChunk, BroadcasterSnapshotEnd,
@@ -603,6 +976,7 @@ mod tests {
     }
 
     struct TestControls {
+        token_store: Arc<TokenStore>,
         native_subscription: BroadcasterSubscriptionStatus,
         vm_subscription: BroadcasterSubscriptionStatus,
         native_state_store: Arc<StateStore>,
@@ -624,10 +998,11 @@ mod tests {
             ));
 
             Self {
+                token_store: Arc::clone(&token_store),
                 native_subscription: BroadcasterSubscriptionStatus::default(),
                 vm_subscription: BroadcasterSubscriptionStatus::default(),
                 native_state_store: Arc::new(StateStore::new(Arc::clone(&token_store))),
-                vm_state_store: Arc::new(StateStore::new(token_store)),
+                vm_state_store: Arc::new(StateStore::new(Arc::clone(&token_store))),
                 native_stream_health: Arc::new(StreamHealth::new()),
                 vm_stream_health: Arc::new(StreamHealth::new()),
                 vm_stream: Arc::new(RwLock::new(VmStreamStatus::default())),
@@ -640,6 +1015,8 @@ mod tests {
                 broadcaster_subscription: self.native_subscription.clone(),
                 state_store: Arc::clone(&self.native_state_store),
                 stream_health: Arc::clone(&self.native_stream_health),
+                tokens: Arc::clone(&self.token_store),
+                protocols: vec!["uniswap_v2".to_string()],
             })
         }
 
@@ -648,6 +1025,8 @@ mod tests {
                 broadcaster_subscription: self.vm_subscription.clone(),
                 state_store: Arc::clone(&self.vm_state_store),
                 stream_health: Arc::clone(&self.vm_stream_health),
+                tokens: Arc::clone(&self.token_store),
+                protocols: vec!["vm:curve".to_string()],
                 vm_stream: Arc::clone(&self.vm_stream),
                 simulation_rebuild_gate: Arc::clone(&self.simulation_rebuild_gate),
             })
@@ -748,6 +1127,31 @@ mod tests {
         ))
     }
 
+    fn empty_snapshot_chunk_envelope() -> Result<BroadcasterEnvelope> {
+        Ok(BroadcasterEnvelope::new(
+            "stream-1",
+            2,
+            BroadcasterPayload::SnapshotChunk(BroadcasterSnapshotChunk::new(
+                "snapshot-1",
+                0,
+                vec![
+                    BroadcasterSnapshotPartition::new(
+                        BroadcasterBackend::Native,
+                        10,
+                        Vec::new(),
+                        BTreeMap::new(),
+                    ),
+                    BroadcasterSnapshotPartition::new(
+                        BroadcasterBackend::Vm,
+                        11,
+                        Vec::new(),
+                        BTreeMap::new(),
+                    ),
+                ],
+            )?),
+        ))
+    }
+
     fn snapshot_end_envelope() -> BroadcasterEnvelope {
         BroadcasterEnvelope::new(
             "stream-1",
@@ -790,6 +1194,114 @@ mod tests {
                 ],
             )?),
         ))
+    }
+
+    async fn spawn_snapshot_session_server(
+        payloads: Vec<BroadcasterEnvelope>,
+    ) -> Result<(String, String, JoinHandle<()>)> {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        let payloads = Arc::new(
+            payloads
+                .into_iter()
+                .map(|payload| serde_json::to_string(&payload))
+                .collect::<Result<Vec<_>, _>>()?,
+        );
+        let server_task = tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    break;
+                };
+                let payloads = Arc::clone(&payloads);
+                tokio::spawn(async move {
+                    let mut buffer = [0u8; 8192];
+                    let Ok(read) = socket.read(&mut buffer).await else {
+                        return;
+                    };
+                    let request = String::from_utf8_lossy(&buffer[..read]);
+                    let first_line = request.lines().next().unwrap_or_default();
+                    let (status, body) = snapshot_server_response(first_line, &payloads);
+                    let response = format!(
+                        "HTTP/1.1 {status}\r\ncontent-type: application/json\r\nconnection: close\r\ncontent-length: {}\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = socket.write_all(response.as_bytes()).await;
+                });
+            }
+        });
+
+        Ok((
+            format!("ws://{addr}/ws"),
+            format!("http://{addr}/snapshot-sessions"),
+            server_task,
+        ))
+    }
+
+    fn snapshot_server_response(first_line: &str, payloads: &[String]) -> (&'static str, String) {
+        if first_line == "POST /snapshot-sessions HTTP/1.1" {
+            return (
+                "201 Created",
+                serde_json::json!({
+                    "chainId": Chain::Ethereum.id(),
+                    "sessionId": 7,
+                    "streamId": "stream-1",
+                    "snapshotId": "snapshot-1",
+                    "payloadCount": payloads.len(),
+                    "snapshotChunkCount": payloads
+                        .iter()
+                        .filter(|payload| payload.contains("\"kind\":\"snapshot_chunk\""))
+                        .count(),
+                    "expiresInMs": 300000
+                })
+                .to_string(),
+            );
+        }
+
+        let Some(path) = first_line
+            .strip_prefix("GET /snapshot-sessions/7/payloads/")
+            .and_then(|rest| rest.strip_suffix(" HTTP/1.1"))
+        else {
+            return (
+                "404 Not Found",
+                serde_json::json!({ "error": "not found" }).to_string(),
+            );
+        };
+        let Ok(index) = path.parse::<usize>() else {
+            return (
+                "416 Range Not Satisfiable",
+                serde_json::json!({ "error": "bad index" }).to_string(),
+            );
+        };
+        match payloads.get(index) {
+            Some(payload) => ("200 OK", payload.clone()),
+            None => (
+                "416 Range Not Satisfiable",
+                serde_json::json!({ "error": "bad index" }).to_string(),
+            ),
+        }
+    }
+
+    fn test_supervisor_config() -> StreamSupervisorConfig {
+        StreamSupervisorConfig {
+            readiness_stale: Duration::from_secs(1),
+            stream_stale: Duration::from_secs(1),
+            missing_block_burst: 3,
+            missing_block_window: Duration::from_secs(60),
+            error_burst: 3,
+            error_window: Duration::from_secs(60),
+            resync_grace: Duration::from_secs(60),
+            restart_backoff_min: Duration::from_millis(10),
+            restart_backoff_max: Duration::from_millis(100),
+            restart_backoff_jitter_pct: 0.0,
+            memory: MemoryConfig {
+                purge_enabled: false,
+                snapshots_enabled: false,
+                snapshots_min_interval_secs: 60,
+                snapshots_min_new_pairs: 1_000,
+                snapshots_emit_emf: false,
+            },
+        }
     }
 
     #[tokio::test]
@@ -839,6 +1351,47 @@ mod tests {
             .last_update_age_ms()
             .await
             .is_some());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn http_snapshot_bootstrap_populates_processor_before_live_attach() -> Result<()> {
+        let controls = TestControls::new();
+        let native_controls = controls.native();
+        let mut processor = BroadcasterSubscriptionProcessor::new(
+            Chain::Ethereum.id(),
+            native_controls.clone(),
+            None,
+        );
+        let payloads = vec![
+            snapshot_start_envelope()?,
+            empty_snapshot_chunk_envelope()?,
+            snapshot_end_envelope(),
+        ];
+        let (ws_url, snapshot_sessions_url, server_task) =
+            spawn_snapshot_session_server(payloads).await?;
+
+        let session = bootstrap_broadcaster_snapshot(
+            &Client::new(),
+            &ws_url,
+            &snapshot_sessions_url,
+            &mut processor,
+            &native_controls,
+            &test_supervisor_config(),
+        )
+        .await?;
+        server_task.abort();
+
+        assert_eq!(session.session_id, 7);
+        assert!(processor.bootstrap_complete());
+        assert_eq!(controls.native_state_store.current_block().await, 10);
+        assert!(!controls.native_state_store.has_pool("pool-native").await);
+        assert!(!controls.native_state_store.has_pool("pool-vm").await);
+        let snapshot = controls.native_subscription.snapshot().await;
+        assert!(snapshot.connected);
+        assert!(snapshot.bootstrap_complete);
+        assert_eq!(snapshot.stream_id.as_deref(), Some("stream-1"));
+        assert_eq!(snapshot.snapshot_id.as_deref(), Some("snapshot-1"));
         Ok(())
     }
 

--- a/crates/runtime/src/services/stream_builder.rs
+++ b/crates/runtime/src/services/stream_builder.rs
@@ -4,14 +4,17 @@ use std::{
     time::Duration,
 };
 
-use crate::models::tokens::TokenStore;
 use anyhow::{bail, Result};
 use futures::StreamExt;
+use simulator_core::broadcaster::BroadcasterBackend;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::info;
+
+use crate::models::tokens::TokenStore;
 use tycho_simulation::{
     evm::{
+        decoder::TychoStreamDecoder,
         engine_db::tycho_db::PreCachedDB,
         protocol::{
             aerodrome_slipstreams::state::AerodromeSlipstreamsState,
@@ -24,6 +27,7 @@ use tycho_simulation::{
             rocketpool::state::RocketpoolState,
             uniswap_v2::state::UniswapV2State,
             uniswap_v3::state::UniswapV3State,
+            uniswap_v4::hooks::hook_handler_creator::initialize_hook_handlers,
             uniswap_v4::state::UniswapV4State,
             vm::state::EVMPoolState,
         },
@@ -39,6 +43,10 @@ use tycho_simulation::{
         stream::RFQStreamBuilder,
     },
     tycho_client::feed::component_tracker::ComponentFilter,
+    tycho_client::{
+        feed::{BlockHeader, FeedMessage},
+        stream::TychoStreamBuilder,
+    },
     tycho_common::{
         models::{token::Token, Chain},
         Bytes,
@@ -206,6 +214,71 @@ pub async fn build_broadcaster_stream(
     }))
 }
 
+pub async fn build_broadcaster_raw_stream(
+    tycho_url: &str,
+    api_key: &str,
+    tvl_add_threshold: f64,
+    tvl_keep_threshold: f64,
+    chain: Chain,
+    protocols: &BroadcasterProtocols,
+) -> Result<
+    impl futures::Stream<
+            Item = Result<
+                FeedMessage<BlockHeader>,
+                Box<dyn std::error::Error + Send + Sync + 'static>,
+            >,
+        > + Unpin
+        + Send,
+> {
+    let (mut builder, tvl_filter) = raw_base_builder(
+        tycho_url,
+        api_key,
+        tvl_add_threshold,
+        tvl_keep_threshold,
+        chain,
+    );
+
+    for protocol in protocols.native.iter().chain(protocols.vm.iter()) {
+        builder = builder.exchange(protocol, tvl_filter.clone());
+    }
+
+    let (_handle, rx) = builder.build().await?;
+    Ok(ReceiverStream::new(rx).map(|item| {
+        item.map_err(|err| -> Box<dyn std::error::Error + Send + Sync + 'static> { Box::new(err) })
+    }))
+}
+
+pub async fn build_broadcaster_subscription_decoder(
+    tokens: Arc<TokenStore>,
+    backend: BroadcasterBackend,
+    protocols: &[String],
+) -> Result<Arc<TychoStreamDecoder<BlockHeader>>> {
+    let mut decoder = TychoStreamDecoder::new();
+    decoder.skip_state_decode_failures(decode_skip_state_failures(match backend {
+        BroadcasterBackend::Native => StreamDecodePolicy::Native,
+        BroadcasterBackend::Vm => StreamDecodePolicy::Vm,
+    }));
+
+    match backend {
+        BroadcasterBackend::Native => {
+            for protocol in protocols {
+                register_native_decoder(&mut decoder, protocol)?;
+            }
+        }
+        BroadcasterBackend::Vm => {
+            for protocol in protocols {
+                register_vm_decoder(&mut decoder, protocol)?;
+            }
+        }
+    }
+
+    initialize_hook_handlers().map_err(|error| {
+        anyhow::anyhow!("failed to initialize Uniswap v4 hook handlers: {error:?}")
+    })?;
+    decoder.set_tokens(tokens.snapshot().await).await;
+    Ok(Arc::new(decoder))
+}
+
 #[derive(Clone)]
 pub struct RFQConfig {
     pub bebop_user: String,
@@ -362,6 +435,49 @@ fn register_vm_protocol(
     }
 }
 
+fn register_native_decoder(
+    decoder: &mut TychoStreamDecoder<BlockHeader>,
+    protocol: &str,
+) -> Result<()> {
+    match protocol {
+        "uniswap_v2" | "sushiswap_v2" => decoder.register_decoder::<UniswapV2State>(protocol),
+        "pancakeswap_v2" => decoder.register_decoder::<PancakeswapV2State>(protocol),
+        "uniswap_v3" | "pancakeswap_v3" => decoder.register_decoder::<UniswapV3State>(protocol),
+        "uniswap_v4" => decoder.register_decoder::<UniswapV4State>(protocol),
+        "ekubo_v2" => decoder.register_decoder::<EkuboState>(protocol),
+        "fluid_v1" => {
+            decoder.register_decoder::<FluidV1>(protocol);
+            decoder.register_filter(protocol, fluid_v1_paused_pools_filter);
+        }
+        "rocketpool" => decoder.register_decoder::<RocketpoolState>(protocol),
+        "ekubo_v3" => decoder.register_decoder::<EkuboV3State>(protocol),
+        "aerodrome_slipstreams" => decoder.register_decoder::<AerodromeSlipstreamsState>(protocol),
+        "erc4626" => {
+            decoder.register_decoder::<ERC4626State>(protocol);
+            decoder.register_filter(protocol, erc4626_filter);
+        }
+        other => bail!("Unknown native protocol in chain profile: {}", other),
+    }
+    Ok(())
+}
+
+fn register_vm_decoder(
+    decoder: &mut TychoStreamDecoder<BlockHeader>,
+    protocol: &str,
+) -> Result<()> {
+    match protocol {
+        "vm:balancer_v2" => {
+            decoder.register_decoder::<EVMPoolState<PreCachedDB>>(protocol);
+            decoder.register_filter(protocol, balancer_v2_pool_filter);
+        }
+        "vm:curve" | "vm:maverick_v2" => {
+            decoder.register_decoder::<EVMPoolState<PreCachedDB>>(protocol);
+        }
+        other => bail!("Unknown VM protocol in chain profile: {}", other),
+    }
+    Ok(())
+}
+
 fn base_builder(
     tycho_url: &str,
     api_key: &str,
@@ -382,6 +498,28 @@ fn base_builder(
         .latency_buffer(15)
         .auth_key(Some(api_key.to_string()))
         .skip_state_decode_failures(skip_state_decode_failures);
+
+    (builder, tvl_filter)
+}
+
+fn raw_base_builder(
+    tycho_url: &str,
+    api_key: &str,
+    tvl_add_threshold: f64,
+    tvl_keep_threshold: f64,
+    chain: Chain,
+) -> (TychoStreamBuilder, ComponentFilter) {
+    let add_tvl = tvl_add_threshold;
+    let keep_tvl = tvl_keep_threshold.min(add_tvl);
+    info!(
+        "Using TVL thresholds: remove/keep={} add={}",
+        keep_tvl, add_tvl
+    );
+    let tvl_filter = ComponentFilter::with_tvl_range(keep_tvl, add_tvl);
+
+    let builder = TychoStreamBuilder::new(tycho_url, chain.into())
+        .timeout(15)
+        .auth_key(Some(api_key.to_string()));
 
     (builder, tvl_filter)
 }

--- a/crates/runtime/src/simulator_service.rs
+++ b/crates/runtime/src/simulator_service.rs
@@ -613,6 +613,8 @@ fn spawn_native_broadcaster_subscription_task(
         broadcaster_subscription: app_state.native_broadcaster_subscription.clone(),
         state_store: Arc::clone(&resources.native_state_store),
         stream_health: Arc::clone(&resources.native_stream_health),
+        tokens: Arc::clone(&app_state.tokens),
+        protocols: config.chain_profile.native_protocols.clone(),
     });
     spawn_backend_broadcaster_subscription_task(
         "native",
@@ -633,6 +635,8 @@ fn spawn_vm_broadcaster_subscription_task(
         broadcaster_subscription: app_state.vm_broadcaster_subscription.clone(),
         state_store: Arc::clone(&resources.vm_state_store),
         stream_health: Arc::clone(&resources.vm_stream_health),
+        tokens: Arc::clone(&app_state.tokens),
+        protocols: config.chain_profile.vm_protocols.clone(),
         vm_stream: Arc::clone(&resources.vm_stream),
         simulation_rebuild_gate: app_state.simulation_rebuild_gate(),
     });

--- a/crates/runtime/src/stream.rs
+++ b/crates/runtime/src/stream.rs
@@ -7,8 +7,9 @@ use tokio::sync::{OwnedRwLockWriteGuard, RwLock};
 use tokio::time::{sleep, timeout, Instant};
 use tracing::{info, warn};
 use tycho_simulation::{
-    evm::engine_db::SHARED_TYCHO_DB, protocol::models::Update as TychoUpdate,
-    tycho_client::feed::SynchronizerState,
+    evm::engine_db::SHARED_TYCHO_DB,
+    protocol::models::Update as TychoUpdate,
+    tycho_client::feed::{BlockHeader, FeedMessage, HeaderLike, SynchronizerState},
 };
 
 use crate::config::MemoryConfig;
@@ -105,6 +106,13 @@ enum StreamMessage {
     Error(String),
 }
 
+enum BroadcasterRawStreamMessage {
+    Stale,
+    Ended,
+    Update(FeedMessage<BlockHeader>),
+    Error(String),
+}
+
 fn stream_exit(reason: StreamRestartReason, last_error: Option<String>) -> StreamExit {
     StreamExit { reason, last_error }
 }
@@ -191,6 +199,53 @@ pub async fn process_broadcaster_stream(
     }
 }
 
+pub async fn process_broadcaster_raw_stream(
+    mut stream: impl futures::Stream<
+            Item = Result<
+                FeedMessage<BlockHeader>,
+                Box<dyn std::error::Error + Send + Sync + 'static>,
+            >,
+        > + Unpin
+        + Send,
+    health: Arc<StreamHealth>,
+    cfg: StreamSupervisorConfig,
+    service: &BroadcasterServiceState,
+) -> StreamExit {
+    info!(
+        stream = StreamKind::Broadcaster.as_str(),
+        "Starting raw broadcaster stream processing"
+    );
+    health.mark_started().await;
+
+    let mut ready_logged = false;
+
+    loop {
+        match next_broadcaster_raw_stream_message(&mut stream, &health, &cfg).await {
+            BroadcasterRawStreamMessage::Stale => {
+                return stream_exit(StreamRestartReason::Stale, None)
+            }
+            BroadcasterRawStreamMessage::Ended => {
+                return stream_exit(StreamRestartReason::Ended, None)
+            }
+            BroadcasterRawStreamMessage::Error(err_msg) => {
+                if let Some(exit) =
+                    handle_stream_error(StreamKind::Broadcaster, err_msg, &health, &cfg).await
+                {
+                    return exit;
+                }
+            }
+            BroadcasterRawStreamMessage::Update(update) => {
+                if let Some(exit) =
+                    handle_broadcaster_raw_update(update, service, &health, &cfg, &mut ready_logged)
+                        .await
+                {
+                    return exit;
+                }
+            }
+        }
+    }
+}
+
 async fn next_stream_message(
     kind: StreamKind,
     stream: &mut (impl futures::Stream<
@@ -240,6 +295,57 @@ async fn next_stream_message(
         }
         Ok(Some(Ok(update))) => StreamMessage::Update(update),
         Ok(Some(Err(err))) => StreamMessage::Error(err.to_string()),
+    }
+}
+
+async fn next_broadcaster_raw_stream_message(
+    stream: &mut (impl futures::Stream<
+        Item = Result<FeedMessage<BlockHeader>, Box<dyn std::error::Error + Send + Sync + 'static>>,
+    > + Unpin
+              + Send),
+    health: &StreamHealth,
+    cfg: &StreamSupervisorConfig,
+) -> BroadcasterRawStreamMessage {
+    let has_received_update = health.has_received_update().await;
+    let stream_timeout = if has_received_update {
+        cfg.stream_stale
+    } else {
+        cfg.readiness_stale
+    };
+
+    match timeout(stream_timeout, stream.next()).await {
+        Err(_) => {
+            let started_age_ms = health.started_age_ms().await.unwrap_or(0);
+            let last_update_age_ms = health.last_update_age_ms().await.unwrap_or(0);
+            let last_block = health.last_block().await;
+            warn!(
+                event = "stream_stale",
+                stream = StreamKind::Broadcaster.as_str(),
+                started_age_ms,
+                has_received_update,
+                last_update_age_ms,
+                last_block,
+                "Raw broadcaster stream stale; triggering restart"
+            );
+            BroadcasterRawStreamMessage::Stale
+        }
+        Ok(None) => {
+            let started_age_ms = health.started_age_ms().await.unwrap_or(0);
+            let last_update_age_ms = health.last_update_age_ms().await.unwrap_or(0);
+            let last_block = health.last_block().await;
+            warn!(
+                event = "stream_ended",
+                stream = StreamKind::Broadcaster.as_str(),
+                started_age_ms,
+                has_received_update,
+                last_update_age_ms,
+                last_block,
+                "Raw broadcaster stream ended unexpectedly"
+            );
+            BroadcasterRawStreamMessage::Ended
+        }
+        Ok(Some(Ok(update))) => BroadcasterRawStreamMessage::Update(update),
+        Ok(Some(Err(err))) => BroadcasterRawStreamMessage::Error(err.to_string()),
     }
 }
 
@@ -376,6 +482,94 @@ async fn handle_broadcaster_update(
     }
 
     None
+}
+
+async fn handle_broadcaster_raw_update(
+    update: FeedMessage<BlockHeader>,
+    service: &BroadcasterServiceState,
+    health: &StreamHealth,
+    cfg: &StreamSupervisorConfig,
+    ready_logged: &mut bool,
+) -> Option<StreamExit> {
+    let now = Instant::now();
+    let has_advanced = update
+        .sync_states
+        .values()
+        .any(|state| matches!(state, SynchronizerState::Advanced(_)));
+
+    if has_advanced {
+        let advanced = health.record_advanced(now).await;
+        if advanced.window_started {
+            info!(
+                event = "stream_advanced",
+                stream = StreamKind::Broadcaster.as_str(),
+                advanced_total = advanced.total_count,
+                burst_count = advanced.burst_count,
+                window_secs = cfg.resync_grace.as_secs(),
+                "Advanced synchronizer state detected"
+            );
+        }
+        if advanced.elapsed >= cfg.resync_grace {
+            return Some(stream_exit(
+                StreamRestartReason::Advanced,
+                Some("advanced_state_grace_exceeded".to_string()),
+            ));
+        }
+    } else {
+        health.clear_advanced().await;
+    }
+
+    let block_number = broadcaster_raw_block_number(&update);
+    let new_pairs = update
+        .state_msgs
+        .values()
+        .map(|message| message.snapshots.states.len())
+        .sum();
+    if let Err(error) = service.apply_feed_message(&update).await {
+        let error = error.to_string();
+        health.set_last_error(Some(error.clone())).await;
+        return Some(stream_exit(StreamRestartReason::Error, Some(error)));
+    }
+
+    health.record_update(block_number).await;
+    maybe_log_memory_snapshot(
+        "broadcaster",
+        "stream_update",
+        Some(new_pairs),
+        cfg.memory,
+        false,
+    );
+    info!(
+        event = "stream_update",
+        stream = StreamKind::Broadcaster.as_str(),
+        block = block_number,
+        new_pairs,
+        "Raw broadcaster update processed"
+    );
+
+    if !*ready_logged {
+        let status = service.status_snapshot().await;
+        if status.snapshot.ready {
+            info!(
+                stream = StreamKind::Broadcaster.as_str(),
+                block = block_number,
+                total_pairs = status.snapshot.total_states,
+                "Broadcaster ready: snapshot cache is bootstrapped"
+            );
+            *ready_logged = true;
+        }
+    }
+
+    None
+}
+
+fn broadcaster_raw_block_number(update: &FeedMessage<BlockHeader>) -> u64 {
+    update
+        .state_msgs
+        .values()
+        .map(|message| message.header.clone().block_number_or_timestamp())
+        .max()
+        .unwrap_or_default()
 }
 
 fn log_stream_update(kind: StreamKind, metrics: &crate::models::state::UpdateMetrics) {
@@ -589,6 +783,85 @@ pub async fn supervise_broadcaster_stream<F, Fut, S>(
             last_block,
             last_update_age_ms,
             "Restarting broadcaster stream"
+        );
+
+        controls
+            .service
+            .handle_generation_reset(exit.reason.as_str(), exit.last_error.clone())
+            .await;
+        maybe_purge_allocator("broadcaster_restart", cfg.memory);
+
+        sleep(Duration::from_millis(backoff_ms)).await;
+        backoff = next_backoff(backoff, cfg.restart_backoff_max);
+    }
+}
+
+pub async fn supervise_broadcaster_raw_stream<F, Fut, S>(
+    build_stream: F,
+    health: Arc<StreamHealth>,
+    cfg: StreamSupervisorConfig,
+    controls: BroadcasterStreamControls,
+) where
+    F: Fn() -> Fut + Send + Sync,
+    Fut: std::future::Future<Output = anyhow::Result<S>> + Send,
+    S: futures::Stream<
+            Item = Result<
+                FeedMessage<BlockHeader>,
+                Box<dyn std::error::Error + Send + Sync + 'static>,
+            >,
+        > + Unpin
+        + Send,
+{
+    let mut backoff = cfg.restart_backoff_min;
+
+    loop {
+        let stream = match build_stream().await {
+            Ok(stream) => {
+                controls.service.mark_upstream_connected().await;
+                stream
+            }
+            Err(err) => {
+                controls.service.mark_build_failed(err.to_string()).await;
+                warn!(
+                    event = "stream_build_failed",
+                    stream = StreamKind::Broadcaster.as_str(),
+                    error = %err,
+                    "Failed to build raw broadcaster stream"
+                );
+                let backoff_ms = jittered_backoff_ms(backoff, cfg.restart_backoff_jitter_pct);
+                sleep(Duration::from_millis(backoff_ms)).await;
+                backoff = next_backoff(backoff, cfg.restart_backoff_max);
+                continue;
+            }
+        };
+
+        let exit = process_broadcaster_raw_stream(
+            stream,
+            Arc::clone(&health),
+            cfg.clone(),
+            &controls.service,
+        )
+        .await;
+
+        let restart_count = health.increment_restart().await;
+        health.reset_bursts().await;
+        let started_age_ms = health.started_age_ms().await.unwrap_or(0);
+        let has_received_update = health.has_received_update().await;
+        let last_update_age_ms = health.last_update_age_ms().await.unwrap_or(0);
+        let last_block = health.last_block().await;
+
+        let backoff_ms = jittered_backoff_ms(backoff, cfg.restart_backoff_jitter_pct);
+        warn!(
+            event = "stream_restart",
+            stream = StreamKind::Broadcaster.as_str(),
+            reason = exit.reason.as_str(),
+            restart_count,
+            backoff_ms,
+            started_age_ms,
+            has_received_update,
+            last_block,
+            last_update_age_ms,
+            "Restarting raw broadcaster stream"
         );
 
         controls

--- a/crates/simulator-core/src/models/broadcaster.rs
+++ b/crates/simulator-core/src/models/broadcaster.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt;
 
 use serde::{
@@ -7,7 +7,9 @@ use serde::{
 };
 use tycho_simulation::{
     protocol::models::{ProtocolComponent, Update as TychoUpdate},
-    tycho_client::feed::{BlockHeader, SynchronizerState},
+    tycho_client::feed::{
+        synchronizer::StateSyncMessage, BlockHeader, FeedMessage, HeaderLike, SynchronizerState,
+    },
     tycho_common::{models::token::Token, simulation::protocol_sim::ProtocolSim, Bytes},
 };
 
@@ -39,6 +41,18 @@ pub struct BroadcasterTokenLookupResponse {
 pub struct BroadcasterTokenSnapshotResponse {
     pub chain_id: u64,
     pub tokens: Vec<BroadcasterTokenDto>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BroadcasterSnapshotSessionResponse {
+    pub chain_id: u64,
+    pub session_id: u64,
+    pub stream_id: String,
+    pub snapshot_id: String,
+    pub payload_count: u32,
+    pub snapshot_chunk_count: u32,
+    pub expires_in_ms: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -244,6 +258,8 @@ pub struct BroadcasterSnapshotPartition {
     pub backend: BroadcasterBackend,
     pub block_number: u64,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub messages: Vec<BroadcasterProtocolMessage>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub states: Vec<BroadcasterStateEntry>,
     // BTreeMap keeps the wire output deterministic for snapshots, deltas, and golden tests.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
@@ -261,7 +277,23 @@ impl BroadcasterSnapshotPartition {
         Self {
             backend,
             block_number,
+            messages: Vec::new(),
             states,
+            sync_statuses,
+        }
+    }
+
+    pub fn with_messages(
+        backend: BroadcasterBackend,
+        block_number: u64,
+        messages: Vec<BroadcasterProtocolMessage>,
+        sync_statuses: BTreeMap<String, BroadcasterProtocolSyncStatus>,
+    ) -> Self {
+        Self {
+            backend,
+            block_number,
+            messages,
+            states: Vec::new(),
             sync_statuses,
         }
     }
@@ -383,6 +415,86 @@ impl BroadcasterUpdateMessage {
 
         Self::new(partitions)
     }
+
+    pub fn from_tycho_feed_message(
+        feed: &FeedMessage<BlockHeader>,
+    ) -> Result<Self, BroadcasterContractError> {
+        let mut partitions = BTreeMap::<BroadcasterBackend, Vec<BroadcasterProtocolMessage>>::new();
+        let mut sync_statuses =
+            BTreeMap::<BroadcasterBackend, BTreeMap<String, BroadcasterProtocolSyncStatus>>::new();
+        let mut block_numbers = BTreeMap::<BroadcasterBackend, u64>::new();
+
+        for (protocol, status) in &feed.sync_states {
+            let backend = backend_for_sync_state(protocol)?;
+            if let Some(block_number) = sync_state_block_number(status) {
+                block_numbers
+                    .entry(backend)
+                    .and_modify(|current| *current = (*current).max(block_number))
+                    .or_insert(block_number);
+            }
+            sync_statuses.entry(backend).or_default().insert(
+                protocol.clone(),
+                BroadcasterProtocolSyncStatus::from_synchronizer_state(status),
+            );
+        }
+
+        for (protocol, message) in &feed.state_msgs {
+            let backend = backend_for_sync_state(protocol)?;
+            let sync_state = feed
+                .sync_states
+                .get(protocol)
+                .cloned()
+                .unwrap_or(SynchronizerState::Started);
+            partitions
+                .entry(backend)
+                .or_default()
+                .push(BroadcasterProtocolMessage::new(
+                    protocol.clone(),
+                    sync_state,
+                    message.clone(),
+                ));
+        }
+
+        let partition_backends = partitions
+            .keys()
+            .chain(sync_statuses.keys())
+            .copied()
+            .collect::<BTreeSet<_>>();
+        let partitions = partition_backends
+            .into_iter()
+            .filter_map(|backend| {
+                let messages = partitions.remove(&backend).unwrap_or_default();
+                let statuses = sync_statuses.remove(&backend).unwrap_or_default();
+                if messages.is_empty() && statuses.is_empty() {
+                    return None;
+                }
+                let block_number = messages
+                    .iter()
+                    .map(|message| message.message.header.clone().block_number_or_timestamp())
+                    .max()
+                    .or_else(|| block_numbers.get(&backend).copied())
+                    .unwrap_or_default();
+                Some(BroadcasterUpdatePartition::with_messages(
+                    backend,
+                    block_number,
+                    messages,
+                    statuses,
+                ))
+            })
+            .collect();
+
+        Self::new(partitions)
+    }
+}
+
+fn sync_state_block_number(state: &SynchronizerState) -> Option<u64> {
+    match state {
+        SynchronizerState::Ready(header)
+        | SynchronizerState::Delayed(header)
+        | SynchronizerState::Stale(header)
+        | SynchronizerState::Advanced(header) => Some(header.clone().block_number_or_timestamp()),
+        SynchronizerState::Started | SynchronizerState::Ended(_) => None,
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -390,6 +502,8 @@ impl BroadcasterUpdateMessage {
 pub struct BroadcasterUpdatePartition {
     pub backend: BroadcasterBackend,
     pub block_number: u64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub messages: Vec<BroadcasterProtocolMessage>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub new_pairs: Vec<BroadcasterStateEntry>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -416,6 +530,7 @@ impl BroadcasterUpdatePartition {
         Self {
             backend,
             block_number,
+            messages: Vec::new(),
             new_pairs,
             updated_states,
             removed_pairs,
@@ -423,11 +538,51 @@ impl BroadcasterUpdatePartition {
         }
     }
 
+    pub fn with_messages(
+        backend: BroadcasterBackend,
+        block_number: u64,
+        messages: Vec<BroadcasterProtocolMessage>,
+        sync_statuses: BTreeMap<String, BroadcasterProtocolSyncStatus>,
+    ) -> Self {
+        Self {
+            backend,
+            block_number,
+            messages,
+            new_pairs: Vec::new(),
+            updated_states: Vec::new(),
+            removed_pairs: Vec::new(),
+            sync_statuses,
+        }
+    }
+
     fn is_empty(&self) -> bool {
-        self.new_pairs.is_empty()
+        self.messages.is_empty()
+            && self.new_pairs.is_empty()
             && self.updated_states.is_empty()
             && self.removed_pairs.is_empty()
             && self.sync_statuses.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BroadcasterProtocolMessage {
+    pub protocol: String,
+    pub sync_state: SynchronizerState,
+    pub message: StateSyncMessage<BlockHeader>,
+}
+
+impl BroadcasterProtocolMessage {
+    pub fn new(
+        protocol: impl Into<String>,
+        sync_state: SynchronizerState,
+        message: StateSyncMessage<BlockHeader>,
+    ) -> Self {
+        Self {
+            protocol: protocol.into(),
+            sync_state,
+            message,
+        }
     }
 }
 
@@ -1546,6 +1701,15 @@ fn validate_snapshot_partition_contents(
     partitions: &[BroadcasterSnapshotPartition],
 ) -> Result<(), BroadcasterContractError> {
     for partition in partitions {
+        for message in &partition.messages {
+            let backend = backend_for_sync_state(&message.protocol)?;
+            validate_partition_content_backend(
+                "snapshot_chunk.partitions.messages",
+                &message.protocol,
+                partition.backend,
+                backend,
+            )?;
+        }
         for state in &partition.states {
             let backend = backend_for_component(&state.component_id, &state.component)?;
             validate_partition_content_backend(
@@ -1572,6 +1736,15 @@ fn validate_update_partition_contents(
     partitions: &[BroadcasterUpdatePartition],
 ) -> Result<(), BroadcasterContractError> {
     for partition in partitions {
+        for message in &partition.messages {
+            let backend = backend_for_sync_state(&message.protocol)?;
+            validate_partition_content_backend(
+                "update.partitions.messages",
+                &message.protocol,
+                partition.backend,
+                backend,
+            )?;
+        }
         for state in &partition.new_pairs {
             let backend = backend_for_component(&state.component_id, &state.component)?;
             validate_partition_content_backend(
@@ -1639,7 +1812,10 @@ mod tests {
     use num_bigint::BigUint;
     use tycho_simulation::{
         protocol::models::{ProtocolComponent, Update as TychoUpdate},
-        tycho_client::feed::{BlockHeader, SynchronizerState},
+        tycho_client::feed::{
+            synchronizer::{Snapshot, StateSyncMessage},
+            BlockHeader, SynchronizerState,
+        },
         tycho_common::{
             dto::ProtocolStateDelta,
             models::{token::Token, Chain},
@@ -1653,13 +1829,14 @@ mod tests {
 
     use super::{
         BroadcasterBackend, BroadcasterBackendHead, BroadcasterContractError, BroadcasterEnvelope,
-        BroadcasterHeartbeat, BroadcasterPayload, BroadcasterProtocolSyncStatus,
-        BroadcasterProtocolSyncStatusKind, BroadcasterRemovedPair, BroadcasterSnapshotChunk,
-        BroadcasterSnapshotEnd, BroadcasterSnapshotPartition, BroadcasterSnapshotStart,
-        BroadcasterStateDelta, BroadcasterStateEntry, BroadcasterSubscriptionEvent,
-        BroadcasterSubscriptionState, BroadcasterSubscriptionTracker, BroadcasterTokenDto,
-        BroadcasterTokenLookupRequest, BroadcasterTokenLookupResponse,
-        BroadcasterTokenSnapshotResponse, BroadcasterUpdateMessage, BroadcasterUpdatePartition,
+        BroadcasterHeartbeat, BroadcasterPayload, BroadcasterProtocolMessage,
+        BroadcasterProtocolSyncStatus, BroadcasterProtocolSyncStatusKind, BroadcasterRemovedPair,
+        BroadcasterSnapshotChunk, BroadcasterSnapshotEnd, BroadcasterSnapshotPartition,
+        BroadcasterSnapshotSessionResponse, BroadcasterSnapshotStart, BroadcasterStateDelta,
+        BroadcasterStateEntry, BroadcasterSubscriptionEvent, BroadcasterSubscriptionState,
+        BroadcasterSubscriptionTracker, BroadcasterTokenDto, BroadcasterTokenLookupRequest,
+        BroadcasterTokenLookupResponse, BroadcasterTokenSnapshotResponse, BroadcasterUpdateMessage,
+        BroadcasterUpdatePartition,
     };
 
     #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -1786,6 +1963,30 @@ mod tests {
         assert_eq!(json["chainId"], 1);
         assert_eq!(json["tokens"][0]["symbol"], "TKN");
         assert!(json.get("chain_id").is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn snapshot_session_contract_uses_camel_case_shape() -> Result<()> {
+        let response = BroadcasterSnapshotSessionResponse {
+            chain_id: 1,
+            session_id: 9,
+            stream_id: "stream-1".to_string(),
+            snapshot_id: "snapshot-1".to_string(),
+            payload_count: 4,
+            snapshot_chunk_count: 2,
+            expires_in_ms: 300_000,
+        };
+        let json = serde_json::to_value(&response)?;
+
+        assert_eq!(json["chainId"], 1);
+        assert_eq!(json["sessionId"], 9);
+        assert_eq!(json["streamId"], "stream-1");
+        assert_eq!(json["snapshotId"], "snapshot-1");
+        assert_eq!(json["payloadCount"], 4);
+        assert_eq!(json["snapshotChunkCount"], 2);
+        assert_eq!(json["expiresInMs"], 300_000);
+        assert!(json.get("session_id").is_none());
         Ok(())
     }
 
@@ -2990,6 +3191,56 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn constructors_reject_raw_message_partition_backend_mismatch() -> Result<()> {
+        let Err(error) = BroadcasterSnapshotChunk::new(
+            "snapshot-1",
+            0,
+            vec![BroadcasterSnapshotPartition::with_messages(
+                BroadcasterBackend::Native,
+                123,
+                vec![raw_protocol_message("vm:curve")],
+                BTreeMap::new(),
+            )],
+        ) else {
+            return Err(anyhow!(
+                "snapshot chunk should reject raw messages from the wrong backend"
+            ));
+        };
+        assert_eq!(
+            error,
+            BroadcasterContractError::PartitionContentBackendMismatch {
+                context: "snapshot_chunk.partitions.messages",
+                entry: "vm:curve".to_string(),
+                partition_backend: BroadcasterBackend::Native,
+                entry_backend: BroadcasterBackend::Vm,
+            }
+        );
+
+        let Err(error) =
+            BroadcasterUpdateMessage::new(vec![BroadcasterUpdatePartition::with_messages(
+                BroadcasterBackend::Native,
+                123,
+                vec![raw_protocol_message("vm:curve")],
+                BTreeMap::new(),
+            )])
+        else {
+            return Err(anyhow!(
+                "update should reject raw messages from the wrong backend"
+            ));
+        };
+        assert_eq!(
+            error,
+            BroadcasterContractError::PartitionContentBackendMismatch {
+                context: "update.partitions.messages",
+                entry: "vm:curve".to_string(),
+                partition_backend: BroadcasterBackend::Native,
+                entry_backend: BroadcasterBackend::Vm,
+            }
+        );
+        Ok(())
+    }
+
     fn ready_tracker() -> Result<BroadcasterSubscriptionTracker> {
         let mut tracker = BroadcasterSubscriptionTracker::new();
         tracker.observe(&snapshot_start_envelope(
@@ -3235,6 +3486,22 @@ mod tests {
             timestamp: number * 10,
             partial_block_index: None,
         }
+    }
+
+    fn raw_protocol_message(protocol: &str) -> BroadcasterProtocolMessage {
+        BroadcasterProtocolMessage::new(
+            protocol,
+            SynchronizerState::Ready(block_header(123, 1)),
+            StateSyncMessage {
+                header: block_header(123, 1),
+                snapshots: Snapshot {
+                    states: HashMap::new(),
+                    vm_storage: HashMap::new(),
+                },
+                deltas: None,
+                removed_components: HashMap::new(),
+            },
+        )
     }
 
     fn assert_dummy_state(state: &dyn ProtocolSim, expected_label: &str) {

--- a/scripts/start_server.sh
+++ b/scripts/start_server.sh
@@ -408,12 +408,24 @@ if [[ -n "$chain_id_arg" ]]; then
   export CHAIN_ID="$chain_id_arg"
 fi
 
-if [[ -z "${TYCHO_BROADCASTER_WS_URL:-}" && "$simulator_already_running" == "false" ]]; then
+if [[ "$simulator_already_running" == "true" ]]; then
+  if [[ -z "${TYCHO_BROADCASTER_WS_URL:-}" ]]; then
+    echo "TYCHO_BROADCASTER_WS_URL not set; skipping broadcaster startup for running simulator."
+  elif [[ -z "${CHAIN_ID:-}" ]]; then
+    echo "Error: missing chain id. Pass --chain-id or set CHAIN_ID in env/.env." >&2
+    exit 2
+  else
+    start_broadcaster_if_local
+  fi
+  exit 0
+fi
+
+if [[ -z "${TYCHO_BROADCASTER_WS_URL:-}" ]]; then
   echo "Error: TYCHO_BROADCASTER_WS_URL is required for simulator startup." >&2
   exit 2
 fi
 
-if [[ -z "${CHAIN_ID:-}" && "$simulator_already_running" == "false" ]]; then
+if [[ -z "${CHAIN_ID:-}" ]]; then
   echo "Error: missing chain id. Pass --chain-id or set CHAIN_ID in env/.env." >&2
   exit 2
 fi
@@ -425,12 +437,6 @@ fi
 
 if [[ -n "${TYCHO_BROADCASTER_WS_URL:-}" ]]; then
   start_broadcaster_if_local
-elif [[ "$simulator_already_running" == "true" ]]; then
-  echo "TYCHO_BROADCASTER_WS_URL not set; skipping broadcaster startup for running simulator."
-fi
-
-if [[ "$simulator_already_running" == "true" ]]; then
-  exit 0
 fi
 
 (


### PR DESCRIPTION
Move broadcaster startup snapshots onto HTTP snapshot sessions, then attach the websocket with `sessionId` for live updates only. This keeps large serialized snapshots behind byte-capped payload fetches, adds the raw Tycho feed handling needed to rebuild those snapshots correctly, and publishes the broadcaster image for `quoter-base`.