### PR TITLE
feat: Unify broadcaster RFQ snapshot sessions

### DIFF
--- a/crates/rpc/src/api/broadcaster.rs
+++ b/crates/rpc/src/api/broadcaster.rs
@@ -6,8 +6,7 @@ use axum::{
 use runtime::broadcaster_service::BroadcasterAppState;
 
 use crate::handlers::broadcaster::{
-    create_rfq_snapshot_session, create_snapshot_session, rfq_snapshot_session_payload,
-    snapshot_session_payload, status, token_lookup, token_snapshot,
+    create_snapshot_session, snapshot_session_payload, status, token_lookup, token_snapshot,
 };
 
 pub fn create_broadcaster_router(app_state: BroadcasterAppState) -> Router {
@@ -17,11 +16,6 @@ pub fn create_broadcaster_router(app_state: BroadcasterAppState) -> Router {
         .route(
             "/snapshot-sessions/:session_id/payloads/:index",
             get(snapshot_session_payload),
-        )
-        .route("/rfq/snapshot-sessions", post(create_rfq_snapshot_session))
-        .route(
-            "/rfq/snapshot-sessions/:session_id/payloads/:index",
-            get(rfq_snapshot_session_payload),
         )
         .route("/tokens/snapshot", get(token_snapshot))
         .route("/tokens/lookup", post(token_lookup))
@@ -283,8 +277,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn root_status_reports_warming_rfq_while_snapshot_sessions_remain_native_only(
-    ) -> Result<()> {
+    async fn snapshot_session_waits_for_rfq_when_rfq_is_configured() -> Result<()> {
         let app = create_broadcaster_router(
             build_state_with_rfq(SeedMode::Ready, SeedMode::WarmingUp).await?,
         );
@@ -298,15 +291,9 @@ mod tests {
         );
         assert!(body["backends"]["rfq"].is_object());
 
-        let (status, body) =
-            post_json(app.clone(), "/snapshot-sessions", serde_json::json!({})).await?;
-        assert_eq!(status, StatusCode::CREATED);
-        let session_id = body["sessionId"]
-            .as_u64()
-            .ok_or_else(|| anyhow!("expected numeric sessionId"))?;
-        let (_status, payload) =
-            get_json(app, &format!("/snapshot-sessions/{session_id}/payloads/0")).await?;
-        assert_eq!(payload["backends"], serde_json::json!(["native"]));
+        let (status, body) = post_json(app, "/snapshot-sessions", serde_json::json!({})).await?;
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(body["status"], "snapshot_warming_up");
         Ok(())
     }
 
@@ -344,40 +331,52 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rfq_snapshot_session_routes_use_rfq_service() -> Result<()> {
+    async fn snapshot_session_create_serves_all_configured_backends() -> Result<()> {
         let app = create_broadcaster_router(
             build_state_with_rfq(SeedMode::Ready, SeedMode::Ready).await?,
         );
 
         let (status, body) =
-            post_json(app.clone(), "/rfq/snapshot-sessions", serde_json::json!({})).await?;
+            post_json(app.clone(), "/snapshot-sessions", serde_json::json!({})).await?;
 
         assert_eq!(status, StatusCode::CREATED);
+        assert_eq!(body["chainId"], Chain::Ethereum.id());
+        assert_eq!(body["streamId"], "chain-1-stream-1");
+        assert_eq!(body["snapshotId"], "chain-1-snapshot-1");
+        assert_eq!(body["payloadCount"], 4);
+        assert_eq!(body["snapshotChunkCount"], 2);
         let session_id = body["sessionId"]
             .as_u64()
             .ok_or_else(|| anyhow!("expected numeric sessionId"))?;
-        let (status, payload) = get_json(
-            app,
-            &format!("/rfq/snapshot-sessions/{session_id}/payloads/0"),
+
+        let (status, start) = get_json(
+            app.clone(),
+            &format!("/snapshot-sessions/{session_id}/payloads/0"),
         )
         .await?;
-
         assert_eq!(status, StatusCode::OK);
-        assert_eq!(payload["kind"], "snapshot_start");
-        assert_eq!(payload["backends"], serde_json::json!(["rfq"]));
-        Ok(())
-    }
+        assert_eq!(start["kind"], "snapshot_start");
+        assert_eq!(start["backends"], serde_json::json!(["native", "rfq"]));
+        assert_eq!(start["totalChunks"], 2);
 
-    #[tokio::test]
-    async fn rfq_snapshot_session_create_reports_not_found_when_rfq_is_unconfigured() -> Result<()>
-    {
-        let app = create_broadcaster_router(build_state(SeedMode::Ready).await?);
+        let (_status, native_chunk) = get_json(
+            app.clone(),
+            &format!("/snapshot-sessions/{session_id}/payloads/1"),
+        )
+        .await?;
+        let (_status, rfq_chunk) = get_json(
+            app.clone(),
+            &format!("/snapshot-sessions/{session_id}/payloads/2"),
+        )
+        .await?;
+        assert_eq!(native_chunk["kind"], "snapshot_chunk");
+        assert_eq!(native_chunk["partitions"][0]["backend"], "native");
+        assert_eq!(rfq_chunk["kind"], "snapshot_chunk");
+        assert_eq!(rfq_chunk["partitions"][0]["backend"], "rfq");
 
-        let (status, body) =
-            post_json(app, "/rfq/snapshot-sessions", serde_json::json!({})).await?;
-
-        assert_eq!(status, StatusCode::NOT_FOUND);
-        assert_eq!(body["error"], "rfq snapshot sessions are not configured");
+        let (status, body) = get_json(app, "/status").await?;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["snapshot_sessions"]["active"], 1);
         Ok(())
     }
 

--- a/crates/rpc/src/handlers/broadcaster.rs
+++ b/crates/rpc/src/handlers/broadcaster.rs
@@ -27,32 +27,11 @@ pub async fn create_snapshot_session(State(state): State<BroadcasterAppState>) -
     snapshot_session_create_response(state.create_snapshot_session().await, &state).await
 }
 
-pub async fn create_rfq_snapshot_session(State(state): State<BroadcasterAppState>) -> Response {
-    if !state.has_rfq_snapshot_service() {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(json!({ "error": "rfq snapshot sessions are not configured" })),
-        )
-            .into_response();
-    }
-    snapshot_session_create_response(state.create_rfq_snapshot_session().await, &state).await
-}
-
 pub async fn snapshot_session_payload(
     State(state): State<BroadcasterAppState>,
     Path((session_id, index)): Path<(u64, u32)>,
 ) -> Response {
     match state.snapshot_session_payload(session_id, index).await {
-        Ok(envelope) => (StatusCode::OK, Json(envelope)).into_response(),
-        Err(error) => snapshot_session_error_response(error),
-    }
-}
-
-pub async fn rfq_snapshot_session_payload(
-    State(state): State<BroadcasterAppState>,
-    Path((session_id, index)): Path<(u64, u32)>,
-) -> Response {
-    match state.rfq_snapshot_session_payload(session_id, index).await {
         Ok(envelope) => (StatusCode::OK, Json(envelope)).into_response(),
         Err(error) => snapshot_session_error_response(error),
     }

--- a/crates/runtime/src/broadcaster/state.rs
+++ b/crates/runtime/src/broadcaster/state.rs
@@ -425,6 +425,129 @@ impl BroadcasterSnapshotCache {
     }
 }
 
+pub(crate) fn combine_snapshot_exports(
+    chain_id: u64,
+    exports: Vec<BroadcasterSnapshotExport>,
+) -> Result<BroadcasterSnapshotExport> {
+    let mut exports = exports.into_iter();
+    let first = exports
+        .next()
+        .ok_or_else(|| anyhow!("cannot combine empty broadcaster snapshot export set"))?;
+    let stream_id = first.stream_id.clone();
+    let snapshot_id = first.snapshot_id.clone();
+    let max_payload_bytes = first.max_payload_bytes;
+    let mut backends = Vec::new();
+    let mut chunks = Vec::new();
+
+    for export in std::iter::once(first).chain(exports) {
+        collect_snapshot_export_parts(
+            chain_id,
+            &stream_id,
+            &snapshot_id,
+            max_payload_bytes,
+            export,
+            &mut backends,
+            &mut chunks,
+        )?;
+    }
+
+    backends.sort();
+    backends.dedup();
+    let total_chunks = chunks.len() as u32;
+    let mut payloads = Vec::with_capacity(chunks.len().saturating_add(2));
+    payloads.push(BroadcasterPayload::SnapshotStart(
+        BroadcasterSnapshotStart::new(snapshot_id.clone(), chain_id, backends, total_chunks)?,
+    ));
+    for (chunk_index, chunk) in chunks.into_iter().enumerate() {
+        payloads.push(BroadcasterPayload::SnapshotChunk(
+            BroadcasterSnapshotChunk::new(
+                snapshot_id.clone(),
+                chunk_index as u32,
+                chunk.partitions,
+            )?,
+        ));
+    }
+    payloads.push(BroadcasterPayload::SnapshotEnd(
+        BroadcasterSnapshotEnd::new(snapshot_id.clone()),
+    ));
+
+    Ok(BroadcasterSnapshotExport {
+        stream_id,
+        snapshot_id,
+        max_payload_bytes,
+        payloads,
+    })
+}
+
+fn collect_snapshot_export_parts(
+    chain_id: u64,
+    stream_id: &str,
+    snapshot_id: &str,
+    max_payload_bytes: usize,
+    export: BroadcasterSnapshotExport,
+    backends: &mut Vec<BroadcasterBackend>,
+    chunks: &mut Vec<BroadcasterSnapshotChunk>,
+) -> Result<()> {
+    ensure!(
+        export.stream_id == stream_id,
+        "snapshot export stream_id mismatch: expected {stream_id}, found {}",
+        export.stream_id
+    );
+    ensure!(
+        export.snapshot_id == snapshot_id,
+        "snapshot export snapshot_id mismatch: expected {snapshot_id}, found {}",
+        export.snapshot_id
+    );
+    ensure!(
+        export.max_payload_bytes == max_payload_bytes,
+        "snapshot export max_payload_bytes mismatch: expected {max_payload_bytes}, found {}",
+        export.max_payload_bytes
+    );
+
+    for payload in export.payloads {
+        match payload {
+            BroadcasterPayload::SnapshotStart(start) => {
+                ensure!(
+                    start.snapshot_id == snapshot_id,
+                    "snapshot_start id mismatch: expected {snapshot_id}, found {}",
+                    start.snapshot_id
+                );
+                ensure!(
+                    start.chain_id == chain_id,
+                    "snapshot_start chain_id mismatch: expected {chain_id}, found {}",
+                    start.chain_id
+                );
+                backends.extend(start.backends);
+            }
+            BroadcasterPayload::SnapshotChunk(chunk) => {
+                ensure!(
+                    chunk.snapshot_id == snapshot_id,
+                    "snapshot_chunk id mismatch: expected {snapshot_id}, found {}",
+                    chunk.snapshot_id
+                );
+                chunks.push(chunk);
+            }
+            BroadcasterPayload::SnapshotEnd(end) => {
+                ensure!(
+                    end.snapshot_id == snapshot_id,
+                    "snapshot_end id mismatch: expected {snapshot_id}, found {}",
+                    end.snapshot_id
+                );
+            }
+            BroadcasterPayload::Update(_)
+            | BroadcasterPayload::Heartbeat(_)
+            | BroadcasterPayload::Progress(_) => {
+                return Err(anyhow!(
+                    "snapshot export contains non-snapshot payload {}",
+                    payload.kind().as_str()
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
 impl BroadcasterPartitionState {
     fn entry_count(&self) -> usize {
         if self.messages.is_empty() {
@@ -1410,6 +1533,83 @@ mod tests {
 
         let heartbeat = cache.heartbeat().await?;
         assert!(matches!(heartbeat, Some(BroadcasterPayload::Heartbeat(_))));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn combines_raw_and_rfq_exports_into_one_snapshot_flow() -> Result<()> {
+        let raw_cache = BroadcasterSnapshotCache::new(1, vec![BroadcasterBackend::Native]);
+        raw_cache.apply_update(&native_only_update()).await?;
+        let rfq_cache = BroadcasterSnapshotCache::new(1, vec![BroadcasterBackend::Rfq]);
+        rfq_cache
+            .apply_update(&rfq_only_update(12, "rfq-1", 7))
+            .await?;
+
+        let export = super::combine_snapshot_exports(
+            1,
+            vec![
+                raw_cache.export_snapshot(8_388_608).await?,
+                rfq_cache.export_snapshot(8_388_608).await?,
+            ],
+        )?;
+
+        assert_eq!(export.stream_id, "chain-1-stream-1");
+        assert_eq!(export.snapshot_id, "chain-1-snapshot-1");
+        assert_eq!(export.payloads.len(), 4);
+        let BroadcasterPayload::SnapshotStart(start) = &export.payloads[0] else {
+            return Err(anyhow!("expected combined snapshot_start"));
+        };
+        assert_eq!(
+            start.backends,
+            vec![BroadcasterBackend::Native, BroadcasterBackend::Rfq]
+        );
+        assert_eq!(start.total_chunks, 2);
+        let chunks = snapshot_chunks(&export);
+        assert_eq!(chunks[0].chunk_index, 0);
+        assert_eq!(chunks[0].partitions[0].backend, BroadcasterBackend::Native);
+        assert_eq!(chunks[1].chunk_index, 1);
+        assert_eq!(chunks[1].partitions[0].backend, BroadcasterBackend::Rfq);
+        assert!(matches!(
+            export.payloads.last(),
+            Some(BroadcasterPayload::SnapshotEnd(end)) if end.snapshot_id == "chain-1-snapshot-1"
+        ));
+        assert_payloads_at_most(&export, 8_388_608)?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn combined_snapshot_export_rejects_mismatched_stream_generation() -> Result<()> {
+        let raw_cache = BroadcasterSnapshotCache::new_with_initial_generation(
+            1,
+            vec![BroadcasterBackend::Native],
+            1,
+        );
+        raw_cache.apply_update(&native_only_update()).await?;
+        let rfq_cache = BroadcasterSnapshotCache::new_with_initial_generation(
+            1,
+            vec![BroadcasterBackend::Rfq],
+            2,
+        );
+        rfq_cache
+            .apply_update(&rfq_only_update(12, "rfq-1", 7))
+            .await?;
+
+        let Err(error) = super::combine_snapshot_exports(
+            1,
+            vec![
+                raw_cache.export_snapshot(8_388_608).await?,
+                rfq_cache.export_snapshot(8_388_608).await?,
+            ],
+        ) else {
+            return Err(anyhow!("mismatched stream generations must fail"));
+        };
+
+        assert!(
+            error
+                .to_string()
+                .contains("snapshot export stream_id mismatch"),
+            "unexpected error: {error}"
+        );
         Ok(())
     }
 

--- a/crates/runtime/src/broadcaster_service.rs
+++ b/crates/runtime/src/broadcaster_service.rs
@@ -68,24 +68,15 @@ impl BroadcasterAppState {
     pub async fn create_snapshot_session(
         &self,
     ) -> Result<Option<BroadcasterSnapshotSessionResponse>> {
-        self.raw_service
-            .create_snapshot_session(self.snapshot_session_ttl)
-            .await
-    }
-
-    pub async fn create_rfq_snapshot_session(
-        &self,
-    ) -> Result<Option<BroadcasterSnapshotSessionResponse>> {
-        let Some(rfq_service) = &self.rfq_service else {
-            return Ok(None);
-        };
-        rfq_service
-            .create_snapshot_session(self.snapshot_session_ttl)
-            .await
-    }
-
-    pub fn has_rfq_snapshot_service(&self) -> bool {
-        self.rfq_service.is_some()
+        let mut services = vec![self.raw_service.clone()];
+        if let Some(rfq_service) = &self.rfq_service {
+            services.push(rfq_service.clone());
+        }
+        BroadcasterServiceState::create_snapshot_session_for_services(
+            &services,
+            self.snapshot_session_ttl,
+        )
+        .await
     }
 
     pub async fn snapshot_session_payload(
@@ -94,16 +85,6 @@ impl BroadcasterAppState {
         index: u32,
     ) -> Result<BroadcasterEnvelope, SnapshotSessionError> {
         self.raw_service
-            .snapshot_session_payload(session_id, index)
-            .await
-    }
-
-    pub async fn rfq_snapshot_session_payload(
-        &self,
-        session_id: u64,
-        index: u32,
-    ) -> Result<BroadcasterEnvelope, SnapshotSessionError> {
-        self.rfq_service()?
             .snapshot_session_payload(session_id, index)
             .await
     }
@@ -155,12 +136,6 @@ impl BroadcasterAppState {
             chain_id: self.chain_id,
             tokens,
         }
-    }
-
-    fn rfq_service(&self) -> Result<&BroadcasterServiceState, SnapshotSessionError> {
-        self.rfq_service
-            .as_ref()
-            .ok_or(SnapshotSessionError::NotFound)
     }
 }
 
@@ -564,6 +539,7 @@ mod tests {
             },
             tuning: BroadcasterTuning {
                 snapshot_max_payload_bytes: 8_388_608,
+                subscriber_buffer_capacity: 128,
                 heartbeat_interval_secs: 5,
                 token_min_quality: 0,
                 snapshot_session_ttl_secs: 300,

--- a/crates/runtime/src/services/broadcaster.rs
+++ b/crates/runtime/src/services/broadcaster.rs
@@ -11,8 +11,8 @@ use tycho_simulation::{
 
 use crate::broadcaster::redis_publisher::BroadcasterRedisPublisher;
 use crate::broadcaster::state::{
-    BroadcasterReadiness, BroadcasterSnapshotCache, BroadcasterStatusSnapshot,
-    BroadcasterUpstreamState,
+    combine_snapshot_exports, BroadcasterReadiness, BroadcasterSnapshotCache,
+    BroadcasterStatusSnapshot, BroadcasterUpstreamState,
 };
 use crate::services::broadcaster_sessions::{
     BroadcasterSnapshotSessionRegistry, SessionCloseReason, SnapshotSessionError,
@@ -141,17 +141,49 @@ impl BroadcasterServiceState {
         &self,
         ttl: Duration,
     ) -> Result<Option<BroadcasterSnapshotSessionResponse>> {
-        let _gate = self.lifecycle_gate.lock().await;
-        let status = self.status_snapshot().await;
-        if status.readiness != BroadcasterReadiness::Ready {
-            return Ok(None);
+        Self::create_snapshot_session_for_services(std::slice::from_ref(self), ttl).await
+    }
+
+    pub async fn create_snapshot_session_for_services(
+        services: &[Self],
+        ttl: Duration,
+    ) -> Result<Option<BroadcasterSnapshotSessionResponse>> {
+        anyhow::ensure!(
+            !services.is_empty(),
+            "combined broadcaster snapshot session requires at least one service"
+        );
+        ensure_shared_lifecycle(services, "combined broadcaster snapshot session")?;
+
+        let _gate = services[0].lifecycle_gate.lock().await;
+        let mut chain_id = None;
+        let mut exports = Vec::with_capacity(services.len());
+
+        for service in services {
+            let status = service.status_snapshot().await;
+            if status.readiness != BroadcasterReadiness::Ready {
+                return Ok(None);
+            }
+            match chain_id {
+                Some(expected) => anyhow::ensure!(
+                    status.chain_id == expected,
+                    "combined broadcaster snapshot session chain_id mismatch: expected {expected}, found {}",
+                    status.chain_id
+                ),
+                None => chain_id = Some(status.chain_id),
+            }
+            exports.push(
+                service
+                    .cache
+                    .export_snapshot(service.snapshot_max_payload_bytes)
+                    .await?,
+            );
         }
 
-        let snapshot = self
-            .cache
-            .export_snapshot(self.snapshot_max_payload_bytes)
-            .await?;
-        let redis_replay_boundary = match self.redis_publisher.replay_boundary().await {
+        let chain_id = chain_id.ok_or_else(|| {
+            anyhow::anyhow!("combined broadcaster snapshot session missing chain_id")
+        })?;
+        let snapshot = combine_snapshot_exports(chain_id, exports)?;
+        let redis_replay_boundary = match services[0].redis_publisher.replay_boundary().await {
             Ok(boundary) => boundary,
             Err(error) => {
                 warn!(
@@ -161,9 +193,11 @@ impl BroadcasterServiceState {
                 return Ok(None);
             }
         };
-        self.snapshot_sessions
-            .create_snapshot_session(snapshot, status.chain_id, redis_replay_boundary, ttl)
+        services[0]
+            .snapshot_sessions
+            .create_snapshot_session(snapshot, chain_id, redis_replay_boundary, ttl)
             .await
+            .context("failed to create combined broadcaster snapshot session")
             .map(Some)
     }
 
@@ -211,6 +245,22 @@ impl BroadcasterServiceState {
     pub(crate) async fn lock_lifecycle_gate_for_test(&self) -> tokio::sync::OwnedMutexGuard<()> {
         self.lifecycle_gate.clone().lock_owned().await
     }
+}
+
+fn ensure_shared_lifecycle(services: &[BroadcasterServiceState], context: &str) -> Result<()> {
+    anyhow::ensure!(
+        services
+            .iter()
+            .all(|service| Arc::ptr_eq(&service.lifecycle_gate, &services[0].lifecycle_gate)),
+        "{context} requires one lifecycle gate"
+    );
+    anyhow::ensure!(
+        services
+            .iter()
+            .all(|service| Arc::ptr_eq(&service.redis_publisher, &services[0].redis_publisher)),
+        "{context} requires one Redis publisher"
+    );
+    Ok(())
 }
 
 #[cfg(test)]
@@ -361,6 +411,126 @@ mod tests {
         ));
         assert_eq!(session.redis_replay_boundary.exclusive_message_seq, 1);
         assert_eq!(publisher_boundary.exclusive_message_seq, 2);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn shared_snapshot_session_boundary_is_registered_before_queued_rfq_update() -> Result<()>
+    {
+        let writer = ServiceFakeRedisWriter::default();
+        let publisher = Arc::new(BroadcasterRedisPublisher::new_with_initial_generation(
+            publisher_config(),
+            Arc::new(writer),
+            1,
+        ));
+        let lifecycle_gate = Arc::new(Mutex::new(()));
+        let raw_service = BroadcasterServiceState::with_lifecycle_gate(
+            8_388_608,
+            BroadcasterSnapshotCache::new(1, vec![BroadcasterBackend::Native]),
+            BroadcasterUpstreamState::default(),
+            Arc::clone(&publisher),
+            Arc::clone(&lifecycle_gate),
+        );
+        let rfq_service = BroadcasterServiceState::with_lifecycle_gate(
+            8_388_608,
+            BroadcasterSnapshotCache::new(1, vec![BroadcasterBackend::Rfq]),
+            BroadcasterUpstreamState::default(),
+            Arc::clone(&publisher),
+            lifecycle_gate,
+        );
+        raw_service.mark_upstream_connected().await;
+        rfq_service.mark_upstream_connected().await;
+        raw_service
+            .apply_update(&native_only_update(10, "native-1"))
+            .await?;
+        rfq_service
+            .apply_update(&rfq_only_update(12, "rfq-1", 7))
+            .await?;
+        let gate = raw_service.lock_lifecycle_gate_for_test().await;
+
+        let services = vec![raw_service.clone(), rfq_service.clone()];
+        let mut subscribe_task = tokio::spawn(async move {
+            BroadcasterServiceState::create_snapshot_session_for_services(
+                &services,
+                Duration::from_secs(300),
+            )
+            .await
+        });
+        tokio::task::yield_now().await;
+
+        let update_task = tokio::spawn({
+            let rfq_service = rfq_service.clone();
+            async move {
+                rfq_service
+                    .apply_update(&rfq_only_update(13, "rfq-2", 8))
+                    .await
+            }
+        });
+
+        assert!(timeout(Duration::from_millis(25), &mut subscribe_task)
+            .await
+            .is_err());
+        drop(gate);
+
+        let session = subscribe_task
+            .await
+            .map_err(|error| anyhow!("subscribe task failed: {error}"))??
+            .ok_or_else(|| anyhow!("expected combined broadcaster snapshot session"))?;
+        update_task
+            .await
+            .map_err(|error| anyhow!("update task failed: {error}"))??;
+
+        let first_payload = raw_service
+            .snapshot_session_payload(session.session_id, 0)
+            .await
+            .map_err(|error| anyhow!("failed to fetch snapshot payload: {error:?}"))?;
+        let publisher_status = publisher.status_snapshot().await;
+        let publisher_boundary = publisher_status
+            .replay_boundary
+            .ok_or_else(|| anyhow!("expected Redis replay boundary after queued update"))?;
+
+        assert!(matches!(
+            first_payload.payload,
+            BroadcasterPayload::SnapshotStart(_)
+        ));
+        assert_eq!(session.redis_replay_boundary.exclusive_message_seq, 2);
+        assert_eq!(publisher_boundary.exclusive_message_seq, 3);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn combined_snapshot_session_rejects_mismatched_lifecycle_gate() -> Result<()> {
+        let writer = ServiceFakeRedisWriter::default();
+        let publisher = Arc::new(BroadcasterRedisPublisher::new_with_initial_generation(
+            publisher_config(),
+            Arc::new(writer),
+            1,
+        ));
+        let raw_service = BroadcasterServiceState::with_lifecycle_gate(
+            8_388_608,
+            BroadcasterSnapshotCache::new(1, vec![BroadcasterBackend::Native]),
+            BroadcasterUpstreamState::default(),
+            Arc::clone(&publisher),
+            Arc::new(Mutex::new(())),
+        );
+        let rfq_service = BroadcasterServiceState::with_lifecycle_gate(
+            8_388_608,
+            BroadcasterSnapshotCache::new(1, vec![BroadcasterBackend::Rfq]),
+            BroadcasterUpstreamState::default(),
+            publisher,
+            Arc::new(Mutex::new(())),
+        );
+
+        let Err(error) = BroadcasterServiceState::create_snapshot_session_for_services(
+            &[raw_service, rfq_service],
+            Duration::from_secs(300),
+        )
+        .await
+        else {
+            return Err(anyhow!("mismatched lifecycle gates should be rejected"));
+        };
+
+        assert!(format!("{error:#}").contains("one lifecycle gate"));
         Ok(())
     }
 
@@ -745,6 +915,33 @@ mod tests {
                 hash: Bytes::from(vec![1u8; 32]),
                 number: block_number,
                 parent_hash: Bytes::from(vec![2u8; 32]),
+                revert: false,
+                timestamp: block_number * 10,
+                partial_block_index: None,
+            }),
+        )]))
+    }
+
+    fn rfq_only_update(block_number: u64, component_id: &str, seed: u8) -> Update {
+        let protocol = "rfq:hashflow";
+        let mut new_pairs = HashMap::new();
+        new_pairs.insert(
+            component_id.to_string(),
+            protocol_component(component_id, protocol),
+        );
+
+        let mut states = HashMap::new();
+        states.insert(
+            component_id.to_string(),
+            Box::new(DummySim(seed)) as Box<dyn ProtocolSim>,
+        );
+
+        Update::new(block_number, states, new_pairs).set_sync_states(HashMap::from([(
+            protocol.to_string(),
+            SynchronizerState::Ready(BlockHeader {
+                hash: Bytes::from(vec![seed; 32]),
+                number: block_number,
+                parent_hash: Bytes::from(vec![seed.saturating_add(1); 32]),
                 revert: false,
                 timestamp: block_number * 10,
                 partial_block_index: None,

--- a/crates/runtime/src/services/broadcaster_subscription.rs
+++ b/crates/runtime/src/services/broadcaster_subscription.rs
@@ -942,11 +942,8 @@ async fn fetch_broadcaster_snapshot_payload(
     decode_success_json(response, &payload_url, "fetch broadcaster snapshot payload").await
 }
 
-fn broadcaster_snapshot_sessions_path(backend: BroadcasterBackend) -> &'static str {
-    match backend {
-        BroadcasterBackend::Rfq => "rfq/snapshot-sessions",
-        BroadcasterBackend::Native | BroadcasterBackend::Vm => "snapshot-sessions",
-    }
+fn broadcaster_snapshot_sessions_path(_backend: BroadcasterBackend) -> &'static str {
+    "snapshot-sessions"
 }
 
 fn broadcaster_snapshot_payload_path(
@@ -1800,6 +1797,13 @@ mod tests {
                     "sessionId": 7,
                     "streamId": "stream-1",
                     "snapshotId": "snapshot-1",
+                    "redisReplayBoundary": {
+                        "streamKey": "dsolver:broadcaster:test:events",
+                        "streamId": "stream-1",
+                        "snapshotId": "snapshot-1",
+                        "generation": 1,
+                        "exclusiveMessageSeq": 0
+                    },
                     "payloadCount": payloads.len(),
                     "snapshotChunkCount": payloads
                         .iter()
@@ -1861,6 +1865,30 @@ mod tests {
         let mut decoder = TychoStreamDecoder::new();
         decoder.register_decoder::<DummySim>("vm:curve");
         Arc::new(decoder)
+    }
+
+    #[test]
+    fn rfq_subscription_uses_root_snapshot_session_path() {
+        assert_eq!(
+            super::broadcaster_snapshot_sessions_path(BroadcasterBackend::Rfq),
+            "snapshot-sessions"
+        );
+        assert_eq!(
+            super::broadcaster_snapshot_payload_path(BroadcasterBackend::Rfq, 7, 2),
+            "snapshot-sessions/7/payloads/2"
+        );
+    }
+
+    #[test]
+    fn native_and_vm_subscription_paths_remain_root_snapshot_paths() {
+        assert_eq!(
+            super::broadcaster_snapshot_sessions_path(BroadcasterBackend::Native),
+            "snapshot-sessions"
+        );
+        assert_eq!(
+            super::broadcaster_snapshot_payload_path(BroadcasterBackend::Vm, 8, 3),
+            "snapshot-sessions/8/payloads/3"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Unifies RFQ snapshot bootstrap behind the root broadcaster snapshot session.

When RFQ is configured, `/snapshot-sessions` now waits for RFQ readiness and returns one snapshot flow with every configured backend. The RFQ specific snapshot routes go away, and RFQ consumers use the same HTTP snapshot path as native and VM. Keeping simulator replay from Redis for the next PR so this stays just the snapshot boundary cleanup.
