### PR TITLE
feat: Add broadcaster Redis delta publisher foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,6 +931,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "arcstr"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
+
+[[package]]
 name = "ark-bls12-381"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1242,6 +1257,17 @@ dependencies = [
  "compression-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1746,6 +1772,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2092,7 +2127,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
+ "futures-core",
  "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -2113,6 +2152,15 @@ name = "compression-core"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "const-hex"
@@ -2710,6 +2758,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -4325,6 +4394,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4911,6 +4986,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "redis"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fd510128eda94d1d49b9f81487744d5c451422431cce41238fe2853d29f4cc"
+dependencies = [
+ "arc-swap",
+ "arcstr",
+ "async-lock",
+ "backon",
+ "bytes",
+ "cfg-if",
+ "combine",
+ "futures-channel",
+ "futures-util",
+ "itoa",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "ryu",
+ "socket2",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "url",
+ "xxhash-rust",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5391,6 +5495,7 @@ dependencies = [
  "num-traits",
  "rand 0.8.6",
  "rayon",
+ "redis",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -7780,6 +7885,12 @@ name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ num-bigint = "0.4"
 num-traits = "0.2"
 rand = "0.8"
 rayon = "1.12"
+redis = { version = "1.2.3", default-features = false, features = ["connection-manager", "streams", "tokio-comp", "tokio-rustls-comp"] }
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -19,6 +19,7 @@ num-bigint.workspace = true
 num-traits.workspace = true
 rand.workspace = true
 rayon.workspace = true
+redis.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/runtime/src/broadcaster/mod.rs
+++ b/crates/runtime/src/broadcaster/mod.rs
@@ -1,1 +1,2 @@
+pub mod redis_publisher;
 pub mod state;

--- a/crates/runtime/src/broadcaster/redis_publisher.rs
+++ b/crates/runtime/src/broadcaster/redis_publisher.rs
@@ -1,0 +1,417 @@
+use std::fmt;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{anyhow, Context, Result};
+use tokio::sync::Mutex;
+use tokio::time::{timeout, Instant};
+use tracing::{debug, warn};
+
+use crate::metrics::{
+    emit_broadcaster_redis_append_failure, emit_broadcaster_redis_generation_reset,
+};
+use simulator_core::broadcaster::{
+    BroadcasterBackend, BroadcasterEnvelope, BroadcasterHeartbeat, BroadcasterPayload,
+    BroadcasterProgress, BroadcasterRedisReplayBoundary, BroadcasterRedisStreamEntry,
+};
+
+mod config;
+mod retry;
+mod writer;
+
+pub use config::BroadcasterRedisPublisherConfig;
+use retry::{remaining_retry_window, sleep_before_retry};
+pub use writer::{RedisStreamWriter, TokioRedisStreamWriter};
+
+const APPEND_EXHAUSTED_MESSAGE: &str = "Redis broadcaster stream append retry window exhausted";
+
+pub struct BroadcasterRedisPublisher {
+    config: BroadcasterRedisPublisherConfig,
+    writer: Arc<dyn RedisStreamWriter>,
+    inner: Arc<Mutex<BroadcasterRedisPublisherState>>,
+}
+
+impl fmt::Debug for BroadcasterRedisPublisher {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BroadcasterRedisPublisher")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct BroadcasterRedisPublisherStatus {
+    pub healthy: bool,
+    pub stream_key: String,
+    pub stream_id: String,
+    pub snapshot_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latest_entry_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replay_boundary: Option<BroadcasterRedisReplayBoundary>,
+    pub append_success_count: u64,
+    pub append_failure_count: u64,
+    pub generation_reset_count: u64,
+    pub retry_exhaustion_count: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug)]
+struct BroadcasterRedisPublisherState {
+    generation: u64,
+    stream_id: String,
+    snapshot_id: String,
+    next_message_seq: u64,
+    latest_entry_id: Option<String>,
+    append_success_count: u64,
+    append_failure_count: u64,
+    generation_reset_count: u64,
+    retry_exhaustion_count: u64,
+    last_error: Option<String>,
+}
+
+impl BroadcasterRedisPublisherState {
+    fn record_append_success(&mut self, entry_id: String, next_message_seq: u64) {
+        self.append_success_count = self.append_success_count.saturating_add(1);
+        self.latest_entry_id = Some(entry_id);
+        self.next_message_seq = next_message_seq;
+        self.last_error = None;
+    }
+
+    fn record_append_failure(&mut self) {
+        self.append_failure_count = self.append_failure_count.saturating_add(1);
+    }
+
+    fn record_unhealthy(&mut self, last_error: String, retry_exhausted: bool) {
+        if retry_exhausted {
+            self.retry_exhaustion_count = self.retry_exhaustion_count.saturating_add(1);
+        }
+        self.last_error = Some(last_error);
+    }
+
+    fn advance_generation(&mut self, chain_id: u64) -> Result<()> {
+        self.generation_reset_count = self.generation_reset_count.saturating_add(1);
+        self.generation = self
+            .generation
+            .checked_add(1)
+            .ok_or_else(|| anyhow!("Redis broadcaster generation overflow"))?;
+        self.stream_id = format_redis_stream_id(chain_id, self.generation);
+        self.snapshot_id = format_redis_snapshot_id(chain_id, self.generation);
+        self.next_message_seq = 1;
+        self.latest_entry_id = None;
+        self.last_error = None;
+        Ok(())
+    }
+}
+
+impl BroadcasterRedisPublisher {
+    pub fn new_with_initial_generation(
+        config: BroadcasterRedisPublisherConfig,
+        writer: Arc<dyn RedisStreamWriter>,
+        generation: u64,
+    ) -> Self {
+        Self::with_initial_generation(config, writer, generation)
+    }
+
+    fn with_initial_generation(
+        config: BroadcasterRedisPublisherConfig,
+        writer: Arc<dyn RedisStreamWriter>,
+        generation: u64,
+    ) -> Self {
+        let stream_id = format_redis_stream_id(config.chain_id, generation);
+        let snapshot_id = format_redis_snapshot_id(config.chain_id, generation);
+        Self {
+            config,
+            writer,
+            inner: Arc::new(Mutex::new(BroadcasterRedisPublisherState {
+                generation,
+                stream_id,
+                snapshot_id,
+                next_message_seq: 1,
+                latest_entry_id: None,
+                append_success_count: 0,
+                append_failure_count: 0,
+                generation_reset_count: 0,
+                retry_exhaustion_count: 0,
+                last_error: None,
+            })),
+        }
+    }
+
+    pub async fn publish_accepted_payload(&self, payload: BroadcasterPayload) -> Result<()> {
+        let mut guard = self.inner.lock().await;
+        if let Some(error) = &guard.last_error {
+            return Err(anyhow!(
+                "Redis broadcaster publisher is unhealthy; shared broadcaster generation reset is required before publishing more deltas: {error}"
+            ));
+        }
+        let payload = normalize_live_payload(payload, &guard.snapshot_id)?;
+        let append_failures_before = guard.append_failure_count;
+        match self.append_payload_locked(&mut guard, payload).await {
+            Ok(_) => Ok(()),
+            Err(error) => {
+                let message = format!("{error:#}");
+                let retry_exhausted = guard.append_failure_count > append_failures_before;
+                guard.record_unhealthy(message, retry_exhausted);
+                Err(error)
+            }
+        }
+    }
+
+    pub async fn replay_boundary(&self) -> Result<BroadcasterRedisReplayBoundary> {
+        let guard = self.inner.lock().await;
+        if let Some(error) = &guard.last_error {
+            return Err(anyhow!(
+                "Redis broadcaster replay boundary is unavailable while publisher is unhealthy: {error}"
+            ));
+        }
+        self.replay_boundary_locked(&guard)
+    }
+
+    pub async fn reset_generation(
+        &self,
+        reason: impl Into<String>,
+        backends: Vec<BroadcasterBackend>,
+    ) {
+        let mut guard = self.inner.lock().await;
+        let reason = reason.into();
+        if let Err(error) = reset_redis_generation(&mut guard, self.config.chain_id, &reason) {
+            warn!(
+                event = "redis_generation_reset_failed",
+                error = %error,
+                "Redis broadcaster generation reset failed"
+            );
+            return;
+        }
+
+        let marker = match BroadcasterProgress::new(
+            self.config.chain_id,
+            guard.snapshot_id.clone(),
+            backends,
+            reason,
+        ) {
+            Ok(marker) => marker,
+            Err(error) => {
+                guard.record_unhealthy(error.to_string(), false);
+                warn!(
+                    event = "redis_generation_reset_marker_invalid",
+                    error = %error,
+                    "Redis broadcaster generation reset marker was invalid"
+                );
+                return;
+            }
+        };
+        let append_failures_before = guard.append_failure_count;
+        if let Err(error) = self
+            .append_payload_locked(&mut guard, BroadcasterPayload::Progress(marker))
+            .await
+        {
+            let message = format!("{error:#}");
+            let retry_exhausted = guard.append_failure_count > append_failures_before;
+            guard.record_unhealthy(message, retry_exhausted);
+        }
+    }
+
+    pub async fn status_snapshot(&self) -> BroadcasterRedisPublisherStatus {
+        let guard = self.inner.lock().await;
+        let replay_boundary = if guard.last_error.is_none() {
+            self.replay_boundary_locked(&guard).ok()
+        } else {
+            None
+        };
+        BroadcasterRedisPublisherStatus {
+            healthy: guard.last_error.is_none(),
+            stream_key: self.config.stream_key.clone(),
+            stream_id: guard.stream_id.clone(),
+            snapshot_id: guard.snapshot_id.clone(),
+            latest_entry_id: guard.latest_entry_id.clone(),
+            replay_boundary,
+            append_success_count: guard.append_success_count,
+            append_failure_count: guard.append_failure_count,
+            generation_reset_count: guard.generation_reset_count,
+            retry_exhaustion_count: guard.retry_exhaustion_count,
+            last_error: guard.last_error.clone(),
+        }
+    }
+
+    async fn append_payload_locked(
+        &self,
+        guard: &mut BroadcasterRedisPublisherState,
+        payload: BroadcasterPayload,
+    ) -> Result<(BroadcasterRedisStreamEntry, String)> {
+        let message_seq = guard.next_message_seq;
+        let next_message_seq = message_seq
+            .checked_add(1)
+            .ok_or_else(|| anyhow!("Redis broadcaster message_seq overflow"))?;
+        let envelope = BroadcasterEnvelope::new(guard.stream_id.clone(), message_seq, payload);
+        let entry = BroadcasterRedisStreamEntry::from_envelope(
+            self.config.chain_id,
+            current_time_ms(),
+            &envelope,
+        )?;
+        let entry_id = self
+            .append_with_retry(guard, &entry)
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to append Redis broadcaster message_seq {}",
+                    entry.message_seq
+                )
+            })?;
+        guard.record_append_success(entry_id.clone(), next_message_seq);
+        debug!(
+            event = "redis_stream_append",
+            stream_key = self.config.stream_key.as_str(),
+            stream_id = entry.stream_id.as_str(),
+            message_seq = entry.message_seq,
+            kind = %entry.kind,
+            redis_entry_id = entry_id.as_str(),
+            "Redis broadcaster stream entry appended"
+        );
+        Ok((entry, entry_id))
+    }
+
+    fn replay_boundary_locked(
+        &self,
+        guard: &BroadcasterRedisPublisherState,
+    ) -> Result<BroadcasterRedisReplayBoundary> {
+        BroadcasterRedisReplayBoundary::new(
+            self.config.stream_key.clone(),
+            guard.stream_id.clone(),
+            guard.snapshot_id.clone(),
+            guard.generation,
+            guard.next_message_seq.saturating_sub(1),
+        )
+        .map_err(Into::into)
+    }
+
+    async fn append_with_retry(
+        &self,
+        guard: &mut BroadcasterRedisPublisherState,
+        entry: &BroadcasterRedisStreamEntry,
+    ) -> Result<String> {
+        let started_at = Instant::now();
+        let mut attempts = 0u64;
+        let mut last_error = None;
+        loop {
+            let Some(remaining) =
+                remaining_retry_window(started_at, self.config.append_retry_window)
+            else {
+                let error =
+                    anyhow!(last_error.unwrap_or_else(|| APPEND_EXHAUSTED_MESSAGE.to_string()));
+                self.record_write_failure(guard, entry, attempts, &error);
+                return Err(error);
+            };
+            attempts = attempts.saturating_add(1);
+            match timeout(
+                remaining,
+                self.writer
+                    .append(&self.config.stream_key, self.config.maxlen, entry),
+            )
+            .await
+            {
+                Err(_) => {
+                    let error = anyhow!(APPEND_EXHAUSTED_MESSAGE);
+                    self.record_write_failure(guard, entry, attempts, &error);
+                    return Err(error);
+                }
+                Ok(Ok(result)) => return Ok(result),
+                Ok(Err(error)) => {
+                    if started_at.elapsed() >= self.config.append_retry_window {
+                        self.record_write_failure(guard, entry, attempts, &error);
+                        return Err(error);
+                    }
+                    last_error = Some(error.to_string());
+                    sleep_before_retry(started_at, self.config.append_retry_window, attempts).await;
+                }
+            }
+        }
+    }
+
+    fn record_write_failure(
+        &self,
+        guard: &mut BroadcasterRedisPublisherState,
+        entry: &BroadcasterRedisStreamEntry,
+        attempts: u64,
+        error: &anyhow::Error,
+    ) {
+        guard.record_append_failure();
+        emit_broadcaster_redis_append_failure();
+        warn!(
+            event = "redis_stream_append_failed",
+            stream_key = self.config.stream_key.as_str(),
+            stream_id = entry.stream_id.as_str(),
+            message_seq = entry.message_seq,
+            kind = %entry.kind,
+            attempts,
+            error = %error,
+            "Redis broadcaster stream append retry window exhausted"
+        );
+    }
+}
+
+fn normalize_live_payload(
+    payload: BroadcasterPayload,
+    snapshot_id: &str,
+) -> Result<BroadcasterPayload> {
+    match payload {
+        BroadcasterPayload::Update(_) => Ok(payload),
+        BroadcasterPayload::Heartbeat(heartbeat) => {
+            Ok(BroadcasterPayload::Heartbeat(BroadcasterHeartbeat::new(
+                heartbeat.chain_id,
+                snapshot_id.to_string(),
+                heartbeat.backend_heads,
+            )?))
+        }
+        BroadcasterPayload::Progress(progress) => {
+            Ok(BroadcasterPayload::Progress(BroadcasterProgress::new(
+                progress.chain_id,
+                snapshot_id.to_string(),
+                progress.backends,
+                progress.reason,
+            )?))
+        }
+        BroadcasterPayload::SnapshotStart(_)
+        | BroadcasterPayload::SnapshotChunk(_)
+        | BroadcasterPayload::SnapshotEnd(_) => Err(anyhow!(
+            "Redis broadcaster live payload cannot be a snapshot message"
+        )),
+    }
+}
+
+fn format_redis_stream_id(chain_id: u64, generation: u64) -> String {
+    format!("chain-{chain_id}-stream-{generation}")
+}
+
+fn format_redis_snapshot_id(chain_id: u64, generation: u64) -> String {
+    format!("chain-{chain_id}-snapshot-{generation}")
+}
+
+fn reset_redis_generation(
+    guard: &mut BroadcasterRedisPublisherState,
+    chain_id: u64,
+    reason: &str,
+) -> Result<()> {
+    guard.advance_generation(chain_id)?;
+    emit_broadcaster_redis_generation_reset();
+    warn!(
+        event = "redis_generation_reset",
+        stream_id = guard.stream_id.as_str(),
+        snapshot_id = guard.snapshot_id.as_str(),
+        generation = guard.generation,
+        reason,
+        "Redis broadcaster generation reset"
+    );
+    Ok(())
+}
+
+fn current_time_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/runtime/src/broadcaster/redis_publisher/config.rs
+++ b/crates/runtime/src/broadcaster/redis_publisher/config.rs
@@ -1,0 +1,22 @@
+use std::time::Duration;
+
+use crate::config::BroadcasterRedisConfig;
+
+#[derive(Debug, Clone)]
+pub struct BroadcasterRedisPublisherConfig {
+    pub stream_key: String,
+    pub chain_id: u64,
+    pub append_retry_window: Duration,
+    pub maxlen: Option<u64>,
+}
+
+impl BroadcasterRedisPublisherConfig {
+    pub fn from_redis_config(redis_config: &BroadcasterRedisConfig, chain_id: u64) -> Self {
+        Self {
+            stream_key: redis_config.stream_key.clone(),
+            chain_id,
+            append_retry_window: Duration::from_millis(redis_config.append_retry_window_ms),
+            maxlen: redis_config.maxlen,
+        }
+    }
+}

--- a/crates/runtime/src/broadcaster/redis_publisher/retry.rs
+++ b/crates/runtime/src/broadcaster/redis_publisher/retry.rs
@@ -1,0 +1,34 @@
+use std::time::Duration;
+
+use rand::Rng;
+use tokio::time::Instant;
+
+const RETRY_BACKOFF_BASE: Duration = Duration::from_millis(5);
+const RETRY_BACKOFF_CAP: Duration = Duration::from_millis(200);
+
+pub(super) fn remaining_retry_window(
+    started_at: Instant,
+    retry_window: Duration,
+) -> Option<Duration> {
+    let remaining = retry_window.saturating_sub(started_at.elapsed());
+    (!remaining.is_zero()).then_some(remaining)
+}
+
+pub(super) async fn sleep_before_retry(started_at: Instant, retry_window: Duration, attempts: u64) {
+    let elapsed = started_at.elapsed();
+    let remaining = retry_window.saturating_sub(elapsed);
+    if remaining.is_zero() {
+        return;
+    }
+    let backoff = retry_backoff(attempts).min(remaining);
+    let max_delay_ms = backoff.as_millis().max(1) as u64;
+    let delay_ms = rand::thread_rng().gen_range(1..=max_delay_ms);
+    tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+}
+
+fn retry_backoff(attempts: u64) -> Duration {
+    let multiplier = 1u32 << attempts.saturating_sub(1).min(5);
+    RETRY_BACKOFF_BASE
+        .saturating_mul(multiplier)
+        .min(RETRY_BACKOFF_CAP)
+}

--- a/crates/runtime/src/broadcaster/redis_publisher/tests.rs
+++ b/crates/runtime/src/broadcaster/redis_publisher/tests.rs
@@ -1,0 +1,675 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::{anyhow, Result};
+use num_bigint::BigUint;
+use redis::streams::{StreamId, StreamRangeReply};
+use redis::Value;
+use tokio::sync::Mutex;
+use tokio::time::{sleep, Duration};
+use tycho_simulation::protocol::models::{ProtocolComponent, Update};
+use tycho_simulation::tycho_client::feed::{BlockHeader, SynchronizerState};
+use tycho_simulation::tycho_common::dto::ProtocolStateDelta;
+use tycho_simulation::tycho_common::models::{token::Token, Chain};
+use tycho_simulation::tycho_common::simulation::errors::{SimulationError, TransitionError};
+use tycho_simulation::tycho_common::simulation::protocol_sim::{
+    Balances, GetAmountOutResult, ProtocolSim,
+};
+use tycho_simulation::tycho_common::Bytes;
+
+use super::{
+    writer::{
+        next_generation_after_entry_id, redis_entry_fields, redis_entry_id,
+        redis_stream_entry_matches_reply, redis_xadd_command,
+    },
+    BroadcasterRedisPublisher, BroadcasterRedisPublisherConfig, RedisStreamWriter,
+};
+use crate::broadcaster::state::BroadcasterSnapshotCache;
+use simulator_core::broadcaster::{
+    BroadcasterBackend, BroadcasterMessageKind, BroadcasterPayload, BroadcasterProgress,
+    BroadcasterRedisStreamEntry,
+};
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+struct DummySim(u8);
+
+#[typetag::serde(name = "RedisPublisherDummySim")]
+impl ProtocolSim for DummySim {
+    fn fee(&self) -> f64 {
+        0.0
+    }
+
+    fn spot_price(&self, _base: &Token, _quote: &Token) -> Result<f64, SimulationError> {
+        Ok(0.0)
+    }
+
+    fn get_amount_out(
+        &self,
+        amount_in: BigUint,
+        _token_in: &Token,
+        _token_out: &Token,
+    ) -> Result<GetAmountOutResult, SimulationError> {
+        Ok(GetAmountOutResult::new(
+            amount_in,
+            BigUint::from(0u8),
+            self.clone_box(),
+        ))
+    }
+
+    fn get_limits(
+        &self,
+        _sell_token: Bytes,
+        _buy_token: Bytes,
+    ) -> Result<(BigUint, BigUint), SimulationError> {
+        Ok((BigUint::from(0u8), BigUint::from(0u8)))
+    }
+
+    fn delta_transition(
+        &mut self,
+        _delta: ProtocolStateDelta,
+        _tokens: &HashMap<Bytes, Token>,
+        _balances: &Balances,
+    ) -> Result<(), TransitionError> {
+        Ok(())
+    }
+
+    fn clone_box(&self) -> Box<dyn ProtocolSim> {
+        Box::new(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    fn eq(&self, other: &dyn ProtocolSim) -> bool {
+        other
+            .as_any()
+            .downcast_ref::<DummySim>()
+            .map(|value| value.0 == self.0)
+            .unwrap_or(false)
+    }
+}
+
+#[tokio::test]
+async fn replay_boundary_starts_before_first_delta_without_publishing_snapshot() -> Result<()> {
+    let writer = FakeRedisWriter::default();
+    let publisher = BroadcasterRedisPublisher::new_with_initial_generation(
+        publisher_config(),
+        Arc::new(writer.clone()),
+        1,
+    );
+
+    let boundary = publisher.replay_boundary().await?;
+
+    assert_eq!(boundary.stream_key, "dsolver:broadcaster:test:events");
+    assert_eq!(boundary.stream_id, "chain-1-stream-1");
+    assert_eq!(boundary.snapshot_id, "chain-1-snapshot-1");
+    assert_eq!(boundary.generation, 1);
+    assert_eq!(boundary.exclusive_message_seq, 0);
+    assert_eq!(boundary.exclusive_entry_id(), "1-0");
+    assert!(
+        writer.appends().await.is_empty(),
+        "HTTP snapshots are the bootstrap source; Redis must not receive full snapshot entries"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn publishes_live_updates_and_heartbeats_as_deltas_after_replay_boundary() -> Result<()> {
+    let raw_cache = ready_cache(BroadcasterBackend::Native, 10, "native-1").await?;
+    let rfq_cache = ready_cache(BroadcasterBackend::Rfq, 20, "rfq-1").await?;
+    let writer = FakeRedisWriter::default();
+    let publisher = BroadcasterRedisPublisher::new_with_initial_generation(
+        publisher_config(),
+        Arc::new(writer.clone()),
+        1,
+    );
+    let boundary = publisher.replay_boundary().await?;
+
+    let native_update = raw_cache
+        .apply_update(&update(BroadcasterBackend::Native, 11, "native-2"))
+        .await?;
+    publisher
+        .publish_accepted_payload(BroadcasterPayload::Update(native_update))
+        .await?;
+    let rfq_update = rfq_cache
+        .apply_update(&update(BroadcasterBackend::Rfq, 21, "rfq-2"))
+        .await?;
+    publisher
+        .publish_accepted_payload(BroadcasterPayload::Update(rfq_update))
+        .await?;
+    let heartbeat = raw_cache
+        .heartbeat()
+        .await?
+        .ok_or_else(|| anyhow!("ready raw cache should produce heartbeat"))?;
+    publisher.publish_accepted_payload(heartbeat).await?;
+
+    let appends = writer.appends().await;
+    assert_eq!(
+        appends
+            .iter()
+            .map(|append| append.entry.message_seq)
+            .collect::<Vec<_>>(),
+        vec![1, 2, 3]
+    );
+    assert_eq!(appends[0].entry.kind.as_str(), "update");
+    assert_eq!(appends[0].entry.backend_scope, "native");
+    assert_eq!(appends[0].entry.block_number, Some(11));
+    assert_eq!(appends[1].entry.kind.as_str(), "update");
+    assert_eq!(appends[1].entry.backend_scope, "rfq");
+    assert_eq!(appends[1].entry.block_number, None);
+    assert_eq!(appends[2].entry.kind.as_str(), "heartbeat");
+    assert_eq!(appends[2].entry.backend_scope, "native");
+    assert_eq!(appends[2].entry.stream_id, boundary.stream_id);
+    assert_eq!(
+        appends[2].entry.snapshot_id.as_deref(),
+        Some(boundary.snapshot_id.as_str())
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn append_retry_success_preserves_message_sequence_order() -> Result<()> {
+    let raw_cache = ready_cache(BroadcasterBackend::Native, 10, "native-1").await?;
+    let writer = FakeRedisWriter::default();
+    writer.fail_next_appends(1).await;
+    let publisher = BroadcasterRedisPublisher::new_with_initial_generation(
+        publisher_config(),
+        Arc::new(writer.clone()),
+        1,
+    );
+
+    let update = raw_cache
+        .apply_update(&update(BroadcasterBackend::Native, 11, "native-2"))
+        .await?;
+    publisher
+        .publish_accepted_payload(BroadcasterPayload::Update(update))
+        .await?;
+
+    let appends = writer.appends().await;
+    assert_eq!(writer.append_attempt_count().await, 2);
+    assert_eq!(
+        appends
+            .iter()
+            .map(|append| append.entry.message_seq)
+            .collect::<Vec<_>>(),
+        vec![1]
+    );
+    assert_eq!(appends[0].entry.kind.as_str(), "update");
+    Ok(())
+}
+
+#[tokio::test]
+async fn readiness_triggering_update_is_published_as_a_delta() -> Result<()> {
+    let rfq_cache =
+        BroadcasterSnapshotCache::new(Chain::Ethereum.id(), vec![BroadcasterBackend::Rfq]);
+    let writer = FakeRedisWriter::default();
+    let publisher = BroadcasterRedisPublisher::new_with_initial_generation(
+        publisher_config(),
+        Arc::new(writer.clone()),
+        1,
+    );
+    let rfq_update = rfq_cache
+        .apply_update(&update(BroadcasterBackend::Rfq, 20, "rfq-1"))
+        .await?;
+
+    publisher
+        .publish_accepted_payload(BroadcasterPayload::Update(rfq_update))
+        .await?;
+
+    let appends = writer.appends().await;
+    assert_eq!(appends.len(), 1);
+    assert_eq!(appends[0].entry.kind.as_str(), "update");
+    assert_eq!(appends[0].entry.backend_scope, "rfq");
+    Ok(())
+}
+
+#[tokio::test]
+async fn retry_exhaustion_marks_unhealthy_until_generation_reset() -> Result<()> {
+    let raw_cache = ready_cache(BroadcasterBackend::Native, 10, "native-1").await?;
+    let writer = FakeRedisWriter::default();
+    writer.fail_next_appends(100).await;
+    let publisher = BroadcasterRedisPublisher::new_with_initial_generation(
+        publisher_config(),
+        Arc::new(writer.clone()),
+        1,
+    );
+
+    let failed_update = raw_cache
+        .apply_update(&update(BroadcasterBackend::Native, 11, "native-2"))
+        .await?;
+    let Err(error) = publisher
+        .publish_accepted_payload(BroadcasterPayload::Update(failed_update))
+        .await
+    else {
+        return Err(anyhow!(
+            "retry exhaustion should surface the failed publication"
+        ));
+    };
+    assert!(error
+        .to_string()
+        .contains("failed to append Redis broadcaster"));
+
+    let failed_status = publisher.status_snapshot().await;
+    assert!(!failed_status.healthy);
+    assert_eq!(failed_status.generation_reset_count, 0);
+    assert_eq!(failed_status.retry_exhaustion_count, 1);
+    assert_eq!(failed_status.stream_id, "chain-1-stream-1");
+    assert!(failed_status.replay_boundary.is_none());
+    assert!(failed_status
+        .last_error
+        .as_deref()
+        .unwrap_or("")
+        .contains("planned append failure"));
+
+    writer.fail_next_appends(0).await;
+    let blocked_update = raw_cache
+        .apply_update(&update(BroadcasterBackend::Native, 12, "native-3"))
+        .await?;
+    let Err(error) = publisher
+        .publish_accepted_payload(BroadcasterPayload::Update(blocked_update))
+        .await
+    else {
+        return Err(anyhow!(
+            "publisher should stay unavailable until the shared generation reset"
+        ));
+    };
+    assert!(format!("{error:#}").contains("publisher is unhealthy"));
+    assert_eq!(
+        writer.appends().await.len(),
+        0,
+        "a blocked publisher must not append into a Redis-only generation"
+    );
+
+    publisher
+        .reset_generation(
+            "shared broadcaster generation reset",
+            vec![BroadcasterBackend::Native],
+        )
+        .await;
+    let reset_status = publisher.status_snapshot().await;
+    assert!(reset_status.healthy);
+    assert_eq!(reset_status.generation_reset_count, 1);
+    assert_eq!(reset_status.retry_exhaustion_count, 1);
+    assert_eq!(reset_status.stream_id, "chain-1-stream-2");
+    assert!(reset_status.replay_boundary.is_some());
+    let appends_after_reset = writer.appends().await;
+    let reset_marker = appends_after_reset
+        .last()
+        .ok_or_else(|| anyhow!("generation reset should publish a Redis progress marker"))?;
+    assert_eq!(reset_marker.entry.stream_id, "chain-1-stream-2");
+    assert_eq!(reset_marker.entry.message_seq, 1);
+    assert_eq!(reset_marker.entry.kind, BroadcasterMessageKind::Progress);
+    assert_eq!(reset_marker.entry.backend_scope, "native");
+    assert!(reset_marker
+        .entry
+        .payload_json
+        .contains("shared broadcaster generation reset"));
+
+    let recovered_update = raw_cache
+        .apply_update(&update(BroadcasterBackend::Native, 13, "native-4"))
+        .await?;
+    publisher
+        .publish_accepted_payload(BroadcasterPayload::Update(recovered_update))
+        .await?;
+
+    let recovered_status = publisher.status_snapshot().await;
+    assert!(recovered_status.healthy);
+    assert_eq!(recovered_status.stream_id, "chain-1-stream-2");
+    assert!(recovered_status.replay_boundary.is_some());
+    assert!(recovered_status.last_error.is_none());
+
+    let recovered_stream_entries = writer
+        .appends()
+        .await
+        .into_iter()
+        .filter(|append| append.entry.stream_id == recovered_status.stream_id)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        recovered_stream_entries
+            .iter()
+            .map(|append| append.entry.message_seq)
+            .collect::<Vec<_>>(),
+        vec![1, 2]
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn stalled_append_exhausts_retry_window() -> Result<()> {
+    let raw_cache = ready_cache(BroadcasterBackend::Native, 10, "native-1").await?;
+    let writer = FakeRedisWriter::default();
+    writer.delay_appends(Duration::from_millis(50)).await;
+    let publisher = BroadcasterRedisPublisher::new_with_initial_generation(
+        publisher_config(),
+        Arc::new(writer.clone()),
+        1,
+    );
+
+    let update = raw_cache
+        .apply_update(&update(BroadcasterBackend::Native, 11, "native-2"))
+        .await?;
+    let Err(error) = publisher
+        .publish_accepted_payload(BroadcasterPayload::Update(update))
+        .await
+    else {
+        return Err(anyhow!("stalled append should exhaust the retry window"));
+    };
+    assert!(format!("{error:#}").contains("retry window exhausted"));
+
+    let failed_status = publisher.status_snapshot().await;
+    assert!(!failed_status.healthy);
+    assert_eq!(failed_status.append_failure_count, 1);
+    assert_eq!(failed_status.generation_reset_count, 0);
+    assert_eq!(failed_status.retry_exhaustion_count, 1);
+    assert!(failed_status.replay_boundary.is_none());
+    assert!(writer.appends().await.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn publish_rejects_message_sequence_overflow() -> Result<()> {
+    let raw_cache = ready_cache(BroadcasterBackend::Native, 10, "native-1").await?;
+    let writer = FakeRedisWriter::default();
+    let publisher = BroadcasterRedisPublisher::new_with_initial_generation(
+        publisher_config(),
+        Arc::new(writer.clone()),
+        1,
+    );
+    publisher.inner.lock().await.next_message_seq = u64::MAX;
+
+    let update = raw_cache
+        .apply_update(&update(BroadcasterBackend::Native, 11, "native-2"))
+        .await?;
+    let Err(error) = publisher
+        .publish_accepted_payload(BroadcasterPayload::Update(update))
+        .await
+    else {
+        return Err(anyhow!("message sequence overflow should fail"));
+    };
+
+    assert!(format!("{error:#}").contains("message_seq overflow"));
+    let failed_status = publisher.status_snapshot().await;
+    assert!(!failed_status.healthy);
+    assert_eq!(failed_status.retry_exhaustion_count, 0);
+    assert!(writer.appends().await.is_empty());
+    Ok(())
+}
+
+#[test]
+fn redis_entry_id_uses_generation_and_message_sequence() -> Result<()> {
+    let entry = BroadcasterRedisStreamEntry {
+        schema_version: "1".to_string(),
+        chain_id: Chain::Ethereum.id(),
+        stream_id: "chain-1-stream-42".to_string(),
+        message_seq: 7,
+        kind: simulator_core::broadcaster::BroadcasterMessageKind::Update,
+        snapshot_id: None,
+        backend_scope: "native".to_string(),
+        block_number: Some(11),
+        observed_timestamp_ms: None,
+        event_time_ms: 1_710_000_000_123,
+        payload_json: "{}".to_string(),
+    };
+
+    assert_eq!(redis_entry_id(&entry)?, "42-7");
+    Ok(())
+}
+
+#[test]
+fn next_generation_starts_after_retained_redis_stream_top() -> Result<()> {
+    assert_eq!(next_generation_after_entry_id("42-7")?, 43);
+    assert_eq!(next_generation_after_entry_id("0-0")?, 1);
+    assert!(next_generation_after_entry_id("not-an-entry-id").is_err());
+    Ok(())
+}
+
+#[test]
+fn redis_xadd_command_uses_configured_maxlen() -> Result<()> {
+    let entry = BroadcasterRedisStreamEntry {
+        schema_version: "1".to_string(),
+        chain_id: Chain::Ethereum.id(),
+        stream_id: "chain-1-stream-42".to_string(),
+        message_seq: 7,
+        kind: simulator_core::broadcaster::BroadcasterMessageKind::Update,
+        snapshot_id: None,
+        backend_scope: "native".to_string(),
+        block_number: Some(11),
+        observed_timestamp_ms: None,
+        event_time_ms: 1_710_000_000_123,
+        payload_json: "{}".to_string(),
+    };
+
+    let command = redis_xadd_command("stream:test", Some(1_000), &entry)?;
+    let packed = String::from_utf8(command.get_packed_command())?;
+
+    assert!(packed.contains("MAXLEN"));
+    assert!(packed.contains("\r\n~\r\n"));
+    assert!(packed.contains("\r\n1000\r\n"));
+    Ok(())
+}
+
+#[test]
+fn redis_progress_entry_carries_generation_reset_reason() -> Result<()> {
+    let envelope = simulator_core::broadcaster::BroadcasterEnvelope::new(
+        "chain-1-stream-2",
+        1,
+        BroadcasterPayload::Progress(BroadcasterProgress::new(
+            Chain::Ethereum.id(),
+            "chain-1-snapshot-2",
+            vec![BroadcasterBackend::Native],
+            "stream_restart",
+        )?),
+    );
+    let entry = BroadcasterRedisStreamEntry::from_envelope(
+        Chain::Ethereum.id(),
+        1_710_000_000_123,
+        &envelope,
+    )?;
+
+    assert_eq!(entry.kind, BroadcasterMessageKind::Progress);
+    assert_eq!(entry.snapshot_id.as_deref(), Some("chain-1-snapshot-2"));
+    assert_eq!(entry.backend_scope, "native");
+    assert_eq!(entry.block_number, None);
+    Ok(())
+}
+
+#[test]
+fn redis_xadd_recovery_requires_existing_entry_to_match_exact_fields() -> Result<()> {
+    let entry = BroadcasterRedisStreamEntry {
+        schema_version: "1".to_string(),
+        chain_id: 1,
+        stream_id: "chain-1-stream-7".to_string(),
+        message_seq: 3,
+        kind: simulator_core::broadcaster::BroadcasterMessageKind::Update,
+        snapshot_id: None,
+        backend_scope: "native".to_string(),
+        block_number: Some(12),
+        observed_timestamp_ms: None,
+        event_time_ms: 1_000,
+        payload_json: "{}".to_string(),
+    };
+    let entry_id = redis_entry_id(&entry)?;
+    let fields = redis_entry_fields(&entry)?;
+    let reply = stream_range_reply(&entry_id, &fields);
+
+    assert!(redis_stream_entry_matches_reply(
+        &reply, &entry_id, &fields
+    )?);
+
+    let mut changed_fields = fields.clone();
+    let message_seq = changed_fields
+        .iter_mut()
+        .find(|(field, _)| field == "message_seq")
+        .ok_or_else(|| anyhow!("message_seq field missing"))?;
+    message_seq.1 = "4".to_string();
+    assert!(!redis_stream_entry_matches_reply(
+        &reply,
+        &entry_id,
+        &changed_fields
+    )?);
+    assert!(!redis_stream_entry_matches_reply(&reply, "7-4", &fields)?);
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct CapturedAppend {
+    entry: BroadcasterRedisStreamEntry,
+}
+
+fn stream_range_reply(entry_id: &str, fields: &[(String, String)]) -> StreamRangeReply {
+    let map = fields
+        .iter()
+        .map(|(field, value)| (field.clone(), Value::BulkString(value.as_bytes().to_vec())))
+        .collect();
+    StreamRangeReply {
+        ids: vec![StreamId {
+            id: entry_id.to_string(),
+            map,
+            milliseconds_elapsed_from_delivery: None,
+            delivered_count: None,
+        }],
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct FakeRedisWriter {
+    inner: Arc<Mutex<FakeRedisWriterState>>,
+}
+
+#[derive(Debug, Default)]
+struct FakeRedisWriterState {
+    appends: Vec<CapturedAppend>,
+    fail_next_appends: usize,
+    append_delay: Option<Duration>,
+    append_attempt_count: usize,
+}
+
+impl FakeRedisWriter {
+    async fn fail_next_appends(&self, count: usize) {
+        self.inner.lock().await.fail_next_appends = count;
+    }
+
+    async fn delay_appends(&self, delay: Duration) {
+        self.inner.lock().await.append_delay = Some(delay);
+    }
+
+    async fn append_attempt_count(&self) -> usize {
+        self.inner.lock().await.append_attempt_count
+    }
+
+    async fn appends(&self) -> Vec<CapturedAppend> {
+        self.inner.lock().await.appends.clone()
+    }
+}
+
+impl RedisStreamWriter for FakeRedisWriter {
+    fn append<'a>(
+        &'a self,
+        _stream_key: &'a str,
+        _maxlen: Option<u64>,
+        entry: &'a BroadcasterRedisStreamEntry,
+    ) -> futures::future::BoxFuture<'a, Result<String>> {
+        Box::pin(async move {
+            let delay = self.inner.lock().await.append_delay;
+            if let Some(delay) = delay {
+                sleep(delay).await;
+            }
+            let mut guard = self.inner.lock().await;
+            guard.append_attempt_count = guard.append_attempt_count.saturating_add(1);
+            if guard.fail_next_appends > 0 {
+                guard.fail_next_appends -= 1;
+                return Err(anyhow!("planned append failure"));
+            }
+            let entry_id = format!("1000-{}", guard.appends.len());
+            guard.appends.push(CapturedAppend {
+                entry: entry.clone(),
+            });
+            Ok(entry_id)
+        })
+    }
+}
+
+async fn ready_cache(
+    backend: BroadcasterBackend,
+    block_number: u64,
+    component_id: &str,
+) -> Result<BroadcasterSnapshotCache> {
+    let cache = BroadcasterSnapshotCache::new(Chain::Ethereum.id(), vec![backend]);
+    cache
+        .apply_update(&update(backend, block_number, component_id))
+        .await?;
+    Ok(cache)
+}
+
+fn update(backend: BroadcasterBackend, block_number: u64, component_id: &str) -> Update {
+    let protocol = match backend {
+        BroadcasterBackend::Native => "uniswap_v2",
+        BroadcasterBackend::Vm => "vm:balancer_v2",
+        BroadcasterBackend::Rfq => "rfq:bebop",
+    };
+    let mut new_pairs = HashMap::new();
+    new_pairs.insert(
+        component_id.to_string(),
+        protocol_component(protocol, block_number as u8),
+    );
+
+    let mut states = HashMap::new();
+    states.insert(
+        component_id.to_string(),
+        Box::new(DummySim(block_number as u8)) as Box<dyn ProtocolSim>,
+    );
+
+    Update::new(block_number, states, new_pairs).set_sync_states(HashMap::from([(
+        protocol.to_string(),
+        SynchronizerState::Ready(BlockHeader {
+            hash: Bytes::from(vec![1u8; 32]),
+            number: block_number,
+            parent_hash: Bytes::from(vec![2u8; 32]),
+            revert: false,
+            timestamp: block_number,
+            partial_block_index: None,
+        }),
+    )]))
+}
+
+fn protocol_component(protocol: &str, seed: u8) -> ProtocolComponent {
+    ProtocolComponent::new(
+        Bytes::from([seed; 20]),
+        protocol.to_string(),
+        protocol.to_string(),
+        Chain::Ethereum,
+        vec![dummy_token(1, "TKNA"), dummy_token(2, "TKNB")],
+        Vec::new(),
+        HashMap::new(),
+        Bytes::from([9u8; 32]),
+        chrono::DateTime::<chrono::Utc>::from_timestamp(0, 0)
+            .unwrap_or_else(|| unreachable!("unix epoch"))
+            .naive_utc(),
+    )
+}
+
+fn dummy_token(seed: u8, symbol: &str) -> Token {
+    Token::new(
+        &Bytes::from([seed; 20]),
+        symbol,
+        18,
+        0,
+        &[],
+        Chain::Ethereum,
+        1,
+    )
+}
+
+fn publisher_config() -> BroadcasterRedisPublisherConfig {
+    BroadcasterRedisPublisherConfig {
+        stream_key: "dsolver:broadcaster:test:events".to_string(),
+        chain_id: Chain::Ethereum.id(),
+        append_retry_window: Duration::from_millis(10),
+        maxlen: None,
+    }
+}

--- a/crates/runtime/src/broadcaster/redis_publisher/writer.rs
+++ b/crates/runtime/src/broadcaster/redis_publisher/writer.rs
@@ -1,0 +1,211 @@
+use anyhow::{anyhow, Context, Result};
+use futures::future::BoxFuture;
+use redis::streams::{StreamInfoStreamReply, StreamRangeReply};
+use serde_json::Value;
+
+use simulator_core::broadcaster::BroadcasterRedisStreamEntry;
+
+pub trait RedisStreamWriter: Send + Sync {
+    fn append<'a>(
+        &'a self,
+        stream_key: &'a str,
+        maxlen: Option<u64>,
+        entry: &'a BroadcasterRedisStreamEntry,
+    ) -> BoxFuture<'a, Result<String>>;
+}
+
+pub struct TokioRedisStreamWriter {
+    connection: redis::aio::ConnectionManager,
+}
+
+impl TokioRedisStreamWriter {
+    pub async fn connect(redis_url: &str) -> Result<Self> {
+        let client = redis::Client::open(redis_url)
+            .context("failed to create Redis client from BROADCASTER_REDIS_URL")?;
+        let connection = client
+            .get_connection_manager()
+            .await
+            .context("failed to connect to broadcaster Redis")?;
+        Ok(Self { connection })
+    }
+
+    pub async fn next_generation(&self, stream_key: &str) -> Result<u64> {
+        let mut connection = self.connection.clone();
+        let reply = redis::cmd("XINFO")
+            .arg("STREAM")
+            .arg(stream_key)
+            .query_async::<StreamInfoStreamReply>(&mut connection)
+            .await;
+        next_generation_from_xinfo_reply(reply)
+    }
+}
+
+impl RedisStreamWriter for TokioRedisStreamWriter {
+    fn append<'a>(
+        &'a self,
+        stream_key: &'a str,
+        maxlen: Option<u64>,
+        entry: &'a BroadcasterRedisStreamEntry,
+    ) -> BoxFuture<'a, Result<String>> {
+        Box::pin(async move {
+            let entry_id = redis_entry_id(entry)?;
+            let fields = redis_entry_fields(entry)?;
+            let command = redis_xadd_command_from_fields(stream_key, maxlen, &entry_id, &fields);
+            let mut connection = self.connection.clone();
+            match command.query_async::<String>(&mut connection).await {
+                Ok(entry_id) => Ok(entry_id),
+                Err(error) => {
+                    if redis_stream_entry_matches(&mut connection, stream_key, &entry_id, &fields)
+                        .await?
+                    {
+                        Ok(entry_id)
+                    } else {
+                        Err(error).context("Redis XADD failed")
+                    }
+                }
+            }
+        })
+    }
+}
+
+fn next_generation_from_xinfo_reply(
+    reply: std::result::Result<StreamInfoStreamReply, redis::RedisError>,
+) -> Result<u64> {
+    match reply {
+        Ok(reply) => next_generation_after_entry_id(&reply.last_generated_id),
+        Err(error) if redis_stream_missing_key(&error) => Ok(1),
+        Err(error) => Err(anyhow!(error).context("Redis XINFO STREAM failed")),
+    }
+}
+
+pub(super) fn next_generation_after_entry_id(entry_id: &str) -> Result<u64> {
+    let generation = entry_id
+        .split_once('-')
+        .map(|(generation, _)| generation)
+        .ok_or_else(|| anyhow!("Redis stream last-generated-id is invalid: {entry_id}"))?
+        .parse::<u64>()
+        .with_context(|| format!("Redis stream last-generated-id is invalid: {entry_id}"))?;
+    generation
+        .checked_add(1)
+        .ok_or_else(|| anyhow!("Redis broadcaster generation overflow"))
+}
+
+fn redis_stream_missing_key(error: &redis::RedisError) -> bool {
+    error
+        .detail()
+        .is_some_and(|detail| detail.contains("no such key"))
+}
+
+#[cfg(test)]
+pub(super) fn redis_xadd_command(
+    stream_key: &str,
+    maxlen: Option<u64>,
+    entry: &BroadcasterRedisStreamEntry,
+) -> Result<redis::Cmd> {
+    let entry_id = redis_entry_id(entry)?;
+    let fields = redis_entry_fields(entry)?;
+    Ok(redis_xadd_command_from_fields(
+        stream_key, maxlen, &entry_id, &fields,
+    ))
+}
+
+fn redis_xadd_command_from_fields(
+    stream_key: &str,
+    maxlen: Option<u64>,
+    entry_id: &str,
+    fields: &[(String, String)],
+) -> redis::Cmd {
+    let mut command = redis::cmd("XADD");
+    command.arg(stream_key);
+    if let Some(maxlen) = maxlen {
+        command.arg("MAXLEN").arg("~").arg(maxlen);
+    }
+    command.arg(entry_id);
+    for (field, value) in fields {
+        command.arg(field).arg(value);
+    }
+    command
+}
+
+pub(super) fn redis_entry_id(entry: &BroadcasterRedisStreamEntry) -> Result<String> {
+    let generation = entry
+        .stream_id
+        .rsplit_once('-')
+        .map(|(_, generation)| generation)
+        .ok_or_else(|| anyhow!("Redis broadcaster stream_id is missing generation"))?;
+    let generation = generation.parse::<u64>().with_context(|| {
+        format!("Redis broadcaster stream_id has invalid generation: {generation}")
+    })?;
+    Ok(format!("{generation}-{}", entry.message_seq))
+}
+
+async fn redis_stream_entry_matches(
+    connection: &mut redis::aio::ConnectionManager,
+    stream_key: &str,
+    entry_id: &str,
+    expected_fields: &[(String, String)],
+) -> Result<bool> {
+    let reply = redis::cmd("XRANGE")
+        .arg(stream_key)
+        .arg(entry_id)
+        .arg(entry_id)
+        .arg("COUNT")
+        .arg(1)
+        .query_async::<StreamRangeReply>(connection)
+        .await
+        .context("Redis XRANGE failed while checking XADD result")?;
+    redis_stream_entry_matches_reply(&reply, entry_id, expected_fields)
+}
+
+pub(super) fn redis_stream_entry_matches_reply(
+    reply: &StreamRangeReply,
+    entry_id: &str,
+    expected_fields: &[(String, String)],
+) -> Result<bool> {
+    let Some(existing) = reply.ids.first() else {
+        return Ok(false);
+    };
+    if reply.ids.len() != 1
+        || existing.id != entry_id
+        || existing.map.len() != expected_fields.len()
+    {
+        return Ok(false);
+    }
+
+    for (field, expected_value) in expected_fields {
+        let Some(value) = existing.map.get(field) else {
+            return Ok(false);
+        };
+        let actual_value = redis::from_redis_value::<String>(value.clone())
+            .with_context(|| format!("Redis XRANGE returned invalid value for field {field}"))?;
+        if actual_value != *expected_value {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+pub(super) fn redis_entry_fields(
+    entry: &BroadcasterRedisStreamEntry,
+) -> Result<Vec<(String, String)>> {
+    let Value::Object(fields) =
+        serde_json::to_value(entry).context("failed to serialize Redis stream entry")?
+    else {
+        return Err(anyhow!("Redis stream entry did not serialize as an object"));
+    };
+
+    fields
+        .into_iter()
+        .map(|(field, value)| {
+            let value = match value {
+                Value::String(value) => value,
+                Value::Number(value) => value.to_string(),
+                Value::Bool(value) => value.to_string(),
+                Value::Null => String::new(),
+                Value::Array(_) | Value::Object(_) => serde_json::to_string(&value)
+                    .context("failed to serialize nested Redis stream field")?,
+            };
+            Ok((field, value))
+        })
+        .collect()
+}

--- a/crates/runtime/src/metrics.rs
+++ b/crates/runtime/src/metrics.rs
@@ -9,6 +9,8 @@ const METRIC_NAMESPACE: &str = "Tycho/Simulation";
 const METRIC_SIMULATE_COMPLETION: &str = "SimulateCompletion";
 const METRIC_SIMULATE_RESULT_QUALITY: &str = "SimulateResultQuality";
 const METRIC_SIMULATE_TIMEOUT: &str = "SimulateRequestTimeout";
+const METRIC_BROADCASTER_REDIS_APPEND_FAILURE: &str = "BroadcasterRedisAppendFailure";
+const METRIC_BROADCASTER_REDIS_GENERATION_RESET: &str = "BroadcasterRedisGenerationReset";
 const METRIC_JEMALLOC_ALLOCATED_BYTES: &str = "JemallocAllocatedBytes";
 const METRIC_JEMALLOC_RESIDENT_BYTES: &str = "JemallocResidentBytes";
 const DIM_STATUS: &str = "Status";
@@ -57,6 +59,14 @@ pub fn emit_simulate_result_quality(quality: QuoteResultQuality) {
         METRIC_SIMULATE_RESULT_QUALITY,
         &[(DIM_RESULT_QUALITY, json!(quality))],
     );
+}
+
+pub fn emit_broadcaster_redis_append_failure() {
+    emit_count_metric(METRIC_BROADCASTER_REDIS_APPEND_FAILURE, &[]);
+}
+
+pub fn emit_broadcaster_redis_generation_reset() {
+    emit_count_metric(METRIC_BROADCASTER_REDIS_GENERATION_RESET, &[]);
 }
 
 pub fn emit_jemalloc_snapshot(label: &str, allocated_bytes: usize, resident_bytes: usize) {

--- a/crates/runtime/src/services/broadcaster_subscription.rs
+++ b/crates/runtime/src/services/broadcaster_subscription.rs
@@ -694,6 +694,7 @@ impl BroadcasterSubscriptionProcessor {
                     }
                 }
             }
+            BroadcasterPayload::Progress(_) => {}
         }
 
         Ok(())

--- a/crates/simulator-core/src/broadcaster.rs
+++ b/crates/simulator-core/src/broadcaster.rs
@@ -17,7 +17,7 @@ use crate::models::protocol::ProtocolKind;
 
 mod redis_streams;
 
-pub use redis_streams::{BroadcasterRedisSnapshotPointer, BroadcasterRedisStreamEntry};
+pub use redis_streams::{BroadcasterRedisReplayBoundary, BroadcasterRedisStreamEntry};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -134,6 +134,7 @@ pub enum BroadcasterMessageKind {
     SnapshotEnd,
     Update,
     Heartbeat,
+    Progress,
 }
 
 impl BroadcasterMessageKind {
@@ -144,6 +145,7 @@ impl BroadcasterMessageKind {
             Self::SnapshotEnd => "snapshot_end",
             Self::Update => "update",
             Self::Heartbeat => "heartbeat",
+            Self::Progress => "progress",
         }
     }
 }
@@ -188,6 +190,7 @@ pub enum BroadcasterPayload {
     SnapshotEnd(BroadcasterSnapshotEnd),
     Update(BroadcasterUpdateMessage),
     Heartbeat(BroadcasterHeartbeat),
+    Progress(BroadcasterProgress),
 }
 
 impl BroadcasterPayload {
@@ -198,6 +201,7 @@ impl BroadcasterPayload {
             Self::SnapshotEnd(_) => BroadcasterMessageKind::SnapshotEnd,
             Self::Update(_) => BroadcasterMessageKind::Update,
             Self::Heartbeat(_) => BroadcasterMessageKind::Heartbeat,
+            Self::Progress(_) => BroadcasterMessageKind::Progress,
         }
     }
 }
@@ -624,6 +628,38 @@ impl BroadcasterHeartbeat {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct BroadcasterProgress {
+    pub chain_id: u64,
+    pub snapshot_id: String,
+    #[serde(deserialize_with = "deserialize_unique_progress_backends")]
+    pub backends: Vec<BroadcasterBackend>,
+    pub reason: String,
+}
+
+impl BroadcasterProgress {
+    pub fn new(
+        chain_id: u64,
+        snapshot_id: impl Into<String>,
+        mut backends: Vec<BroadcasterBackend>,
+        reason: impl Into<String>,
+    ) -> Result<Self, BroadcasterContractError> {
+        backends.sort();
+        validate_progress_backends(&backends)?;
+        let reason = reason.into();
+        if reason.trim().is_empty() {
+            return Err(BroadcasterContractError::ProgressReasonEmpty);
+        }
+        Ok(Self {
+            chain_id,
+            snapshot_id: snapshot_id.into(),
+            backends,
+            reason,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct BroadcasterBackendHead {
     pub backend: BroadcasterBackend,
     pub block_number: u64,
@@ -826,6 +862,7 @@ pub enum BroadcasterSubscriptionEvent {
     },
     UpdateAccepted,
     HeartbeatAccepted,
+    ProgressAccepted,
 }
 
 #[derive(Debug, Clone)]
@@ -861,6 +898,65 @@ impl BroadcasterSubscriptionTracker {
     pub fn reset_for_reconnect(&mut self) {
         self.state = BroadcasterSubscriptionState::AwaitingSnapshot;
         self.next_message_seq = None;
+    }
+
+    pub fn align_live_replay_boundary(
+        &mut self,
+        boundary: &BroadcasterRedisReplayBoundary,
+    ) -> Result<(), BroadcasterContractError> {
+        let BroadcasterSubscriptionState::Live {
+            stream_id,
+            snapshot_id,
+            ..
+        } = &self.state
+        else {
+            return Err(
+                BroadcasterContractError::RedisReplayBoundaryBeforeSnapshotComplete {
+                    state: self.state.label(),
+                },
+            );
+        };
+
+        ensure_stream_id(stream_id, &boundary.stream_id)?;
+        ensure_snapshot_id(snapshot_id, &boundary.snapshot_id)?;
+        self.next_message_seq = Some(next_message_seq(boundary.exclusive_message_seq)?);
+        Ok(())
+    }
+
+    pub fn skip_live_delta(
+        &mut self,
+        envelope: &BroadcasterEnvelope,
+    ) -> Result<(), BroadcasterContractError> {
+        let BroadcasterSubscriptionState::Live { stream_id, .. } = self.state.clone() else {
+            return Err(
+                BroadcasterContractError::RedisReplayBoundaryBeforeSnapshotComplete {
+                    state: self.state.label(),
+                },
+            );
+        };
+
+        ensure_stream_id(&stream_id, &envelope.stream_id)?;
+        ensure_message_seq(self.next_message_seq, envelope.message_seq)?;
+        let next_seq = next_message_seq(envelope.message_seq)?;
+        match &envelope.payload {
+            BroadcasterPayload::SnapshotStart(_) => {
+                Err(BroadcasterContractError::UnexpectedSnapshotStart {
+                    state: self.state.label(),
+                })
+            }
+            BroadcasterPayload::SnapshotChunk(_) => {
+                Err(BroadcasterContractError::UnexpectedSnapshotChunk)
+            }
+            BroadcasterPayload::SnapshotEnd(_) => {
+                Err(BroadcasterContractError::UnexpectedSnapshotEnd)
+            }
+            BroadcasterPayload::Update(_)
+            | BroadcasterPayload::Heartbeat(_)
+            | BroadcasterPayload::Progress(_) => {
+                self.next_message_seq = Some(next_seq);
+                Ok(())
+            }
+        }
     }
 
     pub fn observe(
@@ -1028,6 +1124,9 @@ impl BroadcasterSubscriptionTracker {
             BroadcasterPayload::Heartbeat(_) => {
                 Err(BroadcasterContractError::HeartbeatBeforeSnapshotComplete)
             }
+            BroadcasterPayload::Progress(_) => {
+                Err(BroadcasterContractError::ProgressBeforeSnapshotComplete)
+            }
         }
     }
 
@@ -1068,6 +1167,14 @@ impl BroadcasterSubscriptionTracker {
                 ensure_snapshot_id(snapshot_id, &heartbeat.snapshot_id)?;
                 self.next_message_seq = Some(next_seq);
                 Ok(BroadcasterSubscriptionEvent::HeartbeatAccepted)
+            }
+            BroadcasterPayload::Progress(progress) => {
+                validate_progress_backends(&progress.backends)?;
+                validate_declared_progress_backends(&progress.backends, &declared_backends)?;
+                ensure_chain_id(chain_id, progress.chain_id)?;
+                ensure_snapshot_id(snapshot_id, &progress.snapshot_id)?;
+                self.next_message_seq = Some(next_seq);
+                Ok(BroadcasterSubscriptionEvent::ProgressAccepted)
             }
         }
     }
@@ -1119,7 +1226,12 @@ pub enum BroadcasterContractError {
     },
     UpdateBeforeSnapshotComplete,
     HeartbeatBeforeSnapshotComplete,
+    ProgressBeforeSnapshotComplete,
+    RedisReplayBoundaryBeforeSnapshotComplete {
+        state: &'static str,
+    },
     EmptyUpdate,
+    ProgressReasonEmpty,
     EmptyUpdatePartition {
         backend: BroadcasterBackend,
     },
@@ -1169,7 +1281,7 @@ pub enum BroadcasterContractError {
         kind: BroadcasterMessageKind,
     },
     RedisMessageSequenceZero,
-    RedisFirstMessageNotSnapshotStart {
+    RedisSnapshotPayloadUnsupported {
         kind: BroadcasterMessageKind,
     },
     RedisBackendScopeInvalid {
@@ -1186,20 +1298,12 @@ pub enum BroadcasterContractError {
         entry_block_number: u64,
         payload_block_number: u64,
     },
+    RedisObservedTimestampMismatch {
+        entry_observed_timestamp_ms: u64,
+        payload_observed_timestamp_ms: u64,
+    },
     InvalidRedisEntryId {
         entry_id: String,
-    },
-    RedisSnapshotEntryRangeInvalid {
-        snapshot_start_entry_id: String,
-        snapshot_end_entry_id: String,
-    },
-    RedisSnapshotPointerLiveCursorMismatch {
-        snapshot_end_entry_id: String,
-        live_cursor_entry_id: String,
-    },
-    RedisSnapshotRetentionGap {
-        oldest_retained_entry_id: String,
-        snapshot_start_entry_id: String,
     },
     TokenChainMismatch {
         expected: u64,
@@ -1357,8 +1461,8 @@ fn fmt_redis_contract_error(
         BroadcasterContractError::RedisMessageSequenceZero => {
             write!(f, "redis message_seq must start at 1")
         }
-        BroadcasterContractError::RedisFirstMessageNotSnapshotStart { kind } => {
-            write!(f, "redis message_seq 1 must be snapshot_start, found {kind}")
+        BroadcasterContractError::RedisSnapshotPayloadUnsupported { kind } => {
+            write!(f, "redis stream does not support {kind} payloads in V1")
         }
         BroadcasterContractError::RedisBackendScopeInvalid { backend_scope } => {
             write!(f, "invalid redis backend_scope: {backend_scope}")
@@ -1379,30 +1483,16 @@ fn fmt_redis_contract_error(
             f,
             "redis block_number mismatch: entry {entry_block_number}, payload {payload_block_number}"
         ),
+        BroadcasterContractError::RedisObservedTimestampMismatch {
+            entry_observed_timestamp_ms,
+            payload_observed_timestamp_ms,
+        } => write!(
+            f,
+            "redis observed_timestamp_ms mismatch: entry {entry_observed_timestamp_ms}, payload {payload_observed_timestamp_ms}"
+        ),
         BroadcasterContractError::InvalidRedisEntryId { entry_id } => {
             write!(f, "invalid redis stream entry id: {entry_id}")
         }
-        BroadcasterContractError::RedisSnapshotEntryRangeInvalid {
-            snapshot_start_entry_id,
-            snapshot_end_entry_id,
-        } => write!(
-            f,
-            "redis snapshot range is invalid: start {snapshot_start_entry_id}, end {snapshot_end_entry_id}"
-        ),
-        BroadcasterContractError::RedisSnapshotPointerLiveCursorMismatch {
-            snapshot_end_entry_id,
-            live_cursor_entry_id,
-        } => write!(
-            f,
-            "redis snapshot pointer live cursor {live_cursor_entry_id} must match snapshot end {snapshot_end_entry_id}"
-        ),
-        BroadcasterContractError::RedisSnapshotRetentionGap {
-            oldest_retained_entry_id,
-            snapshot_start_entry_id,
-        } => write!(
-            f,
-            "redis retention starts at {oldest_retained_entry_id}, after latest snapshot start {snapshot_start_entry_id}"
-        ),
         _ => f.write_str("redis contract error"),
     }
 }
@@ -1503,7 +1593,15 @@ impl fmt::Display for BroadcasterContractError {
             Self::HeartbeatBeforeSnapshotComplete => {
                 write!(f, "received heartbeat before snapshot bootstrap completed")
             }
+            Self::ProgressBeforeSnapshotComplete => {
+                write!(f, "received progress before snapshot bootstrap completed")
+            }
+            Self::RedisReplayBoundaryBeforeSnapshotComplete { state } => write!(
+                f,
+                "redis replay boundary requires completed snapshot bootstrap, current state is {state}"
+            ),
             Self::EmptyUpdate => write!(f, "update message must contain at least one partition"),
+            Self::ProgressReasonEmpty => write!(f, "progress reason must not be empty"),
             Self::EmptyUpdatePartition { backend } => {
                 write!(
                     f,
@@ -1543,15 +1641,13 @@ impl fmt::Display for BroadcasterContractError {
             | Self::RedisUnsupportedSchemaVersion { .. }
             | Self::RedisEntryMissingSnapshotId { .. }
             | Self::RedisMessageSequenceZero
-            | Self::RedisFirstMessageNotSnapshotStart { .. }
+            | Self::RedisSnapshotPayloadUnsupported { .. }
             | Self::RedisBackendScopeInvalid { .. }
             | Self::RedisPayloadJsonInvalid { .. }
             | Self::RedisPayloadKindMismatch { .. }
             | Self::RedisBlockNumberMismatch { .. }
-            | Self::InvalidRedisEntryId { .. }
-            | Self::RedisSnapshotEntryRangeInvalid { .. }
-            | Self::RedisSnapshotPointerLiveCursorMismatch { .. }
-            | Self::RedisSnapshotRetentionGap { .. } => fmt_redis_contract_error(f, self),
+            | Self::RedisObservedTimestampMismatch { .. }
+            | Self::InvalidRedisEntryId { .. } => fmt_redis_contract_error(f, self),
             Self::TokenChainMismatch { expected, actual } => {
                 write!(
                     f,
@@ -1707,6 +1803,18 @@ where
     Ok(heads)
 }
 
+fn deserialize_unique_progress_backends<'de, D>(
+    deserializer: D,
+) -> Result<Vec<BroadcasterBackend>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let mut backends = Vec::<BroadcasterBackend>::deserialize(deserializer)?;
+    backends.sort();
+    validate_progress_backends(&backends).map_err(de::Error::custom)?;
+    Ok(backends)
+}
+
 fn validate_snapshot_start_backends(
     backends: &[BroadcasterBackend],
 ) -> Result<(), BroadcasterContractError> {
@@ -1735,6 +1843,12 @@ fn validate_heartbeat_backend_heads(
     heads: &[BroadcasterBackendHead],
 ) -> Result<(), BroadcasterContractError> {
     validate_unique_backend_heads("heartbeat.backend_heads", heads)
+}
+
+fn validate_progress_backends(
+    backends: &[BroadcasterBackend],
+) -> Result<(), BroadcasterContractError> {
+    validate_unique_backends("progress.backends", backends)
 }
 
 fn validate_declared_snapshot_chunk_backends(
@@ -1766,6 +1880,17 @@ fn validate_declared_heartbeat_backends(
     validate_declared_backend_entries(
         "heartbeat.backend_heads",
         heads.iter().map(|head| head.backend),
+        declared_backends,
+    )
+}
+
+fn validate_declared_progress_backends(
+    backends: &[BroadcasterBackend],
+    declared_backends: &HashSet<BroadcasterBackend>,
+) -> Result<(), BroadcasterContractError> {
+    validate_declared_backend_entries(
+        "progress.backends",
+        backends.iter().copied(),
         declared_backends,
     )
 }
@@ -2230,14 +2355,14 @@ mod tests {
     };
     use super::{
         BroadcasterBackend, BroadcasterBackendHead, BroadcasterContractError, BroadcasterEnvelope,
-        BroadcasterHeartbeat, BroadcasterPayload, BroadcasterProtocolMessage,
-        BroadcasterProtocolSyncStatus, BroadcasterProtocolSyncStatusKind, BroadcasterRemovedPair,
-        BroadcasterSnapshotChunk, BroadcasterSnapshotEnd, BroadcasterSnapshotPartition,
-        BroadcasterSnapshotSessionResponse, BroadcasterSnapshotStart, BroadcasterStateDelta,
-        BroadcasterStateEntry, BroadcasterSubscriptionEvent, BroadcasterSubscriptionState,
-        BroadcasterSubscriptionTracker, BroadcasterTokenDto, BroadcasterTokenLookupRequest,
-        BroadcasterTokenLookupResponse, BroadcasterTokenSnapshotResponse, BroadcasterUpdateMessage,
-        BroadcasterUpdatePartition,
+        BroadcasterHeartbeat, BroadcasterPayload, BroadcasterProgress, BroadcasterProtocolMessage,
+        BroadcasterProtocolSyncStatus, BroadcasterProtocolSyncStatusKind,
+        BroadcasterRedisReplayBoundary, BroadcasterRemovedPair, BroadcasterSnapshotChunk,
+        BroadcasterSnapshotEnd, BroadcasterSnapshotPartition, BroadcasterSnapshotSessionResponse,
+        BroadcasterSnapshotStart, BroadcasterStateDelta, BroadcasterStateEntry,
+        BroadcasterSubscriptionEvent, BroadcasterSubscriptionState, BroadcasterSubscriptionTracker,
+        BroadcasterTokenDto, BroadcasterTokenLookupRequest, BroadcasterTokenLookupResponse,
+        BroadcasterTokenSnapshotResponse, BroadcasterUpdateMessage, BroadcasterUpdatePartition,
     };
 
     #[test]
@@ -2701,8 +2826,92 @@ mod tests {
             tracker.observe(&heartbeat_envelope("stream-1", 8453, "snapshot-1", 54)?)?,
             BroadcasterSubscriptionEvent::HeartbeatAccepted
         );
-        assert_eq!(tracker.next_message_seq(), Some(55));
+        assert_eq!(
+            tracker.observe(&BroadcasterEnvelope::new(
+                "stream-1",
+                55,
+                BroadcasterPayload::Progress(BroadcasterProgress::new(
+                    8453,
+                    "snapshot-1",
+                    vec![BroadcasterBackend::Native],
+                    "generation_reset",
+                )?),
+            ))?,
+            BroadcasterSubscriptionEvent::ProgressAccepted
+        );
+        assert_eq!(tracker.next_message_seq(), Some(56));
 
+        Ok(())
+    }
+
+    #[test]
+    fn tracker_can_rebase_live_sequence_to_redis_replay_boundary() -> Result<()> {
+        let mut tracker = BroadcasterSubscriptionTracker::new();
+        tracker.observe(&snapshot_start_envelope(
+            "stream-1",
+            8453,
+            "snapshot-1",
+            50,
+            1,
+        )?)?;
+        tracker.observe(&snapshot_chunk_envelope("stream-1", 51, 0)?)?;
+        tracker.observe(&snapshot_end_envelope("stream-1", 52))?;
+
+        let boundary = BroadcasterRedisReplayBoundary::new(
+            "redis-key".to_string(),
+            "stream-1".to_string(),
+            "snapshot-1".to_string(),
+            1,
+            99,
+        )?;
+        tracker.align_live_replay_boundary(&boundary)?;
+
+        assert_eq!(tracker.next_message_seq(), Some(100));
+        assert_eq!(
+            tracker.observe(&update_envelope("stream-1", 100)?)?,
+            BroadcasterSubscriptionEvent::UpdateAccepted
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn tracker_can_advance_sequence_for_skipped_live_delta() -> Result<()> {
+        let mut tracker = BroadcasterSubscriptionTracker::new();
+        tracker.observe(&snapshot_start_envelope(
+            "stream-1",
+            8453,
+            "snapshot-1",
+            50,
+            1,
+        )?)?;
+        tracker.observe(&snapshot_chunk_envelope("stream-1", 51, 0)?)?;
+        tracker.observe(&snapshot_end_envelope("stream-1", 52))?;
+
+        tracker.skip_live_delta(&BroadcasterEnvelope::new(
+            "stream-1",
+            53,
+            BroadcasterPayload::Update(BroadcasterUpdateMessage::new(vec![
+                BroadcasterUpdatePartition::new(
+                    BroadcasterBackend::Rfq,
+                    124,
+                    vec![BroadcasterStateEntry::new(
+                        "pool-rfq",
+                        protocol_component("pool-rfq", "rfq:hashflow"),
+                        dummy_state("rfq"),
+                    )],
+                    Vec::new(),
+                    Vec::new(),
+                    BTreeMap::new(),
+                ),
+            ])?),
+        ))?;
+
+        assert_eq!(tracker.next_message_seq(), Some(54));
+        assert_eq!(
+            tracker.observe(&update_envelope("stream-1", 54)?)?,
+            BroadcasterSubscriptionEvent::UpdateAccepted
+        );
         Ok(())
     }
 

--- a/crates/simulator-core/src/broadcaster/redis_streams.rs
+++ b/crates/simulator-core/src/broadcaster/redis_streams.rs
@@ -8,7 +8,7 @@ use serde::{
 use super::{
     ensure_chain_id, ensure_message_seq, ensure_snapshot_id, ensure_stream_id, BroadcasterBackend,
     BroadcasterContractError, BroadcasterEnvelope, BroadcasterMessageKind, BroadcasterPayload,
-    BroadcasterSnapshotPartition, BroadcasterUpdatePartition,
+    BroadcasterUpdatePartition,
 };
 
 const REDIS_STREAM_SCHEMA_VERSION: &str = "1";
@@ -32,14 +32,78 @@ pub struct BroadcasterRedisStreamEntry {
         with = "optional_u64_string"
     )]
     pub block_number: Option<u64>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "optional_u64_string"
+    )]
+    pub observed_timestamp_ms: Option<u64>,
     #[serde(with = "u64_string")]
     pub event_time_ms: u64,
-    /// Serialized `BroadcasterEnvelope` for the current HTTP/websocket payload contract.
-    ///
-    /// Snapshot chunks and live updates can still carry `Box<dyn ProtocolSim>`
-    /// state. Keep that coupling visible until Redis gets a stable typed payload
-    /// before live consumers rely on this stream.
+    /// Serialized `BroadcasterEnvelope` for the Redis delta payload contract.
     pub payload_json: String,
+}
+
+/// Redis replay cursor captured with an HTTP snapshot session.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BroadcasterRedisReplayBoundary {
+    pub stream_key: String,
+    pub stream_id: String,
+    pub snapshot_id: String,
+    pub generation: u64,
+    pub exclusive_message_seq: u64,
+}
+
+impl BroadcasterRedisReplayBoundary {
+    pub fn new(
+        stream_key: impl Into<String>,
+        stream_id: impl Into<String>,
+        snapshot_id: impl Into<String>,
+        generation: u64,
+        exclusive_message_seq: u64,
+    ) -> Result<Self, BroadcasterContractError> {
+        Ok(Self {
+            stream_key: required_redis_field("stream_key", stream_key.into())?,
+            stream_id: required_redis_field("stream_id", stream_id.into())?,
+            snapshot_id: required_redis_field("snapshot_id", snapshot_id.into())?,
+            generation: redis_boundary_generation(generation)?,
+            exclusive_message_seq,
+        })
+    }
+
+    pub fn exclusive_entry_id(&self) -> String {
+        format!("{}-{}", self.generation, self.exclusive_message_seq)
+    }
+}
+
+impl<'de> Deserialize<'de> for BroadcasterRedisReplayBoundary {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        #[serde(deny_unknown_fields)]
+        struct WireBoundary {
+            stream_key: String,
+            stream_id: String,
+            snapshot_id: String,
+            generation: u64,
+            exclusive_message_seq: u64,
+        }
+
+        let wire = WireBoundary::deserialize(deserializer)?;
+        let boundary = Self::new(
+            wire.stream_key,
+            wire.stream_id,
+            wire.snapshot_id,
+            wire.generation,
+            wire.exclusive_message_seq,
+        )
+        .map_err(de::Error::custom)?;
+        Ok(boundary)
+    }
 }
 
 impl BroadcasterRedisStreamEntry {
@@ -47,8 +111,9 @@ impl BroadcasterRedisStreamEntry {
         chain_id: u64,
         event_time_ms: u64,
         envelope: &BroadcasterEnvelope,
-        backends: Vec<BroadcasterBackend>,
     ) -> Result<Self, BroadcasterContractError> {
+        ensure_redis_delta_kind(envelope.kind())?;
+        let backends = redis_payload_backend_scope(&envelope.payload)?.unwrap_or_default();
         let payload_json = serde_json::to_string(envelope).map_err(|error| {
             BroadcasterContractError::RedisPayloadJsonInvalid {
                 message: error.to_string(),
@@ -63,6 +128,7 @@ impl BroadcasterRedisStreamEntry {
             snapshot_id: redis_payload_snapshot_id(&envelope.payload).map(str::to_string),
             backend_scope: redis_backend_scope(backends)?,
             block_number: redis_entry_block_number(&envelope.payload),
+            observed_timestamp_ms: redis_entry_observed_timestamp_ms(&envelope.payload),
             event_time_ms,
             payload_json,
         };
@@ -75,7 +141,7 @@ impl BroadcasterRedisStreamEntry {
         required_redis_field("stream_id", self.stream_id.clone())?;
         required_redis_field("payload_json", self.payload_json.clone())?;
         ensure_redis_message_seq(self.message_seq)?;
-        ensure_redis_snapshot_start_message_seq(self.kind, self.message_seq)?;
+        ensure_redis_delta_kind(self.kind)?;
         let backends = parse_redis_backend_scope(&self.backend_scope)?;
         if let Some(snapshot_id) = &self.snapshot_id {
             required_redis_field("snapshot_id", snapshot_id.clone())?;
@@ -109,6 +175,7 @@ impl BroadcasterRedisStreamEntry {
             ensure_redis_backend_scope(backends, &payload_backends)?;
         }
         ensure_redis_payload_block_number(self.block_number, &envelope.payload)?;
+        ensure_redis_payload_observed_timestamp_ms(self.observed_timestamp_ms, &envelope.payload)?;
         Ok(())
     }
 }
@@ -132,6 +199,8 @@ impl<'de> Deserialize<'de> for BroadcasterRedisStreamEntry {
             backend_scope: String,
             #[serde(default, with = "optional_u64_string")]
             block_number: Option<u64>,
+            #[serde(default, with = "optional_u64_string")]
+            observed_timestamp_ms: Option<u64>,
             #[serde(with = "u64_string")]
             event_time_ms: u64,
             payload_json: String,
@@ -147,6 +216,7 @@ impl<'de> Deserialize<'de> for BroadcasterRedisStreamEntry {
             snapshot_id: wire.snapshot_id,
             backend_scope: wire.backend_scope,
             block_number: wire.block_number,
+            observed_timestamp_ms: wire.observed_timestamp_ms,
             event_time_ms: wire.event_time_ms,
             payload_json: wire.payload_json,
         };
@@ -155,149 +225,10 @@ impl<'de> Deserialize<'de> for BroadcasterRedisStreamEntry {
     }
 }
 
-/// Pointer to the latest complete snapshot segment in a Redis stream.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct BroadcasterRedisSnapshotPointer {
-    pub schema_version: String,
-    pub chain_id: u64,
-    pub stream_key: String,
-    pub stream_id: String,
-    pub snapshot_id: String,
-    pub snapshot_start_entry_id: String,
-    pub snapshot_end_entry_id: String,
-    pub live_cursor_entry_id: String,
-    pub completed_at_ms: u64,
-}
-
-impl BroadcasterRedisSnapshotPointer {
-    #[expect(
-        clippy::too_many_arguments,
-        reason = "constructor mirrors the snapshot pointer wire contract"
-    )]
-    pub fn new(
-        chain_id: u64,
-        stream_key: impl Into<String>,
-        stream_id: impl Into<String>,
-        snapshot_id: impl Into<String>,
-        snapshot_start_entry_id: impl Into<String>,
-        snapshot_end_entry_id: impl Into<String>,
-        live_cursor_entry_id: impl Into<String>,
-        completed_at_ms: u64,
-    ) -> Result<Self, BroadcasterContractError> {
-        let snapshot_start_entry_id =
-            required_redis_field("snapshot_start_entry_id", snapshot_start_entry_id.into())?;
-        let snapshot_end_entry_id =
-            required_redis_field("snapshot_end_entry_id", snapshot_end_entry_id.into())?;
-        let live_cursor_entry_id =
-            required_redis_field("live_cursor_entry_id", live_cursor_entry_id.into())?;
-
-        ensure_redis_entry_range(&snapshot_start_entry_id, &snapshot_end_entry_id)?;
-        if live_cursor_entry_id != snapshot_end_entry_id {
-            return Err(
-                BroadcasterContractError::RedisSnapshotPointerLiveCursorMismatch {
-                    snapshot_end_entry_id,
-                    live_cursor_entry_id,
-                },
-            );
-        }
-
-        let pointer = Self {
-            schema_version: REDIS_STREAM_SCHEMA_VERSION.to_string(),
-            chain_id,
-            stream_key: required_redis_field("stream_key", stream_key.into())?,
-            stream_id: required_redis_field("stream_id", stream_id.into())?,
-            snapshot_id: required_redis_field("snapshot_id", snapshot_id.into())?,
-            snapshot_start_entry_id,
-            snapshot_end_entry_id,
-            live_cursor_entry_id,
-            completed_at_ms,
-        };
-        pointer.validate()?;
-        Ok(pointer)
-    }
-
-    pub fn ensure_snapshot_retained(
-        &self,
-        oldest_retained_entry_id: &str,
-    ) -> Result<(), BroadcasterContractError> {
-        let oldest_retained = parse_redis_entry_id(oldest_retained_entry_id)?;
-        let snapshot_start = parse_redis_entry_id(&self.snapshot_start_entry_id)?;
-        if oldest_retained <= snapshot_start {
-            return Ok(());
-        }
-
-        Err(BroadcasterContractError::RedisSnapshotRetentionGap {
-            oldest_retained_entry_id: oldest_retained_entry_id.to_string(),
-            snapshot_start_entry_id: self.snapshot_start_entry_id.clone(),
-        })
-    }
-
-    fn validate(&self) -> Result<(), BroadcasterContractError> {
-        ensure_redis_schema_version(&self.schema_version)?;
-        required_redis_field("stream_key", self.stream_key.clone())?;
-        required_redis_field("stream_id", self.stream_id.clone())?;
-        required_redis_field("snapshot_id", self.snapshot_id.clone())?;
-        required_redis_field(
-            "snapshot_start_entry_id",
-            self.snapshot_start_entry_id.clone(),
-        )?;
-        required_redis_field("snapshot_end_entry_id", self.snapshot_end_entry_id.clone())?;
-        required_redis_field("live_cursor_entry_id", self.live_cursor_entry_id.clone())?;
-        ensure_redis_entry_range(&self.snapshot_start_entry_id, &self.snapshot_end_entry_id)?;
-        if self.live_cursor_entry_id != self.snapshot_end_entry_id {
-            return Err(
-                BroadcasterContractError::RedisSnapshotPointerLiveCursorMismatch {
-                    snapshot_end_entry_id: self.snapshot_end_entry_id.clone(),
-                    live_cursor_entry_id: self.live_cursor_entry_id.clone(),
-                },
-            );
-        }
-        Ok(())
-    }
-}
-
-impl<'de> Deserialize<'de> for BroadcasterRedisSnapshotPointer {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        struct WirePointer {
-            schema_version: String,
-            chain_id: u64,
-            stream_key: String,
-            stream_id: String,
-            snapshot_id: String,
-            snapshot_start_entry_id: String,
-            snapshot_end_entry_id: String,
-            live_cursor_entry_id: String,
-            completed_at_ms: u64,
-        }
-
-        let wire = WirePointer::deserialize(deserializer)?;
-        let pointer = Self {
-            schema_version: wire.schema_version,
-            chain_id: wire.chain_id,
-            stream_key: wire.stream_key,
-            stream_id: wire.stream_id,
-            snapshot_id: wire.snapshot_id,
-            snapshot_start_entry_id: wire.snapshot_start_entry_id,
-            snapshot_end_entry_id: wire.snapshot_end_entry_id,
-            live_cursor_entry_id: wire.live_cursor_entry_id,
-            completed_at_ms: wire.completed_at_ms,
-        };
-        pointer.validate().map_err(de::Error::custom)?;
-        Ok(pointer)
-    }
-}
-
 fn redis_entry_requires_snapshot_id(kind: BroadcasterMessageKind) -> bool {
     matches!(
         kind,
-        BroadcasterMessageKind::SnapshotStart
-            | BroadcasterMessageKind::SnapshotChunk
-            | BroadcasterMessageKind::SnapshotEnd
-            | BroadcasterMessageKind::Heartbeat
+        BroadcasterMessageKind::Heartbeat | BroadcasterMessageKind::Progress
     )
 }
 
@@ -330,17 +261,17 @@ fn ensure_redis_message_seq(message_seq: u64) -> Result<(), BroadcasterContractE
     }
 }
 
-fn ensure_redis_snapshot_start_message_seq(
-    kind: BroadcasterMessageKind,
-    message_seq: u64,
-) -> Result<(), BroadcasterContractError> {
-    if kind == BroadcasterMessageKind::SnapshotStart {
-        return ensure_message_seq(Some(1), message_seq);
+fn ensure_redis_delta_kind(kind: BroadcasterMessageKind) -> Result<(), BroadcasterContractError> {
+    match kind {
+        BroadcasterMessageKind::Update
+        | BroadcasterMessageKind::Heartbeat
+        | BroadcasterMessageKind::Progress => Ok(()),
+        BroadcasterMessageKind::SnapshotStart
+        | BroadcasterMessageKind::SnapshotChunk
+        | BroadcasterMessageKind::SnapshotEnd => {
+            Err(BroadcasterContractError::RedisSnapshotPayloadUnsupported { kind })
+        }
     }
-    if message_seq == 1 {
-        return Err(BroadcasterContractError::RedisFirstMessageNotSnapshotStart { kind });
-    }
-    Ok(())
 }
 
 fn redis_backend_scope(
@@ -440,6 +371,54 @@ fn redis_entry_block_number(payload: &BroadcasterPayload) -> Option<u64> {
     redis_payload_global_block_number(&redis_payload_chain_block_numbers(payload))
 }
 
+fn ensure_redis_payload_observed_timestamp_ms(
+    entry_observed_timestamp_ms: Option<u64>,
+    payload: &BroadcasterPayload,
+) -> Result<(), BroadcasterContractError> {
+    let payload_observed_timestamp_ms = redis_entry_observed_timestamp_ms(payload);
+    match (entry_observed_timestamp_ms, payload_observed_timestamp_ms) {
+        (Some(entry_observed_timestamp_ms), Some(payload_observed_timestamp_ms))
+            if entry_observed_timestamp_ms != payload_observed_timestamp_ms =>
+        {
+            return Err(BroadcasterContractError::RedisObservedTimestampMismatch {
+                entry_observed_timestamp_ms,
+                payload_observed_timestamp_ms,
+            });
+        }
+        (Some(_), None) => {
+            return Err(BroadcasterContractError::RedisEntryUnexpectedField {
+                field: "observed_timestamp_ms",
+            });
+        }
+        (None, Some(_)) => {
+            return Err(BroadcasterContractError::RedisEntryEmptyField {
+                field: "observed_timestamp_ms",
+            });
+        }
+        (Some(_), Some(_)) | (None, None) => {}
+    }
+    Ok(())
+}
+
+fn redis_entry_observed_timestamp_ms(payload: &BroadcasterPayload) -> Option<u64> {
+    match payload {
+        BroadcasterPayload::Update(update) => update
+            .partitions
+            .iter()
+            .find(|partition| partition.backend == BroadcasterBackend::Rfq)
+            .map(|partition| partition.block_number),
+        BroadcasterPayload::Heartbeat(heartbeat) => heartbeat
+            .backend_heads
+            .iter()
+            .find(|head| head.backend == BroadcasterBackend::Rfq)
+            .map(|head| head.block_number),
+        BroadcasterPayload::Progress(_)
+        | BroadcasterPayload::SnapshotStart(_)
+        | BroadcasterPayload::SnapshotChunk(_)
+        | BroadcasterPayload::SnapshotEnd(_) => None,
+    }
+}
+
 fn redis_payload_global_block_number(block_numbers: &[u64]) -> Option<u64> {
     let (&first_block_number, remaining) = block_numbers.split_first()?;
     remaining
@@ -450,17 +429,6 @@ fn redis_payload_global_block_number(block_numbers: &[u64]) -> Option<u64> {
 
 fn redis_payload_chain_block_numbers(payload: &BroadcasterPayload) -> Vec<u64> {
     match payload {
-        BroadcasterPayload::SnapshotChunk(chunk) => chunk
-            .partitions
-            .iter()
-            .filter(|partition| {
-                matches!(
-                    partition.backend,
-                    BroadcasterBackend::Native | BroadcasterBackend::Vm
-                )
-            })
-            .map(|partition| partition.block_number)
-            .collect(),
         BroadcasterPayload::Update(update) => update
             .partitions
             .iter()
@@ -472,9 +440,11 @@ fn redis_payload_chain_block_numbers(payload: &BroadcasterPayload) -> Vec<u64> {
             })
             .map(|partition| partition.block_number)
             .collect(),
-        BroadcasterPayload::SnapshotStart(_)
-        | BroadcasterPayload::SnapshotEnd(_)
-        | BroadcasterPayload::Heartbeat(_) => Vec::new(),
+        BroadcasterPayload::Heartbeat(_)
+        | BroadcasterPayload::Progress(_)
+        | BroadcasterPayload::SnapshotStart(_)
+        | BroadcasterPayload::SnapshotChunk(_)
+        | BroadcasterPayload::SnapshotEnd(_) => Vec::new(),
     }
 }
 
@@ -490,21 +460,23 @@ fn parse_redis_payload_json(
 
 fn redis_payload_snapshot_id(payload: &BroadcasterPayload) -> Option<&str> {
     match payload {
-        BroadcasterPayload::SnapshotStart(start) => Some(&start.snapshot_id),
-        BroadcasterPayload::SnapshotChunk(chunk) => Some(&chunk.snapshot_id),
-        BroadcasterPayload::SnapshotEnd(end) => Some(&end.snapshot_id),
-        BroadcasterPayload::Update(_) => None,
         BroadcasterPayload::Heartbeat(heartbeat) => Some(&heartbeat.snapshot_id),
+        BroadcasterPayload::Progress(progress) => Some(&progress.snapshot_id),
+        BroadcasterPayload::Update(_)
+        | BroadcasterPayload::SnapshotStart(_)
+        | BroadcasterPayload::SnapshotChunk(_)
+        | BroadcasterPayload::SnapshotEnd(_) => None,
     }
 }
 
 fn redis_payload_chain_id(payload: &BroadcasterPayload) -> Option<u64> {
     match payload {
-        BroadcasterPayload::SnapshotStart(start) => Some(start.chain_id),
         BroadcasterPayload::Heartbeat(heartbeat) => Some(heartbeat.chain_id),
-        BroadcasterPayload::SnapshotChunk(_)
-        | BroadcasterPayload::SnapshotEnd(_)
-        | BroadcasterPayload::Update(_) => None,
+        BroadcasterPayload::Progress(progress) => Some(progress.chain_id),
+        BroadcasterPayload::Update(_)
+        | BroadcasterPayload::SnapshotStart(_)
+        | BroadcasterPayload::SnapshotChunk(_)
+        | BroadcasterPayload::SnapshotEnd(_) => None,
     }
 }
 
@@ -512,12 +484,7 @@ fn redis_payload_backend_scope(
     payload: &BroadcasterPayload,
 ) -> Result<Option<Vec<BroadcasterBackend>>, BroadcasterContractError> {
     match payload {
-        BroadcasterPayload::SnapshotStart(start) => Ok(Some(start.backends.clone())),
-        BroadcasterPayload::SnapshotChunk(chunk) => {
-            redis_partition_backend_scope(&chunk.partitions)
-        }
-        BroadcasterPayload::SnapshotEnd(_) => Ok(None),
-        BroadcasterPayload::Update(update) => redis_partition_backend_scope(&update.partitions),
+        BroadcasterPayload::Update(update) => redis_update_backend_scope(&update.partitions),
         BroadcasterPayload::Heartbeat(heartbeat) => Ok(Some(
             heartbeat
                 .backend_heads
@@ -525,36 +492,24 @@ fn redis_payload_backend_scope(
                 .map(|head| head.backend)
                 .collect(),
         )),
+        BroadcasterPayload::Progress(progress) => Ok(Some(progress.backends.clone())),
+        BroadcasterPayload::SnapshotStart(_)
+        | BroadcasterPayload::SnapshotChunk(_)
+        | BroadcasterPayload::SnapshotEnd(_) => Ok(None),
     }
 }
 
-fn redis_partition_backend_scope<T: RedisPartitionBackend>(
-    partitions: &[T],
+fn redis_update_backend_scope(
+    partitions: &[BroadcasterUpdatePartition],
 ) -> Result<Option<Vec<BroadcasterBackend>>, BroadcasterContractError> {
     let backends: Vec<_> = partitions
         .iter()
-        .map(RedisPartitionBackend::backend)
+        .map(|partition| partition.backend)
         .collect();
     if backends.is_empty() {
         return Ok(Some(backends));
     }
     parse_redis_backend_scope(&redis_backend_scope(backends)?).map(Some)
-}
-
-trait RedisPartitionBackend {
-    fn backend(&self) -> BroadcasterBackend;
-}
-
-impl RedisPartitionBackend for BroadcasterSnapshotPartition {
-    fn backend(&self) -> BroadcasterBackend {
-        self.backend
-    }
-}
-
-impl RedisPartitionBackend for BroadcasterUpdatePartition {
-    fn backend(&self) -> BroadcasterBackend {
-        self.backend
-    }
 }
 
 fn ensure_redis_snapshot_id(
@@ -584,45 +539,13 @@ fn ensure_redis_backend_scope(
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-struct RedisEntryIdParts {
-    millis: u64,
-    sequence: u64,
-}
-
-fn parse_redis_entry_id(entry_id: &str) -> Result<RedisEntryIdParts, BroadcasterContractError> {
-    let Some((millis, sequence)) = entry_id.split_once('-') else {
+fn redis_boundary_generation(generation: u64) -> Result<u64, BroadcasterContractError> {
+    if generation == 0 {
         return Err(BroadcasterContractError::InvalidRedisEntryId {
-            entry_id: entry_id.to_string(),
+            entry_id: format!("{generation}-0"),
         });
-    };
-    let Ok(millis) = millis.parse() else {
-        return Err(BroadcasterContractError::InvalidRedisEntryId {
-            entry_id: entry_id.to_string(),
-        });
-    };
-    let Ok(sequence) = sequence.parse() else {
-        return Err(BroadcasterContractError::InvalidRedisEntryId {
-            entry_id: entry_id.to_string(),
-        });
-    };
-    Ok(RedisEntryIdParts { millis, sequence })
-}
-
-fn ensure_redis_entry_range(
-    snapshot_start_entry_id: &str,
-    snapshot_end_entry_id: &str,
-) -> Result<(), BroadcasterContractError> {
-    let snapshot_start = parse_redis_entry_id(snapshot_start_entry_id)?;
-    let snapshot_end = parse_redis_entry_id(snapshot_end_entry_id)?;
-    if snapshot_start < snapshot_end {
-        return Ok(());
     }
-
-    Err(BroadcasterContractError::RedisSnapshotEntryRangeInvalid {
-        snapshot_start_entry_id: snapshot_start_entry_id.to_string(),
-        snapshot_end_entry_id: snapshot_end_entry_id.to_string(),
-    })
+    Ok(generation)
 }
 
 mod u64_string {
@@ -683,23 +606,21 @@ mod tests {
 
     use anyhow::{anyhow, Result};
 
-    use super::{BroadcasterRedisSnapshotPointer, BroadcasterRedisStreamEntry};
+    use super::{BroadcasterRedisReplayBoundary, BroadcasterRedisStreamEntry};
     use crate::broadcaster::test_support::{
-        dummy_state, heartbeat_envelope, protocol_component,
-        snapshot_chunk_envelope_with_partitions, snapshot_end_envelope, snapshot_start_envelope,
-        update_envelope,
+        dummy_state, heartbeat_envelope, protocol_component, snapshot_end_envelope,
+        snapshot_start_envelope, update_envelope,
     };
     use crate::broadcaster::{
-        BroadcasterBackend, BroadcasterContractError, BroadcasterEnvelope, BroadcasterMessageKind,
-        BroadcasterPayload, BroadcasterSnapshotChunk, BroadcasterSnapshotEnd,
-        BroadcasterSnapshotPartition, BroadcasterStateEntry, BroadcasterUpdateMessage,
-        BroadcasterUpdatePartition,
+        BroadcasterBackend, BroadcasterBackendHead, BroadcasterContractError, BroadcasterEnvelope,
+        BroadcasterHeartbeat, BroadcasterMessageKind, BroadcasterPayload, BroadcasterStateEntry,
+        BroadcasterUpdateMessage, BroadcasterUpdatePartition,
     };
 
     #[test]
     fn redis_stream_entry_derives_fields_from_envelope() -> Result<()> {
         let envelope = update_envelope("stream-1", 4)?;
-        let entry = redis_entry(&envelope, vec![BroadcasterBackend::Native])?;
+        let entry = redis_entry(&envelope)?;
 
         assert_eq!(entry.stream_id, "stream-1");
         assert_eq!(entry.message_seq, 4);
@@ -713,32 +634,27 @@ mod tests {
     }
 
     #[test]
-    fn redis_stream_entry_omits_block_number_for_rfq_only_update() -> Result<()> {
-        let envelope = rfq_update_envelope("stream-1", 4, 321)?;
-        let entry = redis_entry(&envelope, vec![BroadcasterBackend::Rfq])?;
+    fn redis_stream_entry_accepts_delta_at_first_message_sequence() -> Result<()> {
+        let envelope = update_envelope("stream-1", 1)?;
+        let entry = redis_entry(&envelope)?;
 
-        assert_eq!(entry.backend_scope, "rfq");
-        assert_eq!(entry.block_number, None);
-
-        let value = serde_json::to_value(&entry)?;
-        assert!(value.get("block_number").is_none());
-
-        let decoded: BroadcasterRedisStreamEntry = serde_json::from_value(value)?;
-        assert_eq!(decoded, entry);
-
+        assert_eq!(entry.message_seq, 1);
+        assert_eq!(entry.kind, BroadcasterMessageKind::Update);
         Ok(())
     }
 
     #[test]
-    fn redis_stream_entry_omits_block_number_for_rfq_only_snapshot_chunk() -> Result<()> {
-        let envelope = rfq_snapshot_chunk_envelope("stream-1", 2, 321)?;
-        let entry = redis_entry(&envelope, vec![BroadcasterBackend::Rfq])?;
+    fn redis_stream_entry_omits_block_number_for_rfq_only_update() -> Result<()> {
+        let envelope = rfq_update_envelope("stream-1", 4, 321)?;
+        let entry = redis_entry(&envelope)?;
 
         assert_eq!(entry.backend_scope, "rfq");
         assert_eq!(entry.block_number, None);
+        assert_eq!(entry.observed_timestamp_ms, Some(321));
 
         let value = serde_json::to_value(&entry)?;
         assert!(value.get("block_number").is_none());
+        assert_eq!(value["observed_timestamp_ms"], "321");
 
         let decoded: BroadcasterRedisStreamEntry = serde_json::from_value(value)?;
         assert_eq!(decoded, entry);
@@ -749,56 +665,7 @@ mod tests {
     #[test]
     fn redis_stream_entry_omits_block_number_for_mixed_backend_update_blocks() -> Result<()> {
         let envelope = mixed_backend_update_envelope("stream-1", 4, 124, 125)?;
-        let entry = redis_entry(
-            &envelope,
-            vec![BroadcasterBackend::Native, BroadcasterBackend::Vm],
-        )?;
-
-        assert_eq!(entry.backend_scope, "native,vm");
-        assert_eq!(entry.block_number, None);
-
-        let value = serde_json::to_value(&entry)?;
-        assert!(value.get("block_number").is_none());
-
-        let decoded: BroadcasterRedisStreamEntry = serde_json::from_value(value)?;
-        assert_eq!(decoded, entry);
-
-        Ok(())
-    }
-
-    #[test]
-    fn redis_stream_entry_omits_block_number_for_mixed_backend_snapshot_blocks() -> Result<()> {
-        let envelope = snapshot_chunk_envelope_with_partitions(
-            "stream-1",
-            2,
-            0,
-            vec![
-                BroadcasterSnapshotPartition::new(
-                    BroadcasterBackend::Native,
-                    124,
-                    vec![BroadcasterStateEntry::new(
-                        "pool-native",
-                        protocol_component("pool-native", "uniswap_v2"),
-                        dummy_state("native-snapshot"),
-                    )],
-                    BTreeMap::new(),
-                ),
-                BroadcasterSnapshotPartition::new(
-                    BroadcasterBackend::Vm,
-                    125,
-                    vec![BroadcasterStateEntry::new(
-                        "pool-vm",
-                        protocol_component("pool-vm", "vm:curve"),
-                        dummy_state("vm-snapshot"),
-                    )],
-                    BTreeMap::new(),
-                ),
-            ],
-        )?;
-        let entry = redis_entry(
-            &envelope,
-            vec![BroadcasterBackend::Native, BroadcasterBackend::Vm],
-        )?;
+        let entry = redis_entry(&envelope)?;
 
         assert_eq!(entry.backend_scope, "native,vm");
         assert_eq!(entry.block_number, None);
@@ -815,13 +682,14 @@ mod tests {
     #[test]
     fn redis_stream_entry_uses_native_block_number_for_native_and_rfq_update() -> Result<()> {
         let envelope = native_and_rfq_update_envelope("stream-1", 4, 124, 321)?;
-        let entry = redis_entry(
-            &envelope,
-            vec![BroadcasterBackend::Native, BroadcasterBackend::Rfq],
-        )?;
+        let entry = redis_entry(&envelope)?;
 
         assert_eq!(entry.backend_scope, "native,rfq");
         assert_eq!(entry.block_number, Some(124));
+        assert_eq!(entry.observed_timestamp_ms, Some(321));
+
+        let value = serde_json::to_value(&entry)?;
+        assert_eq!(value["observed_timestamp_ms"], "321");
 
         Ok(())
     }
@@ -829,7 +697,7 @@ mod tests {
     #[test]
     fn redis_stream_entry_round_trips_with_stable_field_shape() -> Result<()> {
         let envelope = update_envelope("stream-1", 4)?;
-        let entry = redis_entry(&envelope, vec![BroadcasterBackend::Native])?;
+        let entry = redis_entry(&envelope)?;
 
         let value = serde_json::to_value(&entry)?;
 
@@ -841,6 +709,7 @@ mod tests {
         assert!(value.get("snapshot_id").is_none());
         assert_eq!(value["backend_scope"], "native");
         assert_eq!(value["block_number"], "124");
+        assert!(value.get("observed_timestamp_ms").is_none());
         assert_eq!(value["event_time_ms"], "1710000000123");
         assert_eq!(value["payload_json"], serde_json::to_string(&envelope)?);
 
@@ -857,8 +726,7 @@ mod tests {
             "chain_id": "8453",
             "stream_id": "stream-1",
             "message_seq": "1",
-            "kind": "snapshot_start",
-            "snapshot_id": "snapshot-1",
+            "kind": "update",
             "backend_scope": "native",
             "event_time_ms": "1710000000000"
         }))
@@ -872,22 +740,16 @@ mod tests {
 
     #[test]
     fn redis_stream_entry_deserialization_validates_contract_invariants() -> Result<()> {
-        let mut value = redis_entry_value(
-            &snapshot_end_envelope("stream-1", 2),
-            vec![BroadcasterBackend::Native],
-        )?;
+        let mut value = redis_entry_value(&heartbeat_envelope("stream-1", 8453, "snapshot-1", 2)?)?;
         value
             .as_object_mut()
             .ok_or_else(|| anyhow!("redis entry should encode as object"))?
             .remove("snapshot_id");
 
-        let error = redis_entry_decode_error(value, "snapshot entry without snapshot_id")?;
+        let error = redis_entry_decode_error(value, "redis entry without snapshot_id")?;
         assert!(error.to_string().contains("requires snapshot_id"));
 
-        let mut value = redis_entry_value(
-            &snapshot_end_envelope("stream-1", 2),
-            vec![BroadcasterBackend::Native],
-        )?;
+        let mut value = redis_entry_value(&update_envelope("stream-1", 2)?)?;
         value["schema_version"] = serde_json::json!("2");
 
         let error = redis_entry_decode_error(value, "unsupported schema version")?;
@@ -900,13 +762,9 @@ mod tests {
 
     #[test]
     fn redis_stream_entry_rejects_zero_message_sequence() -> Result<()> {
-        let envelope = BroadcasterEnvelope::new(
-            "stream-1",
-            0,
-            BroadcasterPayload::SnapshotEnd(BroadcasterSnapshotEnd::new("snapshot-1")),
-        );
+        let envelope = update_envelope("stream-1", 0)?;
 
-        let Err(error) = redis_entry(&envelope, vec![BroadcasterBackend::Native]) else {
+        let Err(error) = redis_entry(&envelope) else {
             return Err(anyhow!("zero message_seq should fail"));
         };
 
@@ -916,67 +774,30 @@ mod tests {
     }
 
     #[test]
-    fn redis_stream_entry_requires_snapshot_start_to_begin_at_one() -> Result<()> {
-        let envelope = snapshot_start_envelope("stream-1", 8453, "snapshot-1", 2, 1)?;
-
-        let Err(error) = redis_entry(
-            &envelope,
-            vec![BroadcasterBackend::Native, BroadcasterBackend::Vm],
-        ) else {
-            return Err(anyhow!("snapshot_start message_seq must start at one"));
-        };
-
-        assert_eq!(
-            error,
-            BroadcasterContractError::UnexpectedMessageSeq {
-                expected: 1,
-                found: 2,
-            }
-        );
-
-        Ok(())
-    }
-
-    #[test]
-    fn redis_stream_entry_rejects_non_snapshot_start_at_first_message_seq() -> Result<()> {
+    fn redis_stream_entry_rejects_snapshot_payloads() -> Result<()> {
         let envelopes = [
-            update_envelope("stream-1", 1)?,
-            snapshot_end_envelope("stream-1", 1),
-            heartbeat_envelope("stream-1", 8453, "snapshot-1", 1)?,
+            snapshot_start_envelope("stream-1", 8453, "snapshot-1", 2, 1)?,
+            snapshot_end_envelope("stream-1", 2),
         ];
 
-        for envelope in &envelopes {
+        for envelope in envelopes {
             let kind = envelope.kind();
-            let Err(error) = redis_entry(envelope, vec![BroadcasterBackend::Native]) else {
-                return Err(anyhow!("{kind} at message_seq 1 should fail"));
+            let Err(error) = redis_entry(&envelope) else {
+                return Err(anyhow!("{kind} should not be accepted as a Redis delta"));
             };
 
             assert_eq!(
                 error,
-                BroadcasterContractError::RedisFirstMessageNotSnapshotStart { kind }
+                BroadcasterContractError::RedisSnapshotPayloadUnsupported { kind }
             );
         }
-
-        let mut value = redis_entry_value(
-            &snapshot_end_envelope("stream-1", 2),
-            vec![BroadcasterBackend::Native],
-        )?;
-        value["message_seq"] = serde_json::json!("1");
-
-        let error = redis_entry_decode_error(value, "snapshot_end at message_seq 1")?;
-        assert!(error
-            .to_string()
-            .contains("redis message_seq 1 must be snapshot_start"));
 
         Ok(())
     }
 
     #[test]
     fn redis_stream_entry_deserialization_rejects_empty_snapshot_id() -> Result<()> {
-        let mut value = redis_entry_value(
-            &update_envelope("stream-1", 4)?,
-            vec![BroadcasterBackend::Native],
-        )?;
+        let mut value = redis_entry_value(&update_envelope("stream-1", 4)?)?;
         value["snapshot_id"] = serde_json::json!("");
 
         let error = redis_entry_decode_error(value, "empty snapshot_id")?;
@@ -987,10 +808,7 @@ mod tests {
 
     #[test]
     fn redis_stream_entry_requires_block_number_for_native_or_vm_state_entries() -> Result<()> {
-        let mut value = redis_entry_value(
-            &update_envelope("stream-1", 4)?,
-            vec![BroadcasterBackend::Native],
-        )?;
+        let mut value = redis_entry_value(&update_envelope("stream-1", 4)?)?;
         value
             .as_object_mut()
             .ok_or_else(|| anyhow!("redis entry should encode as object"))?
@@ -1005,10 +823,7 @@ mod tests {
 
     #[test]
     fn redis_stream_entry_rejects_payload_block_number_mismatch() -> Result<()> {
-        let mut value = redis_entry_value(
-            &update_envelope("stream-1", 4)?,
-            vec![BroadcasterBackend::Native],
-        )?;
+        let mut value = redis_entry_value(&update_envelope("stream-1", 4)?)?;
         value["block_number"] = serde_json::json!("125");
 
         let error = redis_entry_decode_error(value, "mismatched block_number")?;
@@ -1022,10 +837,7 @@ mod tests {
 
     #[test]
     fn redis_stream_entry_rejects_block_number_for_rfq_only_payload() -> Result<()> {
-        let mut value = redis_entry_value(
-            &rfq_update_envelope("stream-1", 4, 321)?,
-            vec![BroadcasterBackend::Rfq],
-        )?;
+        let mut value = redis_entry_value(&rfq_update_envelope("stream-1", 4, 321)?)?;
         value["block_number"] = serde_json::json!("322");
 
         let error = redis_entry_decode_error(value, "unexpected RFQ block_number")?;
@@ -1038,11 +850,40 @@ mod tests {
     }
 
     #[test]
+    fn redis_stream_entry_rejects_observed_timestamp_mismatch() -> Result<()> {
+        let mut value = redis_entry_value(&rfq_update_envelope("stream-1", 4, 321)?)?;
+        value["observed_timestamp_ms"] = serde_json::json!("322");
+
+        let error = redis_entry_decode_error(value, "mismatched RFQ observed_timestamp_ms")?;
+
+        assert!(error
+            .to_string()
+            .contains("redis observed_timestamp_ms mismatch: entry 322, payload 321"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn redis_stream_entry_requires_observed_timestamp_for_rfq_payload() -> Result<()> {
+        let mut value = redis_entry_value(&rfq_update_envelope("stream-1", 4, 321)?)?;
+        value
+            .as_object_mut()
+            .ok_or_else(|| anyhow!("redis entry should encode as object"))?
+            .remove("observed_timestamp_ms");
+
+        let error = redis_entry_decode_error(value, "RFQ update without observed_timestamp_ms")?;
+
+        assert!(error
+            .to_string()
+            .contains("observed_timestamp_ms must not be empty"));
+
+        Ok(())
+    }
+
+    #[test]
     fn redis_stream_entry_rejects_block_number_for_divergent_backend_blocks() -> Result<()> {
-        let mut value = redis_entry_value(
-            &mixed_backend_update_envelope("stream-1", 4, 124, 125)?,
-            vec![BroadcasterBackend::Native, BroadcasterBackend::Vm],
-        )?;
+        let mut value =
+            redis_entry_value(&mixed_backend_update_envelope("stream-1", 4, 124, 125)?)?;
         value["block_number"] = serde_json::json!("125");
 
         let error = redis_entry_decode_error(value, "unexpected divergent block_number")?;
@@ -1057,13 +898,15 @@ mod tests {
     #[test]
     fn redis_stream_entry_omits_block_number_for_heartbeat_with_backend_heads() -> Result<()> {
         let envelope = heartbeat_envelope("stream-1", 8453, "snapshot-1", 5)?;
-        let entry = redis_entry(&envelope, vec![BroadcasterBackend::Native])?;
+        let entry = redis_entry(&envelope)?;
 
         assert_eq!(entry.kind, BroadcasterMessageKind::Heartbeat);
         assert_eq!(entry.block_number, None);
+        assert_eq!(entry.observed_timestamp_ms, None);
 
         let value = serde_json::to_value(&entry)?;
         assert!(value.get("block_number").is_none());
+        assert!(value.get("observed_timestamp_ms").is_none());
 
         let decoded: BroadcasterRedisStreamEntry = serde_json::from_value(value)?;
         assert_eq!(decoded, entry);
@@ -1072,187 +915,80 @@ mod tests {
     }
 
     #[test]
-    fn redis_stream_entry_rejects_snapshot_chunk_empty_payload_scope() -> Result<()> {
-        let payload_json = serde_json::to_string(&BroadcasterEnvelope::new(
-            "stream-1",
-            2,
-            BroadcasterPayload::SnapshotChunk(BroadcasterSnapshotChunk::new(
-                "snapshot-1",
-                0,
-                Vec::new(),
-            )?),
-        ))?;
+    fn redis_stream_entry_uses_observed_timestamp_for_rfq_heartbeat() -> Result<()> {
+        let envelope = rfq_heartbeat_envelope("stream-1", 8453, "snapshot-1", 5, 321)?;
+        let entry = redis_entry(&envelope)?;
 
-        let error = redis_entry_decode_error(
-            serde_json::json!({
-                "schema_version": "1",
-                "chain_id": "8453",
-                "stream_id": "stream-1",
-                "message_seq": "2",
-                "kind": "snapshot_chunk",
-                "snapshot_id": "snapshot-1",
-                "backend_scope": "native",
-                "block_number": "124",
-                "event_time_ms": "1710000000123",
-                "payload_json": payload_json
-            }),
-            "empty snapshot chunk payload scope",
-        )?;
+        assert_eq!(entry.kind, BroadcasterMessageKind::Heartbeat);
+        assert_eq!(entry.backend_scope, "rfq");
+        assert_eq!(entry.block_number, None);
+        assert_eq!(entry.observed_timestamp_ms, Some(321));
 
-        assert!(error
-            .to_string()
-            .contains("invalid redis backend_scope: native"));
+        let value = serde_json::to_value(&entry)?;
+        assert!(value.get("block_number").is_none());
+        assert_eq!(value["observed_timestamp_ms"], "321");
 
         Ok(())
     }
 
     #[test]
-    fn redis_snapshot_pointer_uses_snake_case_shape_and_validates_live_cursor() -> Result<()> {
-        let pointer = BroadcasterRedisSnapshotPointer::new(
-            8453,
+    fn redis_replay_boundary_uses_camel_case_shape_and_deterministic_cursor() -> Result<()> {
+        let boundary = BroadcasterRedisReplayBoundary::new(
             "dsolver:broadcaster:prod-base:8453:events",
             "chain-8453-stream-7",
             "chain-8453-snapshot-7",
-            "1710000000000-0",
-            "1710000000123-0",
-            "1710000000123-0",
-            1_710_000_000_123,
+            7,
+            42,
         )?;
 
-        let value = serde_json::to_value(&pointer)?;
+        let value = serde_json::to_value(&boundary)?;
 
         assert_eq!(
             value,
             serde_json::json!({
-                "schema_version": "1",
-                "chain_id": 8453,
-                "stream_key": "dsolver:broadcaster:prod-base:8453:events",
-                "stream_id": "chain-8453-stream-7",
-                "snapshot_id": "chain-8453-snapshot-7",
-                "snapshot_start_entry_id": "1710000000000-0",
-                "snapshot_end_entry_id": "1710000000123-0",
-                "live_cursor_entry_id": "1710000000123-0",
-                "completed_at_ms": 1710000000123u64
+                "streamKey": "dsolver:broadcaster:prod-base:8453:events",
+                "streamId": "chain-8453-stream-7",
+                "snapshotId": "chain-8453-snapshot-7",
+                "generation": 7,
+                "exclusiveMessageSeq": 42,
             })
         );
-        let decoded: BroadcasterRedisSnapshotPointer = serde_json::from_value(value)?;
-        assert_eq!(decoded, pointer);
-
-        let Err(error) = BroadcasterRedisSnapshotPointer::new(
-            8453,
-            "dsolver:broadcaster:prod-base:8453:events",
-            "chain-8453-stream-7",
-            "chain-8453-snapshot-7",
-            "1710000000000-0",
-            "1710000000123-0",
-            "1710000000999-0",
-            1_710_000_000_123,
-        ) else {
-            return Err(anyhow!("pointer with mismatched live cursor should fail"));
-        };
-
-        assert_eq!(
-            error,
-            BroadcasterContractError::RedisSnapshotPointerLiveCursorMismatch {
-                snapshot_end_entry_id: "1710000000123-0".to_string(),
-                live_cursor_entry_id: "1710000000999-0".to_string(),
-            }
-        );
+        assert_eq!(boundary.exclusive_entry_id(), "7-42");
+        let decoded: BroadcasterRedisReplayBoundary = serde_json::from_value(value)?;
+        assert_eq!(decoded, boundary);
 
         Ok(())
     }
 
     #[test]
-    fn redis_snapshot_pointer_deserialization_validates_invariants() -> Result<()> {
-        let error = serde_json::from_value::<BroadcasterRedisSnapshotPointer>(serde_json::json!({
-            "schema_version": "1",
-            "chain_id": 8453,
-            "stream_key": "dsolver:broadcaster:prod-base:8453:events",
-            "stream_id": "chain-8453-stream-7",
-            "snapshot_id": "chain-8453-snapshot-7",
-            "snapshot_start_entry_id": "1710000000000-0",
-            "snapshot_end_entry_id": "1710000000123-0",
-            "live_cursor_entry_id": "1710000000999-0",
-            "completed_at_ms": 1710000000123u64
-        }))
-        .err()
-        .ok_or_else(|| anyhow!("mismatched live cursor should fail"))?;
+    fn redis_replay_boundary_rejects_stale_entry_id_field() -> Result<()> {
+        let value = serde_json::json!({
+            "streamKey": "dsolver:broadcaster:prod-base:8453:events",
+            "streamId": "chain-8453-stream-7",
+            "snapshotId": "chain-8453-snapshot-7",
+            "generation": 7,
+            "exclusiveEntryId": "7-99",
+            "exclusiveMessageSeq": 42,
+        });
 
-        assert!(error
-            .to_string()
-            .contains("live cursor 1710000000999-0 must match snapshot end"));
-
-        Ok(())
-    }
-
-    #[test]
-    fn redis_snapshot_pointer_rejects_single_entry_range() -> Result<()> {
-        let Err(error) = BroadcasterRedisSnapshotPointer::new(
-            8453,
-            "dsolver:broadcaster:prod-base:8453:events",
-            "chain-8453-stream-7",
-            "chain-8453-snapshot-7",
-            "1710000000000-0",
-            "1710000000000-0",
-            "1710000000000-0",
-            1_710_000_000_123,
-        ) else {
-            return Err(anyhow!("single-entry snapshot range should fail"));
+        let Err(error) = serde_json::from_value::<BroadcasterRedisReplayBoundary>(value) else {
+            return Err(anyhow!(
+                "stale replay boundary entry id field should fail under the sequence boundary contract"
+            ));
         };
 
-        assert_eq!(
-            error,
-            BroadcasterContractError::RedisSnapshotEntryRangeInvalid {
-                snapshot_start_entry_id: "1710000000000-0".to_string(),
-                snapshot_end_entry_id: "1710000000000-0".to_string(),
-            }
-        );
-
-        Ok(())
-    }
-
-    #[test]
-    fn redis_snapshot_pointer_detects_retention_gap() -> Result<()> {
-        let pointer = BroadcasterRedisSnapshotPointer::new(
-            8453,
-            "dsolver:broadcaster:prod-base:8453:events",
-            "chain-8453-stream-7",
-            "chain-8453-snapshot-7",
-            "1710000000000-0",
-            "1710000000123-0",
-            "1710000000123-0",
-            1_710_000_000_123,
-        )?;
-
-        pointer.ensure_snapshot_retained("1709999999999-0")?;
-        pointer.ensure_snapshot_retained("1710000000000-0")?;
-        let Err(error) = pointer.ensure_snapshot_retained("1710000000001-0") else {
-            return Err(anyhow!("retention past snapshot start should fail"));
-        };
-
-        assert_eq!(
-            error,
-            BroadcasterContractError::RedisSnapshotRetentionGap {
-                oldest_retained_entry_id: "1710000000001-0".to_string(),
-                snapshot_start_entry_id: "1710000000000-0".to_string(),
-            }
-        );
-
+        assert!(error.to_string().contains("exclusiveEntryId"));
         Ok(())
     }
 
     fn redis_entry(
         envelope: &BroadcasterEnvelope,
-        backends: Vec<BroadcasterBackend>,
     ) -> Result<BroadcasterRedisStreamEntry, BroadcasterContractError> {
-        BroadcasterRedisStreamEntry::from_envelope(8453, 1_710_000_000_123, envelope, backends)
+        BroadcasterRedisStreamEntry::from_envelope(8453, 1_710_000_000_123, envelope)
     }
 
-    fn redis_entry_value(
-        envelope: &BroadcasterEnvelope,
-        backends: Vec<BroadcasterBackend>,
-    ) -> Result<serde_json::Value> {
-        serde_json::to_value(redis_entry(envelope, backends)?).map_err(Into::into)
+    fn redis_entry_value(envelope: &BroadcasterEnvelope) -> Result<serde_json::Value> {
+        serde_json::to_value(redis_entry(envelope)?).map_err(Into::into)
     }
 
     fn redis_entry_decode_error(
@@ -1289,26 +1025,25 @@ mod tests {
         ))
     }
 
-    fn rfq_snapshot_chunk_envelope(
+    fn rfq_heartbeat_envelope(
         stream_id: &str,
+        chain_id: u64,
+        snapshot_id: &str,
         message_seq: u64,
-        block_number: u64,
+        observed_timestamp_ms: u64,
     ) -> Result<BroadcasterEnvelope> {
-        snapshot_chunk_envelope_with_partitions(
+        Ok(BroadcasterEnvelope::new(
             stream_id,
             message_seq,
-            0,
-            vec![BroadcasterSnapshotPartition::new(
-                BroadcasterBackend::Rfq,
-                block_number,
-                vec![BroadcasterStateEntry::new(
-                    "pool-rfq",
-                    protocol_component("pool-rfq", "rfq:hashflow"),
-                    dummy_state("rfq-snapshot"),
+            BroadcasterPayload::Heartbeat(BroadcasterHeartbeat::new(
+                chain_id,
+                snapshot_id,
+                vec![BroadcasterBackendHead::new(
+                    BroadcasterBackend::Rfq,
+                    observed_timestamp_ms,
                 )],
-                BTreeMap::new(),
-            )],
-        )
+            )?),
+        ))
     }
 
     fn mixed_backend_update_envelope(


### PR DESCRIPTION
Adds the Redis delta publisher foundation on top of the broadcaster stream contract.

Redis only carries accepted deltas here, not snapshot bootstrap payloads. This adds the replay boundary contract, the publisher/writer/config/retry pieces, and the focused tests around entry IDs, retries, TLS URLs, and generation reset behavior. Keeping the HTTP snapshot boundary and simulator replay for the next PRs so this one stays just the foundation.