### PR TITLE
feat: Replay broadcaster Redis deltas in simulator

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,9 @@
 TYCHO_API_KEY=your_api_key_here
 # Runtime chain selection (required): must match a chain in simulator-manifest.toml
 CHAIN_ID=1
-# Required for the simulator service: websocket endpoint for the Tycho broadcaster.
+# Required for the simulator service: HTTP base URL for the Tycho broadcaster.
 # Local helpers use this loopback URL to start the broadcaster on PORT=3001 before the simulator.
-TYCHO_BROADCASTER_WS_URL=ws://127.0.0.1:3001/ws
+TYCHO_BROADCASTER_URL=http://127.0.0.1:3001
 # Hosted Tycho endpoint is selected automatically from CHAIN_ID.
 # Optional JSON-RPC endpoint matching CHAIN_ID, used for on-chain helpers like ERC4626 deposits
 RPC_URL=
@@ -30,10 +30,15 @@ HOST=127.0.0.1
 # 8 MiB cap per serialized snapshot payload; keeps HTTP chunks large enough for throughput
 # without making retries expensive when one chunk fails.
 BROADCASTER_SNAPSHOT_MAX_PAYLOAD_BYTES=8388608
-BROADCASTER_SUBSCRIBER_BUFFER_CAPACITY=128
 BROADCASTER_HEARTBEAT_INTERVAL_SECS=5
 BROADCASTER_TOKEN_MIN_QUALITY=0
 BROADCASTER_SNAPSHOT_SESSION_TTL_SECS=300
+BROADCASTER_REDIS_URL=redis://127.0.0.1:6379/0
+BROADCASTER_REDIS_STREAM_KEY=dsolver:broadcaster:local:1:events
+BROADCASTER_REDIS_BLOCK_MS=5000
+BROADCASTER_REDIS_READ_COUNT=128
+BROADCASTER_REDIS_APPEND_RETRY_WINDOW_MS=5000
+BROADCASTER_REDIS_MAXLEN=100000
 
 # Logging settings
 RUST_LOG=info

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5498,7 +5498,6 @@ dependencies = [
  "simulator-core",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite 0.24.0",
  "tokio-util",
  "toml",
  "tracing",
@@ -6499,18 +6498,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.24.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
@@ -6824,24 +6811,6 @@ dependencies = [
  "sha1",
  "thiserror 1.0.69",
  "url",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http 1.4.0",
- "httparse",
- "log",
- "rand 0.8.6",
- "sha1",
- "thiserror 1.0.69",
  "utf-8",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }
 tokio-stream = "0.1.18"
-tokio-tungstenite = "0.24.0"
 tokio-util = "0.7"
 toml = "0.8"
 tower = { version = "0.5", features = ["timeout", "util"] }

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ DSolver Simulator is a Rust service for DeFi quote simulation and route encoding
 | Binary | `dsolver-simulator-service` |
 | Endpoints | `GET /status`, `POST /simulate`, `POST /encode` |
 | Supported chains | Defined in `simulator-manifest.toml` |
-| Required inputs | `TYCHO_API_KEY`, `CHAIN_ID`, `TYCHO_BROADCASTER_WS_URL` |
+| Required inputs | `TYCHO_API_KEY`, `CHAIN_ID`, `TYCHO_BROADCASTER_URL` |
 | Common optional inputs | `RPC_URL`, `ENABLE_VM_POOLS`, `ENABLE_RFQ_POOLS`, `HOST`, `PORT` |
 | License | MIT |
 
@@ -79,13 +79,14 @@ Use the explicit `-p ... --bin ...` form for local runs and builds so it's alway
 workspace binary you're targeting.
 
 For manual service runs, start `dsolver-tycho-broadcaster-service` first on the port used by
-`TYCHO_BROADCASTER_WS_URL`, then start `dsolver-simulator-service`.
+`TYCHO_BROADCASTER_URL`, then start `dsolver-simulator-service`.
 
 Required runtime inputs:
 
 - `TYCHO_API_KEY` for Tycho access
 - `CHAIN_ID` for chain selection from `simulator-manifest.toml`
-- `TYCHO_BROADCASTER_WS_URL` pointing at the broadcaster websocket, for example `ws://127.0.0.1:3001/ws`
+- `TYCHO_BROADCASTER_URL` pointing at the broadcaster HTTP base URL, for example `http://127.0.0.1:3001`
+- `BROADCASTER_REDIS_URL` and `BROADCASTER_REDIS_STREAM_KEY` for the Redis stream that carries broadcaster deltas after each HTTP snapshot replay boundary
 
 Common optional inputs:
 
@@ -97,6 +98,8 @@ Common optional inputs:
 - `BROADCASTER_TOKEN_MIN_QUALITY` to tune the broadcaster's startup Tycho token quality floor
 - `BROADCASTER_SNAPSHOT_MAX_PAYLOAD_BYTES` to cap serialized HTTP snapshot payloads
 - `BROADCASTER_SNAPSHOT_SESSION_TTL_SECS` to set how long an unattached snapshot session can wait before cleanup
+- `BROADCASTER_REDIS_BLOCK_MS`, `BROADCASTER_REDIS_READ_COUNT`, and `BROADCASTER_REDIS_APPEND_RETRY_WINDOW_MS` to tune Redis stream reads and append retries
+- `BROADCASTER_REDIS_MAXLEN` to cap retained Redis delta entries and force simulators to fail readiness if replay data is trimmed before catch-up
 - `TOKEN_SNAPSHOT_TIMEOUT_MS` for the simulator's startup load of the full broadcaster token snapshot
 - `TOKEN_REFRESH_TIMEOUT_MS` for RFQ provider token bootstrap and later single-token lookup misses
 - timeout and stream-health knobs from `crates/runtime/src/config/mod.rs`
@@ -220,7 +223,7 @@ cargo run -p apps --bin sim-analysis -- --chain-id 1 --stop
 cargo run -p apps --bin sim-analysis -- --chain-id 8453 --stop
 ```
 
-When `TYCHO_BROADCASTER_WS_URL` points at local loopback, the analyzer uses the repo lifecycle
+When `TYCHO_BROADCASTER_URL` points at local loopback, the analyzer uses the repo lifecycle
 helper to start the broadcaster before the simulator. Non-local broadcaster URLs are treated as
 externally managed.
 

--- a/STRESS_TEST_README.md
+++ b/STRESS_TEST_README.md
@@ -31,7 +31,7 @@ cargo run -p apps --bin sim-analysis -- --chain-id 1 --baseline none --stop
 ## What the analyzer does
 
 - reuses the existing local simulator if it is already responding, otherwise starts the local stack with the repo lifecycle helper
-- starts `dsolver-tycho-broadcaster-service` first when `TYCHO_BROADCASTER_WS_URL` points at local loopback, then starts `dsolver-simulator-service`; non-local broadcaster URLs are treated as externally managed
+- starts `dsolver-tycho-broadcaster-service` first when `TYCHO_BROADCASTER_URL` points at local loopback, then starts `dsolver-simulator-service`; non-local broadcaster URLs are treated as externally managed, and Redis carries broadcaster deltas after each HTTP snapshot replay boundary
 - waits for `/status` service health, then confirms native readiness first and includes VM and RFQ readiness when those backends are enabled
 - allows longer VM or RFQ warmups on fresh starts; budget up to about 10 minutes before assuming either backend is stuck
 - runs a balanced `/simulate` sweep across representative pairs

--- a/crates/rpc/src/handlers/readiness.rs
+++ b/crates/rpc/src/handlers/readiness.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 
 use axum::{extract::State, http::StatusCode, Json};
 use serde::Serialize;
+use simulator_core::broadcaster::BroadcasterRedisReplayBoundary;
 
 use crate::models::state::{
     AppState, SimulatorBackendKind, SimulatorBackendStatusSnapshot,
@@ -89,6 +90,13 @@ pub struct BackendSubscriptionPayload {
     stream_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     snapshot_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    redis_replay_boundary: Option<BroadcasterRedisReplayBoundary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    redis_catch_up_cursor: Option<String>,
+    redis_replay_caught_up: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    redis_gap_reason: Option<String>,
     restart_count: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     last_error: Option<String>,
@@ -101,6 +109,10 @@ impl From<SimulatorBackendSubscriptionSnapshot> for BackendSubscriptionPayload {
             bootstrap_complete: snapshot.bootstrap_complete,
             stream_id: snapshot.stream_id,
             snapshot_id: snapshot.snapshot_id,
+            redis_replay_boundary: snapshot.redis_replay_boundary,
+            redis_catch_up_cursor: snapshot.redis_catch_up_cursor,
+            redis_replay_caught_up: snapshot.redis_replay_caught_up,
+            redis_gap_reason: snapshot.redis_gap_reason,
             restart_count: snapshot.restart_count,
             last_error: snapshot.last_error,
         }
@@ -136,6 +148,7 @@ mod tests {
     use chrono::NaiveDateTime;
     use num_bigint::BigUint;
     use num_traits::Zero;
+    use simulator_core::broadcaster::BroadcasterRedisReplayBoundary;
     use tycho_simulation::protocol::models::{ProtocolComponent, Update};
     use tycho_simulation::tycho_common::dto::ProtocolStateDelta;
     use tycho_simulation::tycho_common::models::{token::Token, Chain};
@@ -381,6 +394,88 @@ mod tests {
             subscription.last_error.as_deref(),
             Some("rfq broadcaster dropped")
         );
+    }
+
+    #[tokio::test]
+    async fn status_returns_service_unavailable_for_enabled_backend_redis_gap() {
+        let state = test_state(false, true);
+        seed_native_ready_store(&state).await;
+        state.native_stream_health.record_update(1).await;
+
+        let rfq_component = ProtocolComponent::new(
+            address(31),
+            "rfq:hashflow".to_string(),
+            "hashflow".to_string(),
+            Chain::Ethereum,
+            vec![token(32, "RFQA"), token(33, "RFQB")],
+            Vec::new(),
+            HashMap::new(),
+            Bytes::default(),
+            NaiveDateTime::default(),
+        );
+        state
+            .rfq_state_store
+            .apply_update(Update::new(
+                1,
+                HashMap::from([(
+                    "pool-rfq".to_string(),
+                    Box::new(ReadyStateSim) as Box<dyn ProtocolSim>,
+                )]),
+                HashMap::from([("pool-rfq".to_string(), rfq_component)]),
+            ))
+            .await;
+        state.rfq_stream_health.record_update(1).await;
+        state
+            .rfq_broadcaster_subscription
+            .mark_redis_gap("RFQ Redis replay gap")
+            .await;
+
+        let (status_code, Json(payload)): (_, Json<StatusPayload>) = status(State(state)).await;
+
+        assert_eq!(status_code, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(payload.status, "warming_up");
+        assert_eq!(payload.backends["native"].status, "ready");
+        assert_eq!(payload.backends["rfq"].status, "warming_up");
+        assert_eq!(payload.backends["rfq"].reason, Some("redis_replay_gap"));
+        assert_eq!(
+            payload.backends["rfq"]
+                .subscription
+                .as_ref()
+                .and_then(|subscription| subscription.redis_gap_reason.as_deref()),
+            Some("RFQ Redis replay gap")
+        );
+    }
+
+    #[tokio::test]
+    async fn status_reports_redis_replay_boundary_and_cursor() {
+        let state = test_state(false, false);
+        let boundary = BroadcasterRedisReplayBoundary::new(
+            "dsolver:broadcaster:test:1:events",
+            "stream-test",
+            "snapshot-test",
+            2,
+            12,
+        )
+        .unwrap_or_else(|err| unreachable!("valid replay boundary: {err}"));
+        state
+            .native_broadcaster_subscription
+            .mark_bootstrap_complete_with_redis_boundary(boundary.clone())
+            .await;
+        state
+            .native_broadcaster_subscription
+            .mark_redis_catch_up_cursor("2-14")
+            .await;
+
+        let (_status_code, Json(payload)): (_, Json<StatusPayload>) = status(State(state)).await;
+        let subscription = payload.backends["native"]
+            .subscription
+            .as_ref()
+            .unwrap_or_else(|| unreachable!("native status must include subscription"));
+
+        assert_eq!(subscription.redis_replay_boundary, Some(boundary));
+        assert_eq!(subscription.redis_catch_up_cursor.as_deref(), Some("2-14"));
+        assert!(subscription.redis_replay_caught_up);
+        assert!(subscription.redis_gap_reason.is_none());
     }
 
     #[tokio::test]

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -25,7 +25,6 @@ serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
-tokio-tungstenite.workspace = true
 tokio-util.workspace = true
 toml.workspace = true
 tracing.workspace = true

--- a/crates/runtime/src/broadcaster_service.rs
+++ b/crates/runtime/src/broadcaster_service.rs
@@ -539,7 +539,6 @@ mod tests {
             },
             tuning: BroadcasterTuning {
                 snapshot_max_payload_bytes: 8_388_608,
-                subscriber_buffer_capacity: 128,
                 heartbeat_interval_secs: 5,
                 token_min_quality: 0,
                 snapshot_session_ttl_secs: 300,

--- a/crates/runtime/src/config/mod.rs
+++ b/crates/runtime/src/config/mod.rs
@@ -20,7 +20,6 @@ const DEFAULT_BROADCASTER_SNAPSHOT_MAX_PAYLOAD_BYTES: &str = "8388608";
 const DEFAULT_BROADCASTER_REDIS_BLOCK_MS: &str = "5000";
 const DEFAULT_BROADCASTER_REDIS_READ_COUNT: &str = "128";
 const DEFAULT_BROADCASTER_REDIS_APPEND_RETRY_WINDOW_MS: &str = "5000";
-const DEFAULT_BROADCASTER_REDIS_RETENTION_SECS: &str = "300";
 
 /// Per-chain runtime profile resolved from `CHAIN_ID`.
 #[derive(Clone, Debug)]
@@ -91,7 +90,7 @@ pub fn load_config() -> AppConfig {
     AppConfig {
         chain_profile,
         tycho_url: resolved_chain.tycho_url,
-        tycho_broadcaster_ws_url: require_trimmed_env("TYCHO_BROADCASTER_WS_URL"),
+        tycho_broadcaster_url: require_trimmed_env("TYCHO_BROADCASTER_URL"),
         bebop_url: resolved_chain.bebop_url,
         hashflow_filename: resolved_chain.hashflow_filename,
         liquorice_url: resolved_chain.liquorice_url,
@@ -329,18 +328,15 @@ struct StreamConfig {
 pub struct BroadcasterRedisConfig {
     pub redis_url: String,
     pub stream_key: String,
-    pub snapshot_key: String,
     pub block_ms: u64,
     pub read_count: u64,
     pub append_retry_window_ms: u64,
-    pub retention_secs: u64,
     pub maxlen: Option<u64>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct BroadcasterTuning {
     pub snapshot_max_payload_bytes: usize,
-    pub subscriber_buffer_capacity: usize,
     pub heartbeat_interval_secs: u64,
     pub token_min_quality: i32,
     pub snapshot_session_ttl_secs: u64,
@@ -491,7 +487,6 @@ pub fn load_broadcaster_redis_config() -> BroadcasterRedisConfig {
 
     let redis_url = require_trimmed_env("BROADCASTER_REDIS_URL");
     let stream_key = require_trimmed_env("BROADCASTER_REDIS_STREAM_KEY");
-    let snapshot_key = require_trimmed_env("BROADCASTER_REDIS_SNAPSHOT_KEY");
     let block_ms = parse_env_or_default(
         "BROADCASTER_REDIS_BLOCK_MS",
         DEFAULT_BROADCASTER_REDIS_BLOCK_MS,
@@ -504,27 +499,15 @@ pub fn load_broadcaster_redis_config() -> BroadcasterRedisConfig {
         "BROADCASTER_REDIS_APPEND_RETRY_WINDOW_MS",
         DEFAULT_BROADCASTER_REDIS_APPEND_RETRY_WINDOW_MS,
     );
-    let retention_secs = parse_env_or_default(
-        "BROADCASTER_REDIS_RETENTION_SECS",
-        DEFAULT_BROADCASTER_REDIS_RETENTION_SECS,
-    );
     let maxlen = optional_trimmed_env("BROADCASTER_REDIS_MAXLEN")
         .map(|value| parse_value_or_panic("BROADCASTER_REDIS_MAXLEN", &value));
 
     assert_valid_redis_url(&redis_url);
-    assert!(
-        stream_key != snapshot_key,
-        "BROADCASTER_REDIS_STREAM_KEY and BROADCASTER_REDIS_SNAPSHOT_KEY must be different"
-    );
     assert!(block_ms > 0, "BROADCASTER_REDIS_BLOCK_MS must be > 0");
     assert!(read_count > 0, "BROADCASTER_REDIS_READ_COUNT must be > 0");
     assert!(
         append_retry_window_ms > 0,
         "BROADCASTER_REDIS_APPEND_RETRY_WINDOW_MS must be > 0"
-    );
-    assert!(
-        retention_secs > 0,
-        "BROADCASTER_REDIS_RETENTION_SECS must be > 0"
     );
     if let Some(maxlen) = maxlen {
         assert!(maxlen > 0, "BROADCASTER_REDIS_MAXLEN must be > 0");
@@ -533,11 +516,9 @@ pub fn load_broadcaster_redis_config() -> BroadcasterRedisConfig {
     BroadcasterRedisConfig {
         redis_url,
         stream_key,
-        snapshot_key,
         block_ms,
         read_count,
         append_retry_window_ms,
-        retention_secs,
         maxlen,
     }
 }
@@ -547,13 +528,10 @@ pub fn load_broadcaster_redis_config() -> BroadcasterRedisConfig {
     reason = "startup config remains fail-fast on invalid Redis URL"
 )]
 fn assert_valid_redis_url(redis_url: &str) {
-    let rest = if let Some(rest) = redis_url.strip_prefix("redis://") {
-        rest
-    } else if let Some(rest) = redis_url.strip_prefix("rediss://") {
-        rest
-    } else {
-        panic!("BROADCASTER_REDIS_URL must start with redis:// or rediss://");
-    };
+    let rest = redis_url
+        .strip_prefix("redis://")
+        .or_else(|| redis_url.strip_prefix("rediss://"))
+        .unwrap_or_else(|| panic!("BROADCASTER_REDIS_URL must start with redis:// or rediss://"));
 
     let authority = rest
         .split(['/', '?', '#'])
@@ -605,8 +583,6 @@ fn load_broadcaster_tuning() -> BroadcasterTuning {
         "BROADCASTER_SNAPSHOT_MAX_PAYLOAD_BYTES",
         DEFAULT_BROADCASTER_SNAPSHOT_MAX_PAYLOAD_BYTES,
     );
-    let subscriber_buffer_capacity =
-        parse_env_or_default("BROADCASTER_SUBSCRIBER_BUFFER_CAPACITY", "128");
     let heartbeat_interval_secs = parse_env_or_default("BROADCASTER_HEARTBEAT_INTERVAL_SECS", "5");
     let token_min_quality = parse_env_or_default("BROADCASTER_TOKEN_MIN_QUALITY", "0");
     let snapshot_session_ttl_secs =
@@ -615,10 +591,6 @@ fn load_broadcaster_tuning() -> BroadcasterTuning {
     assert!(
         snapshot_max_payload_bytes > 0,
         "BROADCASTER_SNAPSHOT_MAX_PAYLOAD_BYTES must be > 0"
-    );
-    assert!(
-        subscriber_buffer_capacity > 0,
-        "BROADCASTER_SUBSCRIBER_BUFFER_CAPACITY must be > 0"
     );
     assert!(
         heartbeat_interval_secs > 0,
@@ -635,7 +607,6 @@ fn load_broadcaster_tuning() -> BroadcasterTuning {
 
     BroadcasterTuning {
         snapshot_max_payload_bytes,
-        subscriber_buffer_capacity,
         heartbeat_interval_secs,
         token_min_quality,
         snapshot_session_ttl_secs,
@@ -679,7 +650,7 @@ fn load_slippage_config() -> SlippageConfig {
 pub struct AppConfig {
     pub chain_profile: ChainProfile,
     pub tycho_url: String,
-    pub tycho_broadcaster_ws_url: String,
+    pub tycho_broadcaster_url: String,
     pub bebop_url: String,
     pub hashflow_filename: String,
     pub liquorice_url: Option<String>,
@@ -844,21 +815,18 @@ mod tests {
         "CUMULATIVE_DEGRADATION_COEFFICIENT_BPS",
         "SATURATION_RAMP_START_SLIPPAGE_BPS",
     ];
-    const BROADCASTER_TUNING_ENV_KEYS: [&str; 5] = [
+    const BROADCASTER_TUNING_ENV_KEYS: [&str; 4] = [
         "BROADCASTER_SNAPSHOT_MAX_PAYLOAD_BYTES",
-        "BROADCASTER_SUBSCRIBER_BUFFER_CAPACITY",
         "BROADCASTER_HEARTBEAT_INTERVAL_SECS",
         "BROADCASTER_TOKEN_MIN_QUALITY",
         "BROADCASTER_SNAPSHOT_SESSION_TTL_SECS",
     ];
-    const BROADCASTER_REDIS_ENV_KEYS: [&str; 8] = [
+    const BROADCASTER_REDIS_ENV_KEYS: [&str; 6] = [
         "BROADCASTER_REDIS_URL",
         "BROADCASTER_REDIS_STREAM_KEY",
-        "BROADCASTER_REDIS_SNAPSHOT_KEY",
         "BROADCASTER_REDIS_BLOCK_MS",
         "BROADCASTER_REDIS_READ_COUNT",
         "BROADCASTER_REDIS_APPEND_RETRY_WINDOW_MS",
-        "BROADCASTER_REDIS_RETENTION_SECS",
         "BROADCASTER_REDIS_MAXLEN",
     ];
     const RFQ_CREDENTIAL_ENV_KEYS: [&str; 6] = [
@@ -894,10 +862,6 @@ mod tests {
             "BROADCASTER_REDIS_STREAM_KEY",
             "dsolver:broadcaster:test:8453:events",
         );
-        std::env::set_var(
-            "BROADCASTER_REDIS_SNAPSHOT_KEY",
-            "dsolver:broadcaster:test:8453:snapshot",
-        );
     }
 
     struct RedisConfigFailureCase {
@@ -910,10 +874,6 @@ mod tests {
         std::env::set_var(
             "BROADCASTER_REDIS_STREAM_KEY",
             "dsolver:broadcaster:test:8453:events",
-        );
-        std::env::set_var(
-            "BROADCASTER_REDIS_SNAPSHOT_KEY",
-            "dsolver:broadcaster:test:8453:snapshot",
         );
     }
 
@@ -937,17 +897,9 @@ mod tests {
         std::env::set_var("BROADCASTER_REDIS_URL", "redis://127.0.0.1:notaport/0");
     }
 
-    fn aliased_broadcaster_redis_keys() {
+    fn zero_broadcaster_redis_maxlen() {
         set_required_broadcaster_redis_env();
-        std::env::set_var(
-            "BROADCASTER_REDIS_SNAPSHOT_KEY",
-            "dsolver:broadcaster:test:8453:events",
-        );
-    }
-
-    fn zero_broadcaster_redis_retention() {
-        set_required_broadcaster_redis_env();
-        std::env::set_var("BROADCASTER_REDIS_RETENTION_SECS", "0");
+        std::env::set_var("BROADCASTER_REDIS_MAXLEN", "0");
     }
 
     fn clear_rfq_credential_env() {
@@ -962,7 +914,7 @@ mod tests {
         "HASHFLOW_FILENAME_CSV",
         "TOKEN_SNAPSHOT_TIMEOUT_MS",
         "TYCHO_API_KEY",
-        "TYCHO_BROADCASTER_WS_URL",
+        "TYCHO_BROADCASTER_URL",
         "BEBOP_USER",
         "BEBOP_KEY",
         "HASHFLOW_USER",
@@ -1000,7 +952,7 @@ mod tests {
     }
 
     fn with_isolated_config_env<T>(
-        broadcaster_ws_url: Option<&str>,
+        broadcaster_base_url: Option<&str>,
         test: impl FnOnce() -> T,
     ) -> T {
         let _guard = ENV_MUTEX
@@ -1024,9 +976,9 @@ mod tests {
         std::env::remove_var("HASHFLOW_FILENAME_CSV");
         std::env::remove_var("TOKEN_SNAPSHOT_TIMEOUT_MS");
         clear_broadcaster_redis_env();
-        match broadcaster_ws_url {
-            Some(value) => std::env::set_var("TYCHO_BROADCASTER_WS_URL", value),
-            None => std::env::remove_var("TYCHO_BROADCASTER_WS_URL"),
+        match broadcaster_base_url {
+            Some(value) => std::env::set_var("TYCHO_BROADCASTER_URL", value),
+            None => std::env::remove_var("TYCHO_BROADCASTER_URL"),
         }
         std::env::set_current_dir(&isolated_dir)
             .unwrap_or_else(|_| unreachable!("expected isolated cwd switch to succeed"));
@@ -1045,8 +997,8 @@ mod tests {
         result
     }
 
-    fn load_config_panic_message(broadcaster_ws_url: Option<&str>) -> String {
-        with_isolated_config_env(broadcaster_ws_url, || {
+    fn load_config_panic_message(broadcaster_base_url: Option<&str>) -> String {
+        with_isolated_config_env(broadcaster_base_url, || {
             match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 let _ = load_config();
             })) {
@@ -1419,7 +1371,7 @@ route_policy = " default "
 
     #[test]
     fn load_config_allows_rfq_without_provider_credentials() {
-        let config = with_isolated_config_env(Some("ws://127.0.0.1:3001/ws"), || {
+        let config = with_isolated_config_env(Some("http://127.0.0.1:3001"), || {
             clear_rfq_credential_env();
             std::env::set_var("ENABLE_RFQ_POOLS", "true");
             load_config()
@@ -1637,7 +1589,7 @@ route_policy = " default "
     }
 
     #[test]
-    fn load_broadcaster_tuning_uses_phase_four_defaults() {
+    fn load_broadcaster_tuning_uses_current_defaults() {
         let _guard = ENV_MUTEX
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -1646,7 +1598,6 @@ route_policy = " default "
         let tuning = load_broadcaster_tuning();
 
         assert_eq!(tuning.snapshot_max_payload_bytes, 8_388_608);
-        assert_eq!(tuning.subscriber_buffer_capacity, 128);
         assert_eq!(tuning.heartbeat_interval_secs, 5);
         assert_eq!(tuning.token_min_quality, 0);
         assert_eq!(tuning.snapshot_session_ttl_secs, 300);
@@ -1659,7 +1610,6 @@ route_policy = " default "
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         clear_broadcaster_tuning_env();
         std::env::set_var("BROADCASTER_SNAPSHOT_MAX_PAYLOAD_BYTES", "64");
-        std::env::set_var("BROADCASTER_SUBSCRIBER_BUFFER_CAPACITY", "32");
         std::env::set_var("BROADCASTER_HEARTBEAT_INTERVAL_SECS", "9");
         std::env::set_var("BROADCASTER_TOKEN_MIN_QUALITY", "7");
         std::env::set_var("BROADCASTER_SNAPSHOT_SESSION_TTL_SECS", "45");
@@ -1667,7 +1617,6 @@ route_policy = " default "
         let tuning = load_broadcaster_tuning();
 
         assert_eq!(tuning.snapshot_max_payload_bytes, 64);
-        assert_eq!(tuning.subscriber_buffer_capacity, 32);
         assert_eq!(tuning.heartbeat_interval_secs, 9);
         assert_eq!(tuning.token_min_quality, 7);
         assert_eq!(tuning.snapshot_session_ttl_secs, 45);
@@ -1720,14 +1669,9 @@ route_policy = " default "
 
         assert_eq!(config.redis_url, "redis://127.0.0.1:6379/0");
         assert_eq!(config.stream_key, "dsolver:broadcaster:test:8453:events");
-        assert_eq!(
-            config.snapshot_key,
-            "dsolver:broadcaster:test:8453:snapshot"
-        );
         assert_eq!(config.block_ms, 5_000);
         assert_eq!(config.read_count, 128);
         assert_eq!(config.append_retry_window_ms, 5_000);
-        assert_eq!(config.retention_secs, 300);
         assert_eq!(config.maxlen, None);
     }
 
@@ -1738,7 +1682,6 @@ route_policy = " default "
             std::env::set_var("BROADCASTER_REDIS_BLOCK_MS", "2500");
             std::env::set_var("BROADCASTER_REDIS_READ_COUNT", "64");
             std::env::set_var("BROADCASTER_REDIS_APPEND_RETRY_WINDOW_MS", "7000");
-            std::env::set_var("BROADCASTER_REDIS_RETENTION_SECS", "600");
             std::env::set_var("BROADCASTER_REDIS_MAXLEN", "4096");
             load_broadcaster_redis_config()
         });
@@ -1746,8 +1689,18 @@ route_policy = " default "
         assert_eq!(config.block_ms, 2_500);
         assert_eq!(config.read_count, 64);
         assert_eq!(config.append_retry_window_ms, 7_000);
-        assert_eq!(config.retention_secs, 600);
         assert_eq!(config.maxlen, Some(4_096));
+    }
+
+    #[test]
+    fn load_broadcaster_redis_config_accepts_rediss_urls() {
+        let config = with_isolated_config_env(None, || {
+            set_required_broadcaster_redis_env();
+            std::env::set_var("BROADCASTER_REDIS_URL", "rediss://redis.internal:6380/0");
+            load_broadcaster_redis_config()
+        });
+
+        assert_eq!(config.redis_url, "rediss://redis.internal:6380/0");
     }
 
     #[test]
@@ -1756,9 +1709,8 @@ route_policy = " default "
             fs::write(
                 ".env",
                 [
-                    "BROADCASTER_REDIS_URL=rediss://redis.internal:6380/0",
+                    "BROADCASTER_REDIS_URL=redis://redis.internal:6380/0",
                     "BROADCASTER_REDIS_STREAM_KEY=dsolver:broadcaster:test:8453:events",
-                    "BROADCASTER_REDIS_SNAPSHOT_KEY=dsolver:broadcaster:test:8453:snapshot",
                     "BROADCASTER_REDIS_READ_COUNT=256",
                 ]
                 .join("\n"),
@@ -1768,16 +1720,12 @@ route_policy = " default "
             load_broadcaster_redis_config()
         });
 
-        assert_eq!(config.redis_url, "rediss://redis.internal:6380/0");
+        assert_eq!(config.redis_url, "redis://redis.internal:6380/0");
         assert_eq!(config.stream_key, "dsolver:broadcaster:test:8453:events");
-        assert_eq!(
-            config.snapshot_key,
-            "dsolver:broadcaster:test:8453:snapshot"
-        );
         assert_eq!(config.block_ms, 5_000);
         assert_eq!(config.read_count, 256);
         assert_eq!(config.append_retry_window_ms, 5_000);
-        assert_eq!(config.retention_secs, 300);
+        assert_eq!(config.maxlen, None);
     }
 
     #[test]
@@ -1809,14 +1757,9 @@ route_policy = " default "
                 expected: "BROADCASTER_REDIS_URL port must be a valid u16",
             },
             RedisConfigFailureCase {
-                name: "snapshot key alias",
-                setup: aliased_broadcaster_redis_keys,
-                expected: "BROADCASTER_REDIS_STREAM_KEY and BROADCASTER_REDIS_SNAPSHOT_KEY must be different",
-            },
-            RedisConfigFailureCase {
-                name: "zero retention",
-                setup: zero_broadcaster_redis_retention,
-                expected: "BROADCASTER_REDIS_RETENTION_SECS must be > 0",
+                name: "zero maxlen",
+                setup: zero_broadcaster_redis_maxlen,
+                expected: "BROADCASTER_REDIS_MAXLEN must be > 0",
             },
         ] {
             let message = broadcaster_redis_config_panic_message(case.setup);
@@ -1831,29 +1774,29 @@ route_policy = " default "
     }
 
     #[test]
-    fn load_config_fails_fast_when_tycho_broadcaster_ws_url_missing() {
+    fn load_config_fails_fast_when_tycho_broadcaster_url_missing() {
         let message = load_config_panic_message(None);
 
-        assert!(message.contains("TYCHO_BROADCASTER_WS_URL must be set"));
+        assert!(message.contains("TYCHO_BROADCASTER_URL must be set"));
     }
 
     #[test]
-    fn load_config_fails_fast_when_tycho_broadcaster_ws_url_blank() {
+    fn load_config_fails_fast_when_tycho_broadcaster_url_blank() {
         let message = load_config_panic_message(Some("   "));
 
-        assert!(message.contains("TYCHO_BROADCASTER_WS_URL must not be empty"));
+        assert!(message.contains("TYCHO_BROADCASTER_URL must not be empty"));
     }
 
     #[test]
     fn load_config_uses_token_snapshot_timeout_default() {
-        let config = with_isolated_config_env(Some("ws://127.0.0.1:3001/ws"), load_config);
+        let config = with_isolated_config_env(Some("http://127.0.0.1:3001"), load_config);
 
         assert_eq!(config.token_snapshot_timeout_ms, 125_000);
     }
 
     #[test]
     fn load_config_reads_token_snapshot_timeout_override() {
-        let config = with_isolated_config_env(Some("ws://127.0.0.1:3001/ws"), || {
+        let config = with_isolated_config_env(Some("http://127.0.0.1:3001"), || {
             std::env::set_var("TOKEN_SNAPSHOT_TIMEOUT_MS", "60000");
             load_config()
         });
@@ -1863,7 +1806,7 @@ route_policy = " default "
 
     #[test]
     fn load_config_rejects_zero_token_snapshot_timeout() {
-        let message = with_isolated_config_env(Some("ws://127.0.0.1:3001/ws"), || {
+        let message = with_isolated_config_env(Some("http://127.0.0.1:3001"), || {
             std::env::set_var("TOKEN_SNAPSHOT_TIMEOUT_MS", "0");
             match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 let _ = load_config();

--- a/crates/runtime/src/models/broadcaster_urls.rs
+++ b/crates/runtime/src/models/broadcaster_urls.rs
@@ -22,61 +22,33 @@ impl fmt::Display for BroadcasterUrlError {
 impl std::error::Error for BroadcasterUrlError {}
 
 pub fn derive_broadcaster_http_url(
-    ws_url: &str,
+    base_url: &str,
     relative_path: &str,
 ) -> Result<String, BroadcasterUrlError> {
-    let mut url = parse_broadcaster_ws_url(ws_url)?;
-    let scheme = match url.scheme() {
-        "ws" => "http",
-        "wss" => "https",
+    let mut url = parse_broadcaster_url(base_url)?;
+    match url.scheme() {
+        "http" | "https" => {}
         other => {
             return Err(BroadcasterUrlError::new(format!(
-                "TYCHO_BROADCASTER_WS_URL must use ws or wss, got {other}"
+                "TYCHO_BROADCASTER_URL must use http or https, got {other}"
             )))
         }
     };
-    let prefix = websocket_path_prefix(&url)?;
+    let prefix = broadcaster_path_prefix(&url);
     let http_path = prefixed_path(prefix, relative_path);
 
-    url.set_scheme(scheme)
-        .map_err(|_| BroadcasterUrlError::new("invalid broadcaster URL scheme"))?;
     url.set_path(&http_path);
     url.set_query(None);
     Ok(url.to_string())
 }
 
-pub fn derive_broadcaster_session_ws_url(
-    ws_url: &str,
-    session_id: u64,
-) -> Result<String, BroadcasterUrlError> {
-    let mut url = parse_broadcaster_ws_url(ws_url)?;
-    websocket_path_prefix(&url)?;
-    url.query_pairs_mut()
-        .clear()
-        .append_pair("sessionId", &session_id.to_string());
-    Ok(url.to_string())
-}
-
-pub fn derive_broadcaster_rfq_session_ws_url(
-    ws_url: &str,
-    session_id: u64,
-) -> Result<String, BroadcasterUrlError> {
-    let mut url = parse_broadcaster_ws_url(ws_url)?;
-    let prefix = websocket_path_prefix(&url)?;
-    let rfq_ws_path = prefixed_path(prefix, "rfq/ws");
-    url.set_path(&rfq_ws_path);
-    url.query_pairs_mut()
-        .clear()
-        .append_pair("sessionId", &session_id.to_string());
-    Ok(url.to_string())
-}
-
-fn parse_broadcaster_ws_url(ws_url: &str) -> Result<reqwest::Url, BroadcasterUrlError> {
-    reqwest::Url::parse(ws_url)
-        .map_err(|err| BroadcasterUrlError::new(format!("invalid TYCHO_BROADCASTER_WS_URL: {err}")))
+fn parse_broadcaster_url(base_url: &str) -> Result<reqwest::Url, BroadcasterUrlError> {
+    reqwest::Url::parse(base_url)
+        .map_err(|err| BroadcasterUrlError::new(format!("invalid TYCHO_BROADCASTER_URL: {err}")))
 }
 
 fn prefixed_path(prefix: &str, relative_path: &str) -> String {
+    let relative_path = relative_path.trim_start_matches('/');
     if prefix.is_empty() {
         format!("/{relative_path}")
     } else {
@@ -84,30 +56,28 @@ fn prefixed_path(prefix: &str, relative_path: &str) -> String {
     }
 }
 
-fn websocket_path_prefix(url: &reqwest::Url) -> Result<&str, BroadcasterUrlError> {
-    url.path()
-        .strip_suffix("/ws")
-        .ok_or_else(|| BroadcasterUrlError::new("TYCHO_BROADCASTER_WS_URL must end with /ws"))
+fn broadcaster_path_prefix(url: &reqwest::Url) -> &str {
+    match url.path().trim_end_matches('/') {
+        "" => "",
+        path => path,
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use anyhow::Result;
 
-    use super::{
-        derive_broadcaster_http_url, derive_broadcaster_rfq_session_ws_url,
-        derive_broadcaster_session_ws_url,
-    };
+    use super::derive_broadcaster_http_url;
 
     #[test]
-    fn derives_http_url_from_broadcaster_websocket_url() -> Result<()> {
+    fn derives_http_url_from_broadcaster_base_url() -> Result<()> {
         assert_eq!(
-            derive_broadcaster_http_url("ws://127.0.0.1:3001/ws", "snapshot-sessions")?,
+            derive_broadcaster_http_url("http://127.0.0.1:3001", "snapshot-sessions")?,
             "http://127.0.0.1:3001/snapshot-sessions"
         );
         assert_eq!(
             derive_broadcaster_http_url(
-                "wss://broadcaster.example/prod/base/ws",
+                "https://broadcaster.example/prod/base",
                 "snapshot-sessions/7/payloads/2"
             )?,
             "https://broadcaster.example/prod/base/snapshot-sessions/7/payloads/2"
@@ -116,48 +86,21 @@ mod tests {
     }
 
     #[test]
-    fn derives_session_websocket_url_from_broadcaster_websocket_url() -> Result<()> {
-        assert_eq!(
-            derive_broadcaster_session_ws_url("ws://127.0.0.1:3001/ws", 42)?,
-            "ws://127.0.0.1:3001/ws?sessionId=42"
-        );
-        assert_eq!(
-            derive_broadcaster_session_ws_url("wss://broadcaster.example/prod/base/ws", 9)?,
-            "wss://broadcaster.example/prod/base/ws?sessionId=9"
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn derives_rfq_session_websocket_url_from_broadcaster_websocket_url() -> Result<()> {
-        assert_eq!(
-            derive_broadcaster_rfq_session_ws_url("ws://127.0.0.1:3001/ws", 42)?,
-            "ws://127.0.0.1:3001/rfq/ws?sessionId=42"
-        );
-        assert_eq!(
-            derive_broadcaster_rfq_session_ws_url("wss://broadcaster.example/prod/base/ws", 9)?,
-            "wss://broadcaster.example/prod/base/rfq/ws?sessionId=9"
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn rejects_non_websocket_url() {
-        let Err(error) =
-            derive_broadcaster_http_url("http://127.0.0.1:3001/ws", "snapshot-sessions")
+    fn rejects_non_http_url() {
+        let Err(error) = derive_broadcaster_http_url("ws://127.0.0.1:3001/ws", "snapshot-sessions")
         else {
-            unreachable!("non-websocket URL should fail");
+            unreachable!("non-http URL should fail");
         };
 
-        assert!(error.to_string().contains("must use ws or wss"));
+        assert!(error.to_string().contains("must use http or https"));
     }
 
     #[test]
-    fn rejects_urls_without_ws_suffix() {
-        let Err(error) = derive_broadcaster_session_ws_url("ws://127.0.0.1:3001/socket", 1) else {
-            unreachable!("non-/ws URL should fail");
-        };
-
-        assert!(error.to_string().contains("must end with /ws"));
+    fn trims_base_url_trailing_slash() -> Result<()> {
+        assert_eq!(
+            derive_broadcaster_http_url("http://127.0.0.1:3001/prod/base/", "/tokens/lookup")?,
+            "http://127.0.0.1:3001/prod/base/tokens/lookup"
+        );
+        Ok(())
     }
 }

--- a/crates/runtime/src/models/state.rs
+++ b/crates/runtime/src/models/state.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
+use simulator_core::broadcaster::BroadcasterRedisReplayBoundary;
 use tokio::sync::{watch, OwnedRwLockReadGuard, RwLock};
 use tokio::time::Instant;
 use tycho_simulation::{
@@ -87,6 +88,10 @@ struct BroadcasterSubscriptionStatusData {
     bootstrap_complete: bool,
     stream_id: Option<String>,
     snapshot_id: Option<String>,
+    redis_replay_boundary: Option<BroadcasterRedisReplayBoundary>,
+    redis_catch_up_cursor: Option<String>,
+    redis_replay_caught_up: bool,
+    redis_gap_reason: Option<String>,
     restart_count: u64,
     last_error: Option<String>,
 }
@@ -97,6 +102,10 @@ pub struct BroadcasterSubscriptionSnapshot {
     pub bootstrap_complete: bool,
     pub stream_id: Option<String>,
     pub snapshot_id: Option<String>,
+    pub redis_replay_boundary: Option<BroadcasterRedisReplayBoundary>,
+    pub redis_catch_up_cursor: Option<String>,
+    pub redis_replay_caught_up: bool,
+    pub redis_gap_reason: Option<String>,
     pub restart_count: u64,
     pub last_error: Option<String>,
 }
@@ -108,6 +117,10 @@ impl BroadcasterSubscriptionStatus {
         guard.bootstrap_complete = false;
         guard.stream_id = None;
         guard.snapshot_id = None;
+        guard.redis_replay_boundary = None;
+        guard.redis_catch_up_cursor = None;
+        guard.redis_replay_caught_up = false;
+        guard.redis_gap_reason = None;
         guard.last_error = None;
     }
 
@@ -121,21 +134,56 @@ impl BroadcasterSubscriptionStatus {
         guard.bootstrap_complete = false;
         guard.stream_id = Some(stream_id.into());
         guard.snapshot_id = Some(snapshot_id.into());
+        guard.redis_replay_boundary = None;
+        guard.redis_catch_up_cursor = None;
+        guard.redis_replay_caught_up = false;
+        guard.redis_gap_reason = None;
         guard.last_error = None;
     }
 
-    pub async fn mark_bootstrap_complete(&self) {
+    pub async fn mark_bootstrap_complete_with_redis_boundary(
+        &self,
+        boundary: BroadcasterRedisReplayBoundary,
+    ) {
         let mut guard = self.inner.write().await;
         guard.connected = true;
         guard.bootstrap_complete = true;
+        guard.redis_catch_up_cursor = Some(boundary.exclusive_entry_id());
+        guard.redis_replay_boundary = Some(boundary);
+        guard.redis_replay_caught_up = false;
+        guard.redis_gap_reason = None;
         guard.last_error = None;
+    }
+
+    pub async fn mark_redis_replay_cursor(&self, cursor: impl Into<String>) {
+        let mut guard = self.inner.write().await;
+        guard.redis_catch_up_cursor = Some(cursor.into());
+        guard.redis_gap_reason = None;
+    }
+
+    pub async fn mark_redis_catch_up_cursor(&self, cursor: impl Into<String>) {
+        let mut guard = self.inner.write().await;
+        guard.redis_catch_up_cursor = Some(cursor.into());
+        guard.redis_replay_caught_up = true;
+        guard.redis_gap_reason = None;
+    }
+
+    pub async fn mark_redis_gap(&self, reason: impl Into<String>) {
+        let mut guard = self.inner.write().await;
+        guard.redis_replay_caught_up = false;
+        guard.redis_gap_reason = Some(reason.into());
     }
 
     pub async fn mark_disconnected(&self, last_error: Option<String>) {
         let mut guard = self.inner.write().await;
         guard.connected = false;
         guard.bootstrap_complete = false;
+        guard.stream_id = None;
         guard.snapshot_id = None;
+        guard.redis_replay_boundary = None;
+        guard.redis_catch_up_cursor = None;
+        guard.redis_replay_caught_up = false;
+        guard.redis_gap_reason = None;
         guard.restart_count = guard.restart_count.saturating_add(1);
         guard.last_error = last_error;
     }
@@ -147,6 +195,10 @@ impl BroadcasterSubscriptionStatus {
             bootstrap_complete: guard.bootstrap_complete,
             stream_id: guard.stream_id.clone(),
             snapshot_id: guard.snapshot_id.clone(),
+            redis_replay_boundary: guard.redis_replay_boundary.clone(),
+            redis_catch_up_cursor: guard.redis_catch_up_cursor.clone(),
+            redis_replay_caught_up: guard.redis_replay_caught_up,
+            redis_gap_reason: guard.redis_gap_reason.clone(),
             restart_count: guard.restart_count,
             last_error: guard.last_error.clone(),
         }
@@ -159,6 +211,10 @@ impl BroadcasterSubscriptionStatus {
                 bootstrap_complete: true,
                 stream_id: Some("stream-test".to_string()),
                 snapshot_id: Some("snapshot-test".to_string()),
+                redis_replay_boundary: None,
+                redis_catch_up_cursor: None,
+                redis_replay_caught_up: true,
+                redis_gap_reason: None,
                 restart_count: 0,
                 last_error: None,
             })),
@@ -285,6 +341,8 @@ pub enum SimulatorReadinessReason {
     DisabledByConfig,
     BroadcasterDisconnected,
     SnapshotBootstrapping,
+    RedisReplayCatchingUp,
+    RedisReplayGap,
     StateWarmingUp,
     Rebuilding,
     Stale,
@@ -296,6 +354,8 @@ impl SimulatorReadinessReason {
             Self::DisabledByConfig => "disabled_by_config",
             Self::BroadcasterDisconnected => "broadcaster_disconnected",
             Self::SnapshotBootstrapping => "snapshot_bootstrapping",
+            Self::RedisReplayCatchingUp => "redis_replay_catching_up",
+            Self::RedisReplayGap => "redis_replay_gap",
             Self::StateWarmingUp => "state_warming_up",
             Self::Rebuilding => "rebuilding",
             Self::Stale => "stale",
@@ -332,6 +392,10 @@ pub struct SimulatorBackendSubscriptionSnapshot {
     pub bootstrap_complete: bool,
     pub stream_id: Option<String>,
     pub snapshot_id: Option<String>,
+    pub redis_replay_boundary: Option<BroadcasterRedisReplayBoundary>,
+    pub redis_catch_up_cursor: Option<String>,
+    pub redis_replay_caught_up: bool,
+    pub redis_gap_reason: Option<String>,
     pub restart_count: u64,
     pub last_error: Option<String>,
 }
@@ -380,26 +444,21 @@ impl EncodeAvailability {
 impl AppState {
     async fn native_broadcaster_bootstrap_ready(&self) -> bool {
         let subscription = self.native_broadcaster_subscription.snapshot().await;
-        subscription.connected && subscription.bootstrap_complete
+        subscription_readiness_reason(&subscription).is_none()
     }
 
     async fn vm_broadcaster_bootstrap_ready(&self) -> bool {
         let subscription = self.vm_broadcaster_subscription.snapshot().await;
-        subscription.connected && subscription.bootstrap_complete
+        subscription_readiness_reason(&subscription).is_none()
     }
 
     async fn rfq_broadcaster_bootstrap_ready(&self) -> bool {
         let subscription = self.rfq_broadcaster_subscription.snapshot().await;
-        subscription.connected && subscription.bootstrap_complete
+        subscription_readiness_reason(&subscription).is_none()
     }
 
     pub async fn status_snapshot(&self) -> SimulatorStatusSnapshot {
         let native = self.native_status_snapshot().await;
-        let status = match native.readiness {
-            SimulatorBackendReadiness::Ready => SimulatorServiceStatus::Ready,
-            SimulatorBackendReadiness::Stale => SimulatorServiceStatus::Stale,
-            _ => SimulatorServiceStatus::WarmingUp,
-        };
         let mut backends = vec![native];
 
         if self.configured_backends.vm {
@@ -408,6 +467,7 @@ impl AppState {
         if self.configured_backends.rfq {
             backends.push(self.rfq_status_snapshot().await);
         }
+        let status = service_status_from_backends(&backends);
 
         SimulatorStatusSnapshot {
             status,
@@ -575,7 +635,31 @@ impl AppState {
     }
 
     pub async fn is_ready(&self) -> bool {
-        matches!(self.native_readiness().await, NativeReadiness::Ready)
+        if !matches!(self.native_readiness().await, NativeReadiness::Ready) {
+            return false;
+        }
+
+        if self.enable_vm_pools
+            && self
+                .vm_broadcaster_subscription
+                .snapshot()
+                .await
+                .redis_gap_reason
+                .is_some()
+        {
+            return false;
+        }
+        if self.enable_rfq_pools
+            && self
+                .rfq_broadcaster_subscription
+                .snapshot()
+                .await
+                .redis_gap_reason
+                .is_some()
+        {
+            return false;
+        }
+        true
     }
 
     pub fn readiness_stale_ms(&self) -> u64 {
@@ -853,12 +937,36 @@ fn is_update_stale(last_update_age_ms: Option<u64>, readiness_stale_ms: u64) -> 
 fn subscription_readiness_reason(
     subscription: &BroadcasterSubscriptionSnapshot,
 ) -> Option<SimulatorReadinessReason> {
-    if !subscription.connected {
+    if subscription.redis_gap_reason.is_some() {
+        Some(SimulatorReadinessReason::RedisReplayGap)
+    } else if !subscription.connected {
         Some(SimulatorReadinessReason::BroadcasterDisconnected)
     } else if !subscription.bootstrap_complete {
         Some(SimulatorReadinessReason::SnapshotBootstrapping)
+    } else if !subscription.redis_replay_caught_up {
+        Some(SimulatorReadinessReason::RedisReplayCatchingUp)
     } else {
         None
+    }
+}
+
+fn service_status_from_backends(
+    backends: &[SimulatorBackendStatusSnapshot],
+) -> SimulatorServiceStatus {
+    if backends.iter().any(|backend| {
+        backend.enabled && backend.reason == Some(SimulatorReadinessReason::RedisReplayGap)
+    }) {
+        return SimulatorServiceStatus::WarmingUp;
+    }
+
+    match backends
+        .first()
+        .map(|backend| backend.readiness)
+        .unwrap_or(SimulatorBackendReadiness::WarmingUp)
+    {
+        SimulatorBackendReadiness::Ready => SimulatorServiceStatus::Ready,
+        SimulatorBackendReadiness::Stale => SimulatorServiceStatus::Stale,
+        _ => SimulatorServiceStatus::WarmingUp,
     }
 }
 
@@ -869,6 +977,10 @@ impl From<BroadcasterSubscriptionSnapshot> for SimulatorBackendSubscriptionSnaps
             bootstrap_complete: snapshot.bootstrap_complete,
             stream_id: snapshot.stream_id,
             snapshot_id: snapshot.snapshot_id,
+            redis_replay_boundary: snapshot.redis_replay_boundary,
+            redis_catch_up_cursor: snapshot.redis_catch_up_cursor,
+            redis_replay_caught_up: snapshot.redis_replay_caught_up,
+            redis_gap_reason: snapshot.redis_gap_reason,
             restart_count: snapshot.restart_count,
             last_error: snapshot.last_error,
         }
@@ -1594,6 +1706,17 @@ mod tests {
         Update::new(1, states, new_pairs)
     }
 
+    fn replay_boundary(exclusive_message_seq: u64) -> BroadcasterRedisReplayBoundary {
+        BroadcasterRedisReplayBoundary::new(
+            "redis-stream",
+            "stream-2",
+            "snapshot-2",
+            1,
+            exclusive_message_seq,
+        )
+        .unwrap_or_else(|error| unreachable!("valid replay boundary: {error}"))
+    }
+
     struct TestAppStateStores {
         token_store: Arc<TokenStore>,
         native_state_store: Arc<StateStore>,
@@ -1675,6 +1798,82 @@ mod tests {
                 enable_rfq_pools,
             },
         )
+    }
+
+    async fn build_ready_state_with_vm_and_rfq() -> AppState {
+        let state = build_readiness_test_state(true, true).await;
+        state.native_stream_health.record_update(1).await;
+        state
+            .vm_state_store
+            .apply_update(mk_update(vec![(
+                "pool-vm".to_string(),
+                mk_component(
+                    38,
+                    "vm:curve",
+                    "curve_pool",
+                    vec![mk_token(39, "TKNA"), mk_token(40, "TKNB")],
+                ),
+                Box::new(DummySim),
+            )]))
+            .await;
+        state
+            .rfq_state_store
+            .apply_update(mk_update(vec![(
+                "pool-rfq".to_string(),
+                mk_component(
+                    41,
+                    "rfq:hashflow",
+                    "hashflow_pool",
+                    vec![mk_token(42, "TKNA"), mk_token(43, "TKNB")],
+                ),
+                Box::new(DummySim),
+            )]))
+            .await;
+        state.vm_stream_health.record_update(1).await;
+        state.rfq_stream_health.record_update(1).await;
+        state
+    }
+
+    async fn assert_service_readiness_fails_for_redis_gap(
+        backend: SimulatorBackendKind,
+        gap_reason: &'static str,
+    ) {
+        let state = build_ready_state_with_vm_and_rfq().await;
+        assert!(state.is_ready().await);
+        assert_eq!(
+            state.status_snapshot().await.status,
+            SimulatorServiceStatus::Ready
+        );
+
+        match backend {
+            SimulatorBackendKind::Vm => {
+                state
+                    .vm_broadcaster_subscription
+                    .mark_redis_gap(gap_reason)
+                    .await;
+            }
+            SimulatorBackendKind::Rfq => {
+                state
+                    .rfq_broadcaster_subscription
+                    .mark_redis_gap(gap_reason)
+                    .await;
+            }
+            SimulatorBackendKind::Native => {
+                state
+                    .native_broadcaster_subscription
+                    .mark_redis_gap(gap_reason)
+                    .await;
+            }
+        }
+
+        assert!(!state.is_ready().await);
+        let snapshot = state.status_snapshot().await;
+        let backend_snapshot = backend_snapshot(&snapshot, backend);
+        assert_eq!(snapshot.status, SimulatorServiceStatus::WarmingUp);
+        assert_eq!(
+            backend_snapshot.reason,
+            Some(SimulatorReadinessReason::RedisReplayGap)
+        );
     }
 
     #[tokio::test]
@@ -1852,10 +2051,136 @@ mod tests {
 
         state
             .native_broadcaster_subscription
-            .mark_bootstrap_complete()
+            .mark_bootstrap_complete_with_redis_boundary(replay_boundary(1))
+            .await;
+        state
+            .native_broadcaster_subscription
+            .mark_redis_catch_up_cursor("1-1")
             .await;
         assert!(state.is_ready().await);
         assert_eq!(state.native_readiness().await, NativeReadiness::Ready);
+    }
+
+    #[tokio::test]
+    async fn native_readiness_waits_for_redis_catch_up_after_replay_boundary() {
+        let state = build_readiness_test_state(false, false).await;
+        state.native_stream_health.record_update(1).await;
+        state
+            .native_broadcaster_subscription
+            .mark_snapshot_started("stream-2", "snapshot-2")
+            .await;
+        state
+            .native_broadcaster_subscription
+            .mark_bootstrap_complete_with_redis_boundary(replay_boundary(7))
+            .await;
+
+        assert!(!state.is_ready().await);
+        let snapshot = state.status_snapshot().await;
+        let native = backend_snapshot(&snapshot, SimulatorBackendKind::Native);
+        assert_eq!(native.readiness, SimulatorBackendReadiness::WarmingUp);
+        assert_eq!(
+            native.reason,
+            Some(SimulatorReadinessReason::RedisReplayCatchingUp)
+        );
+
+        state
+            .native_broadcaster_subscription
+            .mark_redis_catch_up_cursor("1-7")
+            .await;
+
+        assert!(state.is_ready().await);
+        assert_eq!(state.native_readiness().await, NativeReadiness::Ready);
+    }
+
+    #[tokio::test]
+    async fn native_readiness_surfaces_redis_replay_gap() {
+        let state = build_readiness_test_state(false, false).await;
+        state.native_stream_health.record_update(1).await;
+        state
+            .native_broadcaster_subscription
+            .mark_snapshot_started("stream-2", "snapshot-2")
+            .await;
+        state
+            .native_broadcaster_subscription
+            .mark_bootstrap_complete_with_redis_boundary(replay_boundary(7))
+            .await;
+        state
+            .native_broadcaster_subscription
+            .mark_disconnected(Some("Redis replay gap: expected message_seq 8".to_string()))
+            .await;
+        state
+            .native_broadcaster_subscription
+            .mark_redis_gap("Redis replay gap: expected message_seq 8")
+            .await;
+
+        assert!(!state.is_ready().await);
+        let snapshot = state.status_snapshot().await;
+        let native = backend_snapshot(&snapshot, SimulatorBackendKind::Native);
+        assert_eq!(native.readiness, SimulatorBackendReadiness::WarmingUp);
+        assert_eq!(
+            native.reason,
+            Some(SimulatorReadinessReason::RedisReplayGap)
+        );
+        assert_eq!(
+            native
+                .subscription
+                .as_ref()
+                .and_then(|subscription| subscription.redis_gap_reason.as_deref()),
+            Some("Redis replay gap: expected message_seq 8")
+        );
+    }
+
+    #[tokio::test]
+    async fn service_readiness_fails_when_enabled_backend_has_redis_replay_gap() {
+        assert_service_readiness_fails_for_redis_gap(
+            SimulatorBackendKind::Vm,
+            "VM Redis replay gap",
+        )
+        .await;
+        assert_service_readiness_fails_for_redis_gap(
+            SimulatorBackendKind::Rfq,
+            "RFQ Redis replay gap",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn native_readiness_clears_stale_redis_gap_on_plain_disconnect() {
+        let state = build_readiness_test_state(false, false).await;
+        state.native_stream_health.record_update(1).await;
+        state
+            .native_broadcaster_subscription
+            .mark_snapshot_started("stream-2", "snapshot-2")
+            .await;
+        state
+            .native_broadcaster_subscription
+            .mark_bootstrap_complete_with_redis_boundary(replay_boundary(7))
+            .await;
+        state
+            .native_broadcaster_subscription
+            .mark_redis_gap("Redis replay gap: expected message_seq 8")
+            .await;
+        state
+            .native_broadcaster_subscription
+            .mark_disconnected(Some("Redis connection failed".to_string()))
+            .await;
+
+        let snapshot = state.status_snapshot().await;
+        let native = backend_snapshot(&snapshot, SimulatorBackendKind::Native);
+        assert_eq!(
+            native.reason,
+            Some(SimulatorReadinessReason::BroadcasterDisconnected)
+        );
+        assert!(native
+            .subscription
+            .as_ref()
+            .and_then(|subscription| subscription.redis_gap_reason.as_deref())
+            .is_none());
+        assert!(native.subscription.is_some());
+        if let Some(subscription) = native.subscription.as_ref() {
+            assert!(subscription.stream_id.is_none());
+            assert!(subscription.redis_replay_boundary.is_none());
+        }
     }
 
     #[tokio::test]
@@ -2008,11 +2333,18 @@ mod tests {
 
         state
             .vm_broadcaster_subscription
-            .mark_bootstrap_complete()
+            .mark_bootstrap_complete_with_redis_boundary(replay_boundary(1))
             .await;
         state.vm_stream_health.record_update(1).await;
 
         assert_eq!(state.native_readiness().await, NativeReadiness::WarmingUp);
+        assert_eq!(state.vm_readiness().await, VmReadiness::WarmingUp);
+
+        state
+            .vm_broadcaster_subscription
+            .mark_redis_catch_up_cursor("1-1")
+            .await;
+
         assert_eq!(state.vm_readiness().await, VmReadiness::Ready);
         assert_eq!(
             state.encode_availability(false, true, false).await,
@@ -2057,8 +2389,13 @@ mod tests {
 
         state
             .rfq_broadcaster_subscription
-            .mark_bootstrap_complete()
+            .mark_bootstrap_complete_with_redis_boundary(replay_boundary(1))
             .await;
+        state
+            .rfq_broadcaster_subscription
+            .mark_redis_catch_up_cursor("1-1")
+            .await;
+
         assert_eq!(state.rfq_readiness().await, RfqReadiness::Ready);
     }
 

--- a/crates/runtime/src/models/tokens.rs
+++ b/crates/runtime/src/models/tokens.rs
@@ -454,16 +454,16 @@ fn map_fetch_error(
     }
 }
 
-pub fn derive_broadcaster_token_lookup_url(ws_url: &str) -> Result<String, TokenStoreError> {
-    derive_broadcaster_token_url(ws_url, "lookup")
+pub fn derive_broadcaster_token_lookup_url(base_url: &str) -> Result<String, TokenStoreError> {
+    derive_broadcaster_token_url(base_url, "lookup")
 }
 
-pub fn derive_broadcaster_token_snapshot_url(ws_url: &str) -> Result<String, TokenStoreError> {
-    derive_broadcaster_token_url(ws_url, "snapshot")
+pub fn derive_broadcaster_token_snapshot_url(base_url: &str) -> Result<String, TokenStoreError> {
+    derive_broadcaster_token_url(base_url, "snapshot")
 }
 
-fn derive_broadcaster_token_url(ws_url: &str, endpoint: &str) -> Result<String, TokenStoreError> {
-    derive_broadcaster_http_url(ws_url, &format!("tokens/{endpoint}"))
+fn derive_broadcaster_token_url(base_url: &str, endpoint: &str) -> Result<String, TokenStoreError> {
+    derive_broadcaster_http_url(base_url, &format!("tokens/{endpoint}"))
         .map_err(|error| TokenStoreError::RequestFailed(error.to_string()))
 }
 
@@ -672,41 +672,41 @@ mod tests {
     }
 
     #[test]
-    fn derives_token_lookup_url_from_broadcaster_websocket_url() -> Result<()> {
+    fn derives_token_lookup_url_from_broadcaster_base_url() -> Result<()> {
         assert_eq!(
-            derive_broadcaster_token_lookup_url("ws://127.0.0.1:3001/ws")?,
+            derive_broadcaster_token_lookup_url("http://127.0.0.1:3001")?,
             "http://127.0.0.1:3001/tokens/lookup"
         );
         assert_eq!(
-            derive_broadcaster_token_lookup_url("wss://broadcaster.example/ws")?,
+            derive_broadcaster_token_lookup_url("https://broadcaster.example")?,
             "https://broadcaster.example/tokens/lookup"
         );
         assert_eq!(
-            derive_broadcaster_token_lookup_url("wss://broadcaster.example/prod/base/ws")?,
+            derive_broadcaster_token_lookup_url("https://broadcaster.example/prod/base")?,
             "https://broadcaster.example/prod/base/tokens/lookup"
         );
         Ok(())
     }
 
     #[test]
-    fn derives_token_snapshot_url_from_broadcaster_websocket_url() -> Result<()> {
+    fn derives_token_snapshot_url_from_broadcaster_base_url() -> Result<()> {
         assert_eq!(
-            derive_broadcaster_token_snapshot_url("ws://127.0.0.1:3001/ws")?,
+            derive_broadcaster_token_snapshot_url("http://127.0.0.1:3001")?,
             "http://127.0.0.1:3001/tokens/snapshot"
         );
         assert_eq!(
-            derive_broadcaster_token_snapshot_url("wss://broadcaster.example/prod/base/ws")?,
+            derive_broadcaster_token_snapshot_url("https://broadcaster.example/prod/base")?,
             "https://broadcaster.example/prod/base/tokens/snapshot"
         );
         Ok(())
     }
 
     #[test]
-    fn derives_token_lookup_url_rejects_non_websocket_url() {
-        let Err(err) = derive_broadcaster_token_lookup_url("http://127.0.0.1:3001/ws") else {
-            unreachable!("non-websocket URL should fail");
+    fn derives_token_lookup_url_rejects_non_http_url() {
+        let Err(err) = derive_broadcaster_token_lookup_url("ws://127.0.0.1:3001/ws") else {
+            unreachable!("non-http URL should fail");
         };
 
-        assert!(err.to_string().contains("must use ws or wss"));
+        assert!(err.to_string().contains("must use http or https"));
     }
 }

--- a/crates/runtime/src/services/broadcaster_subscription.rs
+++ b/crates/runtime/src/services/broadcaster_subscription.rs
@@ -4,16 +4,14 @@ use std::collections::{
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use futures::StreamExt;
 use rand::Rng;
+use redis::streams::{StreamId, StreamInfoStreamReply, StreamReadOptions, StreamReadReply};
+use redis::AsyncCommands;
 use reqwest::{Client, StatusCode};
 use tokio::sync::{OwnedRwLockWriteGuard, RwLock};
-use tokio::time::{timeout, Instant};
-use tokio_tungstenite::{
-    connect_async,
-    tungstenite::{Error as WsError, Message},
-};
+use tokio::time::Instant;
 use tracing::{info, warn};
 use tycho_simulation::{
     evm::decoder::TychoStreamDecoder,
@@ -25,15 +23,14 @@ use tycho_simulation::{
 
 use simulator_core::broadcaster::{
     BroadcasterBackend, BroadcasterBackendHead, BroadcasterEnvelope, BroadcasterPayload,
-    BroadcasterProtocolMessage, BroadcasterSnapshotPartition, BroadcasterSnapshotSessionResponse,
+    BroadcasterProtocolMessage, BroadcasterRedisReplayBoundary, BroadcasterRedisStreamEntry,
+    BroadcasterSnapshotPartition, BroadcasterSnapshotSessionResponse, BroadcasterSnapshotStart,
     BroadcasterSubscriptionTracker, BroadcasterUpdatePartition,
 };
 
+use crate::config::BroadcasterRedisConfig;
 use crate::memory::maybe_purge_allocator;
-use crate::models::broadcaster_urls::{
-    derive_broadcaster_http_url, derive_broadcaster_rfq_session_ws_url,
-    derive_broadcaster_session_ws_url,
-};
+use crate::models::broadcaster_urls::derive_broadcaster_http_url;
 use crate::models::state::{BroadcasterSubscriptionStatus, StateStore, VmStreamStatus};
 use crate::models::stream_health::StreamHealth;
 use crate::models::tokens::TokenStore;
@@ -133,55 +130,64 @@ impl BroadcasterSubscriptionControls {
     }
 }
 
-pub async fn supervise_broadcaster_subscription(
-    ws_url: String,
+pub async fn supervise_broadcaster_redis_subscription(
+    broadcaster_url: String,
     expected_chain_id: u64,
+    redis_config: BroadcasterRedisConfig,
     cfg: StreamSupervisorConfig,
-    controls: BroadcasterSubscriptionControls,
+    controls: Vec<BroadcasterSubscriptionControls>,
 ) {
-    let mut backoff = cfg.restart_backoff_min;
-    let mut rebuild = None;
+    if controls.is_empty() {
+        warn!("Broadcaster Redis subscription supervisor has no enabled backends");
+        return;
+    }
+
     let client = Client::new();
+    let mut backoff = cfg.restart_backoff_min;
+    let mut rebuilds = empty_rebuilds(controls.len());
 
     loop {
-        let bootstrap = match prepare_broadcaster_subscription(
-            &client,
-            &ws_url,
-            expected_chain_id,
-            &cfg,
-            &controls,
-            rebuild,
-        )
-        .await
-        {
-            Ok(bootstrap) => bootstrap,
+        let reader = match TokioRedisStreamReader::connect(&redis_config.redis_url).await {
+            Ok(reader) => reader,
             Err(error) => {
-                (rebuild, backoff) = reset_subscription_after_error(
+                let message = format!("Failed to connect to broadcaster Redis: {error:#}");
+                (rebuilds, backoff) = reset_redis_subscription_after_error(
                     &controls,
                     &cfg,
                     backoff,
-                    error.rebuild,
-                    error.message,
-                    error.event,
-                    error.detail,
+                    rebuilds,
+                    message,
+                    false,
+                    (
+                        "broadcaster_redis_subscription_connect_failed",
+                        "Failed to connect to broadcaster Redis",
+                    ),
                 )
                 .await;
                 continue;
             }
         };
 
-        let stream = match connect_async(bootstrap.session_ws_url.as_str()).await {
-            Ok((stream, _response)) => stream,
+        let prepared = match prepare_broadcaster_redis_subscription(
+            &client,
+            &broadcaster_url,
+            expected_chain_id,
+            &cfg,
+            &controls,
+            rebuilds,
+        )
+        .await
+        {
+            Ok(prepared) => prepared,
             Err(error) => {
-                let message = format!("Failed to connect to broadcaster websocket: {error}");
-                (rebuild, backoff) = reset_subscription_after_error(
+                (rebuilds, backoff) = reset_redis_subscription_after_error(
                     &controls,
                     &cfg,
                     backoff,
-                    bootstrap.processor.rebuild,
-                    message,
-                    "broadcaster_subscription_connect_failed",
-                    "Failed to connect to broadcaster subscription",
+                    error.rebuilds,
+                    error.message,
+                    false,
+                    (error.event, error.detail),
                 )
                 .await;
                 continue;
@@ -189,176 +195,828 @@ pub async fn supervise_broadcaster_subscription(
         };
 
         info!(
-            ws_url = bootstrap.session_ws_url,
-            session_id = bootstrap.session.session_id,
-            backend = controls.backend_label(),
-            "Connected to broadcaster subscription"
+            stream_key = prepared.replay_boundary.stream_key.as_str(),
+            stream_id = prepared.replay_boundary.stream_id.as_str(),
+            exclusive_entry_id = prepared.replay_boundary.exclusive_entry_id(),
+            "Connected to broadcaster Redis subscription"
         );
-        let (exit, next_rebuild) =
-            process_broadcaster_subscription(stream, bootstrap.processor, &cfg).await;
-        (rebuild, backoff) =
-            restart_after_subscription_exit(&controls, &cfg, backoff, exit, next_rebuild).await;
+
+        let (exit, next_rebuilds) =
+            process_broadcaster_redis_subscription(reader, prepared, &redis_config).await;
+        (rebuilds, backoff) = reset_redis_subscription_after_error(
+            &controls,
+            &cfg,
+            backoff,
+            next_rebuilds,
+            exit.message,
+            exit.redis_gap,
+            (
+                "broadcaster_redis_subscription_restart",
+                "Restarting broadcaster Redis subscription",
+            ),
+        )
+        .await;
     }
 }
 
-struct PreparedBroadcasterSubscription {
-    processor: BroadcasterSubscriptionProcessor,
-    session: BroadcasterSnapshotSessionResponse,
-    session_ws_url: String,
+fn empty_rebuilds(count: usize) -> Vec<Option<SubscriptionRebuildState>> {
+    std::iter::repeat_with(|| None).take(count).collect()
 }
 
-struct PrepareBroadcasterSubscriptionError {
+struct PreparedBroadcasterRedisSubscription {
+    processors: Vec<PreparedRedisProcessor>,
+    replay_boundary: BroadcasterRedisReplayBoundary,
+    required_catch_up_message_seq: u64,
+    expected_chain_id: u64,
+}
+
+struct PreparedRedisProcessor {
+    index: usize,
+    processor: BroadcasterSubscriptionProcessor,
+    replay_boundary: BroadcasterRedisReplayBoundary,
+}
+
+struct PrepareBroadcasterRedisSubscriptionError {
     message: String,
     event: &'static str,
     detail: &'static str,
-    rebuild: Option<SubscriptionRebuildState>,
+    rebuilds: Vec<Option<SubscriptionRebuildState>>,
 }
 
-impl PrepareBroadcasterSubscriptionError {
+impl PrepareBroadcasterRedisSubscriptionError {
     fn new(
         message: String,
         event: &'static str,
         detail: &'static str,
-        rebuild: Option<SubscriptionRebuildState>,
+        rebuilds: Vec<Option<SubscriptionRebuildState>>,
     ) -> Self {
         Self {
             message,
             event,
             detail,
-            rebuild,
+            rebuilds,
         }
     }
 }
 
-async fn prepare_broadcaster_subscription(
+async fn prepare_broadcaster_redis_subscription(
     client: &Client,
-    ws_url: &str,
+    broadcaster_url: &str,
     expected_chain_id: u64,
     cfg: &StreamSupervisorConfig,
-    controls: &BroadcasterSubscriptionControls,
-    rebuild: Option<SubscriptionRebuildState>,
-) -> std::result::Result<PreparedBroadcasterSubscription, PrepareBroadcasterSubscriptionError> {
-    let snapshot_sessions_url = match derive_broadcaster_http_url(
-        ws_url,
-        broadcaster_snapshot_sessions_path(controls.backend()),
-    ) {
-        Ok(url) => url,
-        Err(error) => {
-            return Err(PrepareBroadcasterSubscriptionError::new(
-                format!("Invalid broadcaster websocket URL: {error}"),
-                "broadcaster_subscription_url_invalid",
-                "Failed to derive broadcaster snapshot session URL",
-                rebuild,
-            ));
+    controls: &[BroadcasterSubscriptionControls],
+    mut rebuilds: Vec<Option<SubscriptionRebuildState>>,
+) -> std::result::Result<
+    PreparedBroadcasterRedisSubscription,
+    PrepareBroadcasterRedisSubscriptionError,
+> {
+    let mut processors = Vec::with_capacity(controls.len());
+    let mut last_backend_error = None;
+
+    for (index, controls) in controls.iter().enumerate() {
+        let snapshot_sessions_url = match derive_broadcaster_http_url(
+            broadcaster_url,
+            broadcaster_snapshot_sessions_path(controls.backend()),
+        ) {
+            Ok(url) => url,
+            Err(error) => {
+                return Err(PrepareBroadcasterRedisSubscriptionError::new(
+                    format!("Invalid broadcaster URL: {error}"),
+                    "broadcaster_redis_subscription_url_invalid",
+                    "Failed to derive broadcaster snapshot session URL",
+                    rebuilds,
+                ));
+            }
+        };
+        let decoder = match build_broadcaster_subscription_decoder(
+            controls.tokens(),
+            controls.backend(),
+            controls.protocols(),
+        )
+        .await
+        {
+            Ok(decoder) => decoder,
+            Err(error) => {
+                let message = error.to_string();
+                last_backend_error = Some(message.clone());
+                let rebuild = rebuilds.get_mut(index).and_then(Option::take);
+                rebuilds[index] = handle_subscription_reset(controls, Some(message), rebuild).await;
+                continue;
+            }
+        };
+        let rebuild = rebuilds.get_mut(index).and_then(Option::take);
+        let mut processor = BroadcasterSubscriptionProcessor::with_decoder(
+            expected_chain_id,
+            controls.clone(),
+            decoder,
+            rebuild,
+        );
+        let session = match bootstrap_broadcaster_snapshot(
+            client,
+            broadcaster_url,
+            &snapshot_sessions_url,
+            &mut processor,
+            controls,
+            cfg,
+        )
+        .await
+        {
+            Ok(session) => session,
+            Err(error) => {
+                let message = error.to_string();
+                last_backend_error = Some(message.clone());
+                rebuilds[index] =
+                    handle_subscription_reset(controls, Some(message), processor.rebuild).await;
+                continue;
+            }
+        };
+        if let Err(error) = processor.align_redis_replay_boundary(&session.redis_replay_boundary) {
+            let message = error.to_string();
+            last_backend_error = Some(message.clone());
+            rebuilds[index] =
+                handle_subscription_reset(controls, Some(message), processor.rebuild).await;
+            continue;
         }
-    };
-    let decoder = match build_broadcaster_subscription_decoder(
-        controls.tokens(),
-        controls.backend(),
-        controls.protocols(),
-    )
-    .await
-    {
-        Ok(decoder) => decoder,
-        Err(error) => {
-            return Err(PrepareBroadcasterSubscriptionError::new(
-                error.to_string(),
-                "broadcaster_subscription_decoder_failed",
-                "Failed to build broadcaster subscription decoder",
-                rebuild,
-            ));
-        }
-    };
-    let mut processor = BroadcasterSubscriptionProcessor::with_decoder(
+
+        processors.push(PreparedRedisProcessor {
+            index,
+            processor,
+            replay_boundary: session.redis_replay_boundary,
+        });
+    }
+
+    finish_prepared_broadcaster_redis_subscription(
+        processors,
+        rebuilds,
+        last_backend_error,
         expected_chain_id,
-        controls.clone(),
-        decoder,
-        rebuild,
-    );
-    let session = match bootstrap_broadcaster_snapshot(
-        client,
-        ws_url,
-        &snapshot_sessions_url,
-        &mut processor,
-        controls,
-        cfg,
     )
-    .await
-    {
-        Ok(session) => session,
-        Err(error) => {
-            return Err(PrepareBroadcasterSubscriptionError::new(
-                error.to_string(),
-                "broadcaster_subscription_bootstrap_failed",
-                "Failed to bootstrap broadcaster subscription from HTTP snapshot",
-                processor.rebuild,
-            ));
-        }
-    };
-    let session_ws_url = match derive_broadcaster_subscription_ws_url(
-        ws_url,
-        controls.backend(),
-        session.session_id,
+}
+
+fn finish_prepared_broadcaster_redis_subscription(
+    processors: Vec<PreparedRedisProcessor>,
+    rebuilds: Vec<Option<SubscriptionRebuildState>>,
+    last_backend_error: Option<String>,
+    expected_chain_id: u64,
+) -> std::result::Result<
+    PreparedBroadcasterRedisSubscription,
+    PrepareBroadcasterRedisSubscriptionError,
+> {
+    if let Some(message) = last_backend_error {
+        let rebuilds = merge_redis_processor_rebuilds(processors, rebuilds);
+        return Err(PrepareBroadcasterRedisSubscriptionError::new(
+            message,
+            "broadcaster_redis_subscription_bootstrap_failed",
+            "Failed to bootstrap broadcaster subscription from HTTP snapshot",
+            rebuilds,
+        ));
+    }
+
+    if processors.is_empty() {
+        return Err(PrepareBroadcasterRedisSubscriptionError::new(
+            "no broadcaster backends were prepared".to_string(),
+            "broadcaster_redis_subscription_bootstrap_failed",
+            "Failed to bootstrap broadcaster subscription from HTTP snapshot",
+            rebuilds,
+        ));
+    }
+
+    let required_catch_up_message_seq = processors
+        .iter()
+        .map(|processor| processor.replay_boundary.exclusive_message_seq)
+        .max()
+        .unwrap_or(0);
+    let replay_boundary = match coalesce_redis_replay_boundary(
+        processors
+            .iter()
+            .map(|processor| processor.replay_boundary.clone())
+            .collect(),
     ) {
-        Ok(url) => url,
+        Ok(replay_boundary) => replay_boundary,
         Err(error) => {
-            return Err(PrepareBroadcasterSubscriptionError::new(
-                format!("Invalid broadcaster websocket URL: {error}"),
-                "broadcaster_subscription_url_invalid",
-                "Failed to derive broadcaster session websocket URL",
-                processor.rebuild,
+            return Err(PrepareBroadcasterRedisSubscriptionError::new(
+                error.to_string(),
+                "broadcaster_redis_subscription_boundary_invalid",
+                "Failed to derive process Redis replay boundary",
+                merge_redis_processor_rebuilds(processors, rebuilds),
             ));
         }
     };
 
-    Ok(PreparedBroadcasterSubscription {
-        processor,
-        session,
-        session_ws_url,
+    Ok(PreparedBroadcasterRedisSubscription {
+        processors,
+        replay_boundary,
+        required_catch_up_message_seq,
+        expected_chain_id,
     })
 }
 
-async fn reset_subscription_after_error(
-    controls: &BroadcasterSubscriptionControls,
-    cfg: &StreamSupervisorConfig,
-    backoff: Duration,
-    rebuild: Option<SubscriptionRebuildState>,
-    message: String,
-    event: &'static str,
-    detail: &'static str,
-) -> (Option<SubscriptionRebuildState>, Duration) {
-    let rebuild = handle_subscription_reset(controls, Some(message.clone()), rebuild).await;
-    let backoff_ms = jittered_backoff_ms(backoff, cfg.restart_backoff_jitter_pct);
-    warn!(
-        event = event,
-        backend = controls.backend_label(),
-        backoff_ms,
-        error = %message,
-        "{detail}"
-    );
-    sleep_backoff(backoff_ms, cfg.memory).await;
-    (rebuild, next_backoff(backoff, cfg.restart_backoff_max))
+async fn process_broadcaster_redis_subscription(
+    reader: TokioRedisStreamReader,
+    mut prepared: PreparedBroadcasterRedisSubscription,
+    redis_config: &BroadcasterRedisConfig,
+) -> (SubscriptionExit, Vec<Option<SubscriptionRebuildState>>) {
+    let mut cursor =
+        RedisReplayCursor::new(prepared.replay_boundary.clone(), prepared.expected_chain_id);
+
+    loop {
+        let messages = match reader
+            .read_after(
+                &prepared.replay_boundary.stream_key,
+                cursor.cursor_entry_id(),
+                redis_config.block_ms,
+                redis_config.read_count,
+            )
+            .await
+        {
+            Ok(messages) => messages,
+            Err(error) => {
+                return (
+                    SubscriptionExit::error(format!(
+                        "failed to read broadcaster Redis stream: {error:#}"
+                    )),
+                    redis_processor_rebuilds(prepared.processors),
+                );
+            }
+        };
+
+        let caught_up_after_batch = messages.len() < redis_config.read_count as usize;
+        if messages.is_empty() {
+            if let Err(exit) = handle_empty_redis_poll(&reader, &cursor, &prepared).await {
+                return (exit, redis_processor_rebuilds(prepared.processors));
+            }
+            continue;
+        }
+
+        if let Err(exit) = apply_redis_message_batch(&mut prepared, &mut cursor, messages).await {
+            return (exit, redis_processor_rebuilds(prepared.processors));
+        }
+
+        if caught_up_after_batch {
+            if let Err(error) =
+                cursor.ensure_reached_required_boundary(prepared.required_catch_up_message_seq)
+            {
+                return (
+                    SubscriptionExit::redis_gap(error.to_string()),
+                    redis_processor_rebuilds(prepared.processors),
+                );
+            }
+            mark_redis_catch_up_cursors(&prepared.processors, cursor.cursor_entry_id()).await;
+        }
+    }
 }
 
-async fn restart_after_subscription_exit(
-    controls: &BroadcasterSubscriptionControls,
+async fn handle_empty_redis_poll(
+    reader: &TokioRedisStreamReader,
+    cursor: &RedisReplayCursor,
+    prepared: &PreparedBroadcasterRedisSubscription,
+) -> std::result::Result<(), SubscriptionExit> {
+    let stream_info = match reader
+        .stream_info(&prepared.replay_boundary.stream_key)
+        .await
+    {
+        Ok(stream_info) => stream_info,
+        Err(error) => {
+            return Err(SubscriptionExit::error(format!(
+                "failed to inspect broadcaster Redis stream: {error:#}"
+            )));
+        }
+    };
+
+    match redis_empty_poll_action(
+        cursor,
+        stream_info.as_ref(),
+        prepared.required_catch_up_message_seq,
+    ) {
+        Ok(RedisEmptyPollAction::CaughtUp) => {
+            mark_redis_catch_up_cursors(&prepared.processors, cursor.cursor_entry_id()).await;
+        }
+        Ok(RedisEmptyPollAction::Pending) => {}
+        Err(error) => return Err(SubscriptionExit::redis_gap(error.to_string())),
+    }
+    Ok(())
+}
+
+async fn apply_redis_message_batch(
+    prepared: &mut PreparedBroadcasterRedisSubscription,
+    cursor: &mut RedisReplayCursor,
+    messages: Vec<RedisStreamMessage>,
+) -> std::result::Result<(), SubscriptionExit> {
+    let mut last_applied_entry_id = None;
+    for message in messages {
+        if let Err(error) = cursor.ensure_next_message(&message) {
+            return Err(SubscriptionExit::redis_gap(error.to_string()));
+        }
+
+        let envelope: BroadcasterEnvelope = serde_json::from_str(&message.entry.payload_json)
+            .map_err(|error| {
+                SubscriptionExit::error(format!(
+                    "failed to decode broadcaster Redis payload: {error}"
+                ))
+            })?;
+
+        for prepared_processor in &mut prepared.processors {
+            if message.entry.message_seq <= prepared_processor.replay_boundary.exclusive_message_seq
+            {
+                continue;
+            }
+            prepared_processor
+                .processor
+                .observe_redis_delta(&message.entry, &envelope)
+                .await
+                .map_err(|error| SubscriptionExit::error(error.to_string()))?;
+        }
+
+        cursor.mark_applied(&message);
+        last_applied_entry_id = Some(message.entry_id);
+    }
+    if let Some(entry_id) = last_applied_entry_id {
+        mark_redis_replay_cursors(&prepared.processors, &entry_id, cursor.last_message_seq).await;
+    }
+    Ok(())
+}
+
+async fn mark_redis_replay_cursors(
+    processors: &[PreparedRedisProcessor],
+    entry_id: &str,
+    message_seq: u64,
+) {
+    for prepared in processors {
+        let cursor = if message_seq < prepared.replay_boundary.exclusive_message_seq {
+            prepared.replay_boundary.exclusive_entry_id()
+        } else {
+            entry_id.to_string()
+        };
+        prepared
+            .processor
+            .controls
+            .broadcaster_subscription()
+            .mark_redis_replay_cursor(cursor)
+            .await;
+    }
+}
+
+async fn mark_redis_catch_up_cursors(processors: &[PreparedRedisProcessor], cursor_entry_id: &str) {
+    for prepared in processors {
+        prepared
+            .processor
+            .controls
+            .broadcaster_subscription()
+            .mark_redis_catch_up_cursor(cursor_entry_id.to_string())
+            .await;
+    }
+}
+
+fn redis_processor_rebuilds(
+    processors: Vec<PreparedRedisProcessor>,
+) -> Vec<Option<SubscriptionRebuildState>> {
+    let mut rebuilds = empty_rebuilds(processors.len());
+    for prepared in processors {
+        rebuilds[prepared.index] = prepared.processor.rebuild;
+    }
+    rebuilds
+}
+
+fn merge_redis_processor_rebuilds(
+    processors: Vec<PreparedRedisProcessor>,
+    mut rebuilds: Vec<Option<SubscriptionRebuildState>>,
+) -> Vec<Option<SubscriptionRebuildState>> {
+    for prepared in processors {
+        rebuilds[prepared.index] = prepared.processor.rebuild;
+    }
+    rebuilds
+}
+
+async fn reset_redis_subscription_after_error(
+    controls: &[BroadcasterSubscriptionControls],
     cfg: &StreamSupervisorConfig,
     backoff: Duration,
-    exit: SubscriptionExit,
-    rebuild: Option<SubscriptionRebuildState>,
-) -> (Option<SubscriptionRebuildState>, Duration) {
-    let rebuild = handle_subscription_reset(controls, exit.last_error.clone(), rebuild).await;
+    rebuilds: Vec<Option<SubscriptionRebuildState>>,
+    message: String,
+    is_gap: bool,
+    (event, detail): (&'static str, &'static str),
+) -> (Vec<Option<SubscriptionRebuildState>>, Duration) {
+    let mut next_rebuilds = Vec::with_capacity(controls.len());
+    for (controls, rebuild) in controls.iter().zip(rebuilds) {
+        let rebuild = handle_subscription_reset(controls, Some(message.clone()), rebuild).await;
+        if is_gap {
+            controls
+                .broadcaster_subscription()
+                .mark_redis_gap(message.clone())
+                .await;
+        }
+        next_rebuilds.push(rebuild);
+    }
     let backoff_ms = jittered_backoff_ms(backoff, cfg.restart_backoff_jitter_pct);
     warn!(
-        event = "broadcaster_subscription_restart",
-        backend = controls.backend_label(),
-        reason = exit.reason,
+        event,
         backoff_ms,
-        last_error = exit.last_error.as_deref(),
-        "Restarting broadcaster subscription"
+        error = %message,
+        "{}", detail
     );
     sleep_backoff(backoff_ms, cfg.memory).await;
-    (rebuild, next_backoff(backoff, cfg.restart_backoff_max))
+    (
+        next_rebuilds,
+        next_backoff(backoff, cfg.restart_backoff_max),
+    )
+}
+
+struct TokioRedisStreamReader {
+    blocking_read_connection: redis::aio::ConnectionManager,
+    inspection_connection: redis::aio::ConnectionManager,
+}
+
+impl TokioRedisStreamReader {
+    async fn connect(redis_url: &str) -> Result<Self> {
+        let client = redis::Client::open(redis_url)
+            .context("failed to create Redis client from BROADCASTER_REDIS_URL")?;
+        // Keep blocking XREAD calls away from XINFO. If a blocking read times out locally, Redis
+        // can still hold that command on its socket until the BLOCK window expires.
+        let blocking_read_connection = client
+            .get_connection_manager()
+            .await
+            .context("failed to connect to broadcaster Redis read connection")?;
+        let inspection_connection = client
+            .get_connection_manager()
+            .await
+            .context("failed to connect to broadcaster Redis inspection connection")?;
+        Ok(Self {
+            blocking_read_connection,
+            inspection_connection,
+        })
+    }
+
+    async fn read_after(
+        &self,
+        stream_key: &str,
+        cursor_entry_id: &str,
+        block_ms: u64,
+        read_count: u64,
+    ) -> Result<Vec<RedisStreamMessage>> {
+        let options = StreamReadOptions::default()
+            .block(block_ms as usize)
+            .count(read_count as usize);
+        let mut connection = self.blocking_read_connection.clone();
+        let reply = connection
+            .xread_options(&[stream_key], &[cursor_entry_id], &options)
+            .await;
+        redis_xread_messages(stream_key, reply)
+    }
+
+    async fn stream_info(&self, stream_key: &str) -> Result<Option<RedisStreamInfo>> {
+        let mut connection = self.inspection_connection.clone();
+        let reply = redis::cmd("XINFO")
+            .arg("STREAM")
+            .arg(stream_key)
+            .query_async::<StreamInfoStreamReply>(&mut connection)
+            .await;
+        redis_stream_info(reply)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct RedisStreamMessage {
+    entry_id: String,
+    entry: BroadcasterRedisStreamEntry,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RedisStreamInfo {
+    last_generated_entry_id: String,
+    first_entry_id: Option<String>,
+    last_entry_id: Option<String>,
+}
+
+fn redis_stream_messages(
+    expected_stream_key: &str,
+    reply: StreamReadReply,
+) -> Result<Vec<RedisStreamMessage>> {
+    let mut messages = Vec::new();
+    for key in reply.keys {
+        if key.key != expected_stream_key {
+            return Err(anyhow!(
+                "Redis XREAD returned stream key {}, expected {}",
+                key.key,
+                expected_stream_key
+            ));
+        }
+        for stream_id in key.ids {
+            messages.push(redis_stream_message(stream_id)?);
+        }
+    }
+    Ok(messages)
+}
+
+fn redis_xread_messages(
+    expected_stream_key: &str,
+    reply: std::result::Result<Option<StreamReadReply>, redis::RedisError>,
+) -> Result<Vec<RedisStreamMessage>> {
+    match reply {
+        Ok(Some(reply)) => redis_stream_messages(expected_stream_key, reply),
+        Ok(None) => Ok(Vec::new()),
+        Err(error) if error.is_timeout() => Ok(Vec::new()),
+        Err(error) => Err(anyhow!(error).context("Redis XREAD failed")),
+    }
+}
+
+fn redis_stream_info(
+    reply: std::result::Result<StreamInfoStreamReply, redis::RedisError>,
+) -> Result<Option<RedisStreamInfo>> {
+    match reply {
+        Ok(reply) => redis_stream_info_from_reply(reply).map(Some),
+        Err(error) if redis_stream_missing_key(&error) => Ok(None),
+        Err(error) => Err(anyhow!(error).context("Redis XINFO STREAM failed")),
+    }
+}
+
+fn redis_stream_info_from_reply(reply: StreamInfoStreamReply) -> Result<RedisStreamInfo> {
+    let first_entry_id = redis_stream_info_entry_id(reply.length, reply.first_entry.id)?;
+    let last_entry_id = redis_stream_info_entry_id(reply.length, reply.last_entry.id)?;
+    Ok(RedisStreamInfo {
+        last_generated_entry_id: reply.last_generated_id,
+        first_entry_id,
+        last_entry_id,
+    })
+}
+
+fn redis_stream_info_entry_id(length: usize, entry_id: String) -> Result<Option<String>> {
+    match (length, entry_id.is_empty()) {
+        (0, _) => Ok(None),
+        (_, false) => Ok(Some(entry_id)),
+        (_, true) => Err(anyhow!("Redis XINFO STREAM omitted a retained entry id")),
+    }
+}
+
+fn redis_stream_missing_key(error: &redis::RedisError) -> bool {
+    error
+        .detail()
+        .is_some_and(|detail| detail.contains("no such key"))
+}
+
+fn redis_stream_message(stream_id: StreamId) -> Result<RedisStreamMessage> {
+    let entry_id = stream_id.id;
+    let mut value = serde_json::Map::new();
+    for (field, redis_value) in stream_id.map {
+        let field_value: String = redis::from_redis_value(redis_value)
+            .with_context(|| format!("Redis stream field {field} is not a string"))?;
+        value.insert(field, serde_json::Value::String(field_value));
+    }
+    let entry = serde_json::from_value(serde_json::Value::Object(value))
+        .context("failed to decode Redis stream entry")?;
+    Ok(RedisStreamMessage { entry_id, entry })
+}
+
+fn redis_entry_scope_contains(
+    entry: &BroadcasterRedisStreamEntry,
+    backend: BroadcasterBackend,
+) -> bool {
+    entry
+        .backend_scope
+        .split(',')
+        .any(|scope| scope == backend.as_str())
+}
+
+fn coalesce_redis_replay_boundary(
+    boundaries: Vec<BroadcasterRedisReplayBoundary>,
+) -> Result<BroadcasterRedisReplayBoundary> {
+    let mut boundaries = boundaries.into_iter();
+    let Some(mut earliest) = boundaries.next() else {
+        return Err(anyhow!("no Redis replay boundaries were captured"));
+    };
+
+    for boundary in boundaries {
+        ensure_same_redis_stream_boundary(&earliest, &boundary)?;
+        if boundary.exclusive_message_seq < earliest.exclusive_message_seq {
+            earliest = boundary;
+        }
+    }
+
+    Ok(earliest)
+}
+
+fn ensure_same_redis_stream_boundary(
+    left: &BroadcasterRedisReplayBoundary,
+    right: &BroadcasterRedisReplayBoundary,
+) -> Result<()> {
+    if left.stream_key != right.stream_key
+        || left.stream_id != right.stream_id
+        || left.snapshot_id != right.snapshot_id
+        || left.generation != right.generation
+    {
+        return Err(anyhow!(
+            "backend HTTP snapshots returned different Redis replay boundaries: left stream_id={} generation={} snapshot_id={}, right stream_id={} generation={} snapshot_id={}",
+            left.stream_id,
+            left.generation,
+            left.snapshot_id,
+            right.stream_id,
+            right.generation,
+            right.snapshot_id
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RedisEmptyPollAction {
+    CaughtUp,
+    Pending,
+}
+
+fn redis_empty_poll_action(
+    cursor: &RedisReplayCursor,
+    stream_info: Option<&RedisStreamInfo>,
+    required_message_seq: u64,
+) -> Result<RedisEmptyPollAction> {
+    cursor.ensure_reached_required_boundary(required_message_seq)?;
+    let Some(stream_info) = stream_info else {
+        if cursor.last_message_seq == 0 {
+            return Ok(RedisEmptyPollAction::CaughtUp);
+        }
+        return Err(anyhow!(
+            "Redis replay gap: stream disappeared after cursor {}",
+            cursor.cursor_entry_id
+        ));
+    };
+
+    let cursor_entry_id = parse_redis_entry_id(&cursor.cursor_entry_id)?;
+    let last_generated_entry_id = parse_redis_entry_id(&stream_info.last_generated_entry_id)?;
+    if last_generated_entry_id < cursor_entry_id {
+        return Err(anyhow!(
+            "Redis replay gap: stream moved backwards from cursor {} to last generated {}",
+            cursor.cursor_entry_id,
+            stream_info.last_generated_entry_id
+        ));
+    }
+    if last_generated_entry_id == cursor_entry_id {
+        return Ok(RedisEmptyPollAction::CaughtUp);
+    }
+
+    let expected_seq = cursor
+        .last_message_seq
+        .checked_add(1)
+        .ok_or_else(|| anyhow!("Redis replay message_seq overflow"))?;
+    let expected_entry_id = redis_entry_id(cursor.boundary.generation, expected_seq);
+    let expected_entry_id_parts = parse_redis_entry_id(&expected_entry_id)?;
+    let Some(first_entry_id) = &stream_info.first_entry_id else {
+        return Err(anyhow!(
+            "Redis replay gap: stream generated {} after cursor {} but retained no entries",
+            stream_info.last_generated_entry_id,
+            cursor.cursor_entry_id
+        ));
+    };
+    let Some(last_entry_id) = &stream_info.last_entry_id else {
+        return Err(anyhow!(
+            "Redis replay gap: stream generated {} after cursor {} but retained no last entry",
+            stream_info.last_generated_entry_id,
+            cursor.cursor_entry_id
+        ));
+    };
+
+    let first_entry_id_parts = parse_redis_entry_id(first_entry_id)?;
+    if first_entry_id_parts > expected_entry_id_parts {
+        return Err(anyhow!(
+            "Redis replay gap: first retained entry {} is after expected entry {}",
+            first_entry_id,
+            expected_entry_id
+        ));
+    }
+
+    let last_entry_id_parts = parse_redis_entry_id(last_entry_id)?;
+    if last_entry_id_parts <= cursor_entry_id {
+        return Err(anyhow!(
+            "Redis replay gap: stream generated {} after cursor {} but last retained entry is {}",
+            stream_info.last_generated_entry_id,
+            cursor.cursor_entry_id,
+            last_entry_id
+        ));
+    }
+
+    Ok(RedisEmptyPollAction::Pending)
+}
+
+struct RedisReplayCursor {
+    boundary: BroadcasterRedisReplayBoundary,
+    cursor_entry_id: String,
+    last_message_seq: u64,
+    expected_chain_id: u64,
+}
+
+impl RedisReplayCursor {
+    fn new(boundary: BroadcasterRedisReplayBoundary, expected_chain_id: u64) -> Self {
+        Self {
+            cursor_entry_id: boundary.exclusive_entry_id(),
+            last_message_seq: boundary.exclusive_message_seq,
+            boundary,
+            expected_chain_id,
+        }
+    }
+
+    fn cursor_entry_id(&self) -> &str {
+        &self.cursor_entry_id
+    }
+
+    fn ensure_next_message(&self, message: &RedisStreamMessage) -> Result<()> {
+        if message.entry.stream_id != self.boundary.stream_id {
+            return Err(anyhow!(
+                "Redis replay gap: expected stream_id {}, got {}",
+                self.boundary.stream_id,
+                message.entry.stream_id
+            ));
+        }
+        if message.entry.chain_id != self.expected_chain_id {
+            return Err(anyhow!(
+                "Redis replay gap: expected chain_id {}, got {}",
+                self.expected_chain_id,
+                message.entry.chain_id
+            ));
+        }
+
+        if message.entry.message_seq <= self.last_message_seq {
+            return Err(anyhow!(
+                "Redis replay gap: got stale message_seq {} after {} at {}",
+                message.entry.message_seq,
+                self.cursor_entry_id,
+                message.entry_id
+            ));
+        }
+
+        let expected_seq = self
+            .last_message_seq
+            .checked_add(1)
+            .ok_or_else(|| anyhow!("Redis replay message_seq overflow"))?;
+        if message.entry.message_seq != expected_seq {
+            return Err(anyhow!(
+                "Redis replay gap: expected message_seq {} after {}, got {} at {}",
+                expected_seq,
+                self.cursor_entry_id,
+                message.entry.message_seq,
+                message.entry_id
+            ));
+        }
+
+        let expected_entry_id = redis_entry_id(self.boundary.generation, expected_seq);
+        if message.entry_id != expected_entry_id {
+            return Err(anyhow!(
+                "Redis replay gap: expected entry id {}, got {}",
+                expected_entry_id,
+                message.entry_id
+            ));
+        }
+
+        if let Some(snapshot_id) = &message.entry.snapshot_id {
+            if snapshot_id != &self.boundary.snapshot_id {
+                return Err(anyhow!(
+                    "Redis replay gap: expected snapshot_id {}, got {}",
+                    self.boundary.snapshot_id,
+                    snapshot_id
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn ensure_reached_required_boundary(&self, required_message_seq: u64) -> Result<()> {
+        if self.last_message_seq >= required_message_seq {
+            return Ok(());
+        }
+
+        Err(anyhow!(
+            "Redis replay gap: stream ended at message_seq {} ({}) before required snapshot replay boundary {}",
+            self.last_message_seq,
+            self.cursor_entry_id,
+            required_message_seq
+        ))
+    }
+
+    fn mark_applied(&mut self, message: &RedisStreamMessage) {
+        self.cursor_entry_id = message.entry_id.clone();
+        self.last_message_seq = message.entry.message_seq;
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct RedisEntryIdParts {
+    millis: u64,
+    sequence: u64,
+}
+
+fn parse_redis_entry_id(entry_id: &str) -> Result<RedisEntryIdParts> {
+    let Some((millis, sequence)) = entry_id.split_once('-') else {
+        return Err(anyhow!("invalid Redis stream entry id: {entry_id}"));
+    };
+    Ok(RedisEntryIdParts {
+        millis: millis
+            .parse()
+            .with_context(|| format!("invalid Redis stream entry id: {entry_id}"))?,
+        sequence: sequence
+            .parse()
+            .with_context(|| format!("invalid Redis stream entry id: {entry_id}"))?,
+    })
+}
+
+fn redis_entry_id(generation: u64, message_seq: u64) -> String {
+    format!("{generation}-{message_seq}")
 }
 
 #[derive(Default)]
@@ -603,6 +1261,7 @@ struct BroadcasterSubscriptionProcessor {
     tracker: BroadcasterSubscriptionTracker,
     raw_snapshot: RawSnapshotReassembly,
     bootstrap_block: Option<u64>,
+    bootstrap_redis_replay_boundary: Option<BroadcasterRedisReplayBoundary>,
     rebuild: Option<SubscriptionRebuildState>,
 }
 
@@ -613,12 +1272,14 @@ impl BroadcasterSubscriptionProcessor {
         controls: BroadcasterSubscriptionControls,
         rebuild: Option<SubscriptionRebuildState>,
     ) -> Self {
-        Self::with_decoder(
+        let mut processor = Self::with_decoder(
             expected_chain_id,
             controls,
             Arc::new(TychoStreamDecoder::new()),
             rebuild,
-        )
+        );
+        processor.set_bootstrap_redis_replay_boundary(default_test_redis_replay_boundary());
+        processor
     }
 
     fn with_decoder(
@@ -634,8 +1295,13 @@ impl BroadcasterSubscriptionProcessor {
             tracker: BroadcasterSubscriptionTracker::new(),
             raw_snapshot: RawSnapshotReassembly::default(),
             bootstrap_block: None,
+            bootstrap_redis_replay_boundary: None,
             rebuild,
         }
+    }
+
+    fn set_bootstrap_redis_replay_boundary(&mut self, boundary: BroadcasterRedisReplayBoundary) {
+        self.bootstrap_redis_replay_boundary = Some(boundary);
     }
 
     fn bootstrap_complete(&self) -> bool {
@@ -645,9 +1311,19 @@ impl BroadcasterSubscriptionProcessor {
         )
     }
 
+    fn align_redis_replay_boundary(
+        &mut self,
+        boundary: &BroadcasterRedisReplayBoundary,
+    ) -> Result<()> {
+        self.tracker
+            .align_live_replay_boundary(boundary)
+            .map_err(|error| anyhow!("invalid broadcaster Redis replay boundary: {error}"))
+    }
+
     async fn observe(&mut self, envelope: BroadcasterEnvelope) -> Result<()> {
         if let BroadcasterPayload::SnapshotStart(start) = &envelope.payload {
             self.ensure_snapshot_chain_id(start.chain_id)?;
+            self.ensure_snapshot_includes_backend(start)?;
         }
 
         self.tracker
@@ -674,9 +1350,15 @@ impl BroadcasterSubscriptionProcessor {
             BroadcasterPayload::SnapshotEnd(_end) => {
                 self.apply_reassembled_snapshot_messages().await?;
                 self.refresh_bootstrap_health().await;
+                let boundary = self
+                    .bootstrap_redis_replay_boundary
+                    .clone()
+                    .ok_or_else(|| {
+                        anyhow!("HTTP snapshot completed without Redis replay boundary")
+                    })?;
                 self.controls
                     .broadcaster_subscription()
-                    .mark_bootstrap_complete()
+                    .mark_bootstrap_complete_with_redis_boundary(boundary)
                     .await;
                 self.finish_rebuild().await;
             }
@@ -694,9 +1376,35 @@ impl BroadcasterSubscriptionProcessor {
                     }
                 }
             }
-            BroadcasterPayload::Progress(_) => {}
+            BroadcasterPayload::Progress(_progress) => {}
         }
 
+        Ok(())
+    }
+
+    async fn observe_redis_delta(
+        &mut self,
+        entry: &BroadcasterRedisStreamEntry,
+        envelope: &BroadcasterEnvelope,
+    ) -> Result<()> {
+        if redis_entry_scope_contains(entry, self.controls.backend()) {
+            return self.observe(envelope.clone()).await;
+        }
+
+        self.tracker
+            .skip_live_delta(envelope)
+            .map_err(|error| anyhow!("invalid skipped broadcaster Redis envelope: {error}"))
+    }
+
+    fn ensure_snapshot_includes_backend(&self, start: &BroadcasterSnapshotStart) -> Result<()> {
+        let backend = self.controls.backend();
+        if !start.backends.contains(&backend) {
+            return Err(anyhow!(
+                "broadcaster snapshot start {} does not include {} backend",
+                start.snapshot_id,
+                backend
+            ));
+        }
         Ok(())
     }
 
@@ -847,9 +1555,23 @@ impl BroadcasterSubscriptionProcessor {
     }
 }
 
+#[cfg(test)]
+fn default_test_redis_replay_boundary() -> BroadcasterRedisReplayBoundary {
+    match BroadcasterRedisReplayBoundary::new(
+        "stream:test".to_string(),
+        "stream-1".to_string(),
+        "snapshot-1".to_string(),
+        1,
+        0,
+    ) {
+        Ok(boundary) => boundary,
+        Err(error) => unreachable!("test Redis replay boundary should be valid: {error}"),
+    }
+}
+
 async fn bootstrap_broadcaster_snapshot(
     client: &Client,
-    ws_url: &str,
+    broadcaster_url: &str,
     snapshot_sessions_url: &str,
     processor: &mut BroadcasterSubscriptionProcessor,
     controls: &BroadcasterSubscriptionControls,
@@ -858,6 +1580,7 @@ async fn bootstrap_broadcaster_snapshot(
     let session =
         create_broadcaster_snapshot_session(client, snapshot_sessions_url, cfg.readiness_stale)
             .await?;
+    processor.set_bootstrap_redis_replay_boundary(session.redis_replay_boundary.clone());
     controls.stream_health().mark_started().await;
 
     {
@@ -867,7 +1590,7 @@ async fn bootstrap_broadcaster_snapshot(
                 async move {
                     fetch_broadcaster_snapshot_payload(
                         client,
-                        ws_url,
+                        broadcaster_url,
                         controls.backend(),
                         &session,
                         index,
@@ -918,14 +1641,14 @@ async fn create_broadcaster_snapshot_session(
 
 async fn fetch_broadcaster_snapshot_payload(
     client: &Client,
-    ws_url: &str,
+    broadcaster_url: &str,
     backend: BroadcasterBackend,
     session: &BroadcasterSnapshotSessionResponse,
     index: u32,
     request_timeout: Duration,
 ) -> Result<BroadcasterEnvelope> {
     let payload_url = derive_broadcaster_http_url(
-        ws_url,
+        broadcaster_url,
         &broadcaster_snapshot_payload_path(backend, session.session_id, index),
     )
     .map_err(|error| anyhow!("failed to derive broadcaster snapshot payload URL: {error}"))?;
@@ -957,19 +1680,6 @@ fn broadcaster_snapshot_payload_path(
     )
 }
 
-fn derive_broadcaster_subscription_ws_url(
-    ws_url: &str,
-    backend: BroadcasterBackend,
-    session_id: u64,
-) -> std::result::Result<String, crate::models::broadcaster_urls::BroadcasterUrlError> {
-    match backend {
-        BroadcasterBackend::Rfq => derive_broadcaster_rfq_session_ws_url(ws_url, session_id),
-        BroadcasterBackend::Native | BroadcasterBackend::Vm => {
-            derive_broadcaster_session_ws_url(ws_url, session_id)
-        }
-    }
-}
-
 async fn decode_success_json<T>(
     response: reqwest::Response,
     url: &str,
@@ -992,77 +1702,6 @@ where
 
 fn http_status_error(operation: &str, url: &str, status: StatusCode) -> anyhow::Error {
     anyhow!("{operation} at {url} failed with HTTP {status}")
-}
-
-async fn process_broadcaster_subscription(
-    mut stream: impl futures::Stream<Item = Result<Message, WsError>> + Unpin,
-    mut processor: BroadcasterSubscriptionProcessor,
-    cfg: &StreamSupervisorConfig,
-) -> (SubscriptionExit, Option<SubscriptionRebuildState>) {
-    loop {
-        let next_timeout = if processor.bootstrap_complete() {
-            cfg.stream_stale
-        } else {
-            cfg.readiness_stale
-        };
-
-        let Ok(next_message) = timeout(next_timeout, stream.next()).await else {
-            let reason = if processor.bootstrap_complete() {
-                "live message timeout from broadcaster"
-            } else {
-                "bootstrap timeout from broadcaster"
-            };
-            return (SubscriptionExit::error(reason), processor.rebuild);
-        };
-
-        match next_message {
-            None => {
-                return (
-                    SubscriptionExit::error("broadcaster websocket ended"),
-                    processor.rebuild,
-                )
-            }
-            Some(Ok(Message::Text(text))) => {
-                let envelope: BroadcasterEnvelope = match serde_json::from_str(text.as_ref()) {
-                    Ok(envelope) => envelope,
-                    Err(error) => {
-                        return (
-                            SubscriptionExit::error(format!(
-                                "failed to decode broadcaster payload: {error}"
-                            )),
-                            processor.rebuild,
-                        )
-                    }
-                };
-
-                if let Err(error) = processor.observe(envelope).await {
-                    return (
-                        SubscriptionExit::error(error.to_string()),
-                        processor.rebuild,
-                    );
-                }
-            }
-            Some(Ok(Message::Binary(_))) => {
-                return (
-                    SubscriptionExit::error("unexpected binary broadcaster payload"),
-                    processor.rebuild,
-                );
-            }
-            Some(Ok(Message::Close(_))) => {
-                return (
-                    SubscriptionExit::error("broadcaster websocket closed"),
-                    processor.rebuild,
-                );
-            }
-            Some(Ok(_)) => {}
-            Some(Err(error)) => {
-                return (
-                    SubscriptionExit::error(error.to_string()),
-                    processor.rebuild,
-                )
-            }
-        }
-    }
 }
 
 async fn handle_subscription_reset(
@@ -1201,15 +1840,22 @@ fn jittered_backoff_ms(base: Duration, jitter_pct: f64) -> u64 {
 }
 
 struct SubscriptionExit {
-    reason: &'static str,
-    last_error: Option<String>,
+    message: String,
+    redis_gap: bool,
 }
 
 impl SubscriptionExit {
     fn error(message: impl Into<String>) -> Self {
         Self {
-            reason: "error",
-            last_error: Some(message.into()),
+            message: message.into(),
+            redis_gap: false,
+        }
+    }
+
+    fn redis_gap(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            redis_gap: true,
         }
     }
 }
@@ -1223,6 +1869,7 @@ mod tests {
 
     use anyhow::{anyhow, Result};
     use num_bigint::BigUint;
+    use redis::streams::{StreamKey, StreamReadReply};
     use reqwest::Client;
     use tokio::{
         io::{AsyncReadExt, AsyncWriteExt},
@@ -1254,9 +1901,13 @@ mod tests {
     };
 
     use super::{
-        bootstrap_broadcaster_snapshot, handle_subscription_reset, BroadcasterSubscriptionControls,
-        BroadcasterSubscriptionProcessor, NativeBroadcasterSubscriptionControls,
-        RawSnapshotReassembly, VmBroadcasterSubscriptionControls,
+        bootstrap_broadcaster_snapshot, coalesce_redis_replay_boundary, empty_rebuilds,
+        handle_subscription_reset, mark_redis_replay_cursors,
+        prepare_broadcaster_redis_subscription, redis_empty_poll_action, redis_xread_messages,
+        BroadcasterSubscriptionControls, BroadcasterSubscriptionProcessor,
+        NativeBroadcasterSubscriptionControls, PreparedRedisProcessor, RawSnapshotReassembly,
+        RedisEmptyPollAction, RedisReplayCursor, RedisStreamInfo, RedisStreamMessage,
+        VmBroadcasterSubscriptionControls,
     };
     use crate::config::MemoryConfig;
     use crate::models::state::{BroadcasterSubscriptionStatus, StateStore, VmStreamStatus};
@@ -1265,7 +1916,8 @@ mod tests {
     use crate::stream::StreamSupervisorConfig;
     use simulator_core::broadcaster::{
         BroadcasterBackend, BroadcasterBackendHead, BroadcasterEnvelope, BroadcasterHeartbeat,
-        BroadcasterPayload, BroadcasterProtocolMessage, BroadcasterSnapshotChunk,
+        BroadcasterPayload, BroadcasterProtocolMessage, BroadcasterProtocolSyncStatus,
+        BroadcasterRedisReplayBoundary, BroadcasterRedisStreamEntry, BroadcasterSnapshotChunk,
         BroadcasterSnapshotEnd, BroadcasterSnapshotPartition, BroadcasterSnapshotStart,
         BroadcasterStateDelta, BroadcasterStateEntry, BroadcasterUpdateMessage,
         BroadcasterUpdatePartition,
@@ -1433,6 +2085,404 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn redis_replay_boundary_for_process_uses_earliest_backend_boundary() -> Result<()> {
+        let boundary = coalesce_redis_replay_boundary(vec![
+            replay_boundary(5)?,
+            replay_boundary(3)?,
+            replay_boundary(7)?,
+        ])?;
+
+        assert_eq!(boundary.exclusive_message_seq, 3);
+        assert_eq!(boundary.exclusive_entry_id(), "1-3");
+        Ok(())
+    }
+
+    #[test]
+    fn redis_replay_boundary_rejects_mixed_generations() -> Result<()> {
+        let first = replay_boundary(3)?;
+        let second = BroadcasterRedisReplayBoundary::new(
+            "dsolver:broadcaster:test:events",
+            "stream-1",
+            "snapshot-1",
+            2,
+            4,
+        )?;
+
+        let Err(error) = coalesce_redis_replay_boundary(vec![first, second]) else {
+            return Err(anyhow!(
+                "mixed Redis replay generations must not be coalesced"
+            ));
+        };
+
+        assert!(error
+            .to_string()
+            .contains("different Redis replay boundaries"));
+        Ok(())
+    }
+
+    #[test]
+    fn redis_replay_cursor_detects_message_sequence_gap() -> Result<()> {
+        let cursor = RedisReplayCursor::new(replay_boundary(0)?, Chain::Ethereum.id());
+        let envelope = BroadcasterEnvelope::new(
+            "stream-1",
+            2,
+            BroadcasterPayload::Heartbeat(BroadcasterHeartbeat::new(
+                Chain::Ethereum.id(),
+                "snapshot-1",
+                vec![BroadcasterBackendHead::new(BroadcasterBackend::Native, 12)],
+            )?),
+        );
+        let entry = BroadcasterRedisStreamEntry::from_envelope(
+            Chain::Ethereum.id(),
+            1_710_000_000_123,
+            &envelope,
+        )?;
+
+        let Err(error) = cursor.ensure_next_message(&RedisStreamMessage {
+            entry_id: "1-2".to_string(),
+            entry,
+        }) else {
+            return Err(anyhow!(
+                "message_seq gap should fail before applying the delta"
+            ));
+        };
+
+        assert!(error.to_string().contains("Redis replay gap"));
+        Ok(())
+    }
+
+    #[test]
+    fn redis_replay_cursor_rejects_wrong_chain_id_before_applying_update() -> Result<()> {
+        let cursor = RedisReplayCursor::new(replay_boundary(0)?, Chain::Ethereum.id());
+        let envelope = BroadcasterEnvelope::new(
+            "stream-1",
+            1,
+            BroadcasterPayload::Update(BroadcasterUpdateMessage::new(vec![
+                BroadcasterUpdatePartition::new(
+                    BroadcasterBackend::Native,
+                    12,
+                    Vec::new(),
+                    Vec::new(),
+                    Vec::new(),
+                    BTreeMap::from([(
+                        "uniswap_v2".to_string(),
+                        BroadcasterProtocolSyncStatus::from_synchronizer_state(
+                            &SynchronizerState::Ready(raw_block_header(12, 1)),
+                        ),
+                    )]),
+                ),
+            ])?),
+        );
+        let entry = BroadcasterRedisStreamEntry::from_envelope(
+            Chain::Base.id(),
+            1_710_000_000_123,
+            &envelope,
+        )?;
+
+        let Err(error) = cursor.ensure_next_message(&RedisStreamMessage {
+            entry_id: "1-1".to_string(),
+            entry,
+        }) else {
+            return Err(anyhow!("wrong-chain Redis update should fail"));
+        };
+
+        assert!(error.to_string().contains("expected chain_id"));
+        Ok(())
+    }
+
+    #[test]
+    fn redis_replay_cursor_detects_generation_reset_before_duplicate_sequence() -> Result<()> {
+        let cursor = RedisReplayCursor::new(replay_boundary(18)?, Chain::Ethereum.id());
+        let envelope = BroadcasterEnvelope::new(
+            "stream-2",
+            1,
+            BroadcasterPayload::Heartbeat(BroadcasterHeartbeat::new(
+                Chain::Ethereum.id(),
+                "snapshot-2",
+                vec![BroadcasterBackendHead::new(BroadcasterBackend::Native, 12)],
+            )?),
+        );
+        let entry = BroadcasterRedisStreamEntry::from_envelope(
+            Chain::Ethereum.id(),
+            1_710_000_000_123,
+            &envelope,
+        )?;
+
+        let Err(error) = cursor.ensure_next_message(&RedisStreamMessage {
+            entry_id: "2-1".to_string(),
+            entry,
+        }) else {
+            return Err(anyhow!(
+                "new generation with a low message_seq should fail before being skipped"
+            ));
+        };
+
+        assert!(error.to_string().contains("Redis replay gap"));
+        Ok(())
+    }
+
+    #[test]
+    fn redis_replay_cursor_detects_empty_stream_before_latest_backend_boundary() -> Result<()> {
+        let cursor = RedisReplayCursor::new(replay_boundary(3)?, Chain::Ethereum.id());
+
+        let Err(error) = cursor.ensure_reached_required_boundary(7) else {
+            return Err(anyhow!(
+                "empty Redis poll before the newest backend boundary should fail closed"
+            ));
+        };
+
+        assert!(error.to_string().contains("Redis replay gap"));
+        assert!(error
+            .to_string()
+            .contains("required snapshot replay boundary 7"));
+        Ok(())
+    }
+
+    #[test]
+    fn empty_redis_poll_marks_caught_up_when_no_new_entry_was_generated() -> Result<()> {
+        let cursor = RedisReplayCursor::new(replay_boundary(3)?, Chain::Ethereum.id());
+        let stream_info = RedisStreamInfo {
+            last_generated_entry_id: "1-3".to_string(),
+            first_entry_id: Some("1-1".to_string()),
+            last_entry_id: Some("1-3".to_string()),
+        };
+
+        let action = redis_empty_poll_action(&cursor, Some(&stream_info), 3)?;
+
+        assert_eq!(action, RedisEmptyPollAction::CaughtUp);
+        Ok(())
+    }
+
+    #[test]
+    fn empty_redis_poll_detects_stream_recreation_behind_cursor() -> Result<()> {
+        let cursor = RedisReplayCursor::new(replay_boundary(9)?, Chain::Ethereum.id());
+        let stream_info = RedisStreamInfo {
+            last_generated_entry_id: "1-2".to_string(),
+            first_entry_id: Some("1-1".to_string()),
+            last_entry_id: Some("1-2".to_string()),
+        };
+
+        let Err(error) = redis_empty_poll_action(&cursor, Some(&stream_info), 9) else {
+            return Err(anyhow!(
+                "Redis stream recreation behind the cursor should fail closed"
+            ));
+        };
+
+        assert!(error.to_string().contains("Redis replay gap"));
+        assert!(error.to_string().contains("moved backwards"));
+        Ok(())
+    }
+
+    #[test]
+    fn empty_redis_poll_detects_fully_trimmed_generated_entries() -> Result<()> {
+        let cursor = RedisReplayCursor::new(replay_boundary(3)?, Chain::Ethereum.id());
+        let stream_info = RedisStreamInfo {
+            last_generated_entry_id: "1-5".to_string(),
+            first_entry_id: None,
+            last_entry_id: None,
+        };
+
+        let Err(error) = redis_empty_poll_action(&cursor, Some(&stream_info), 3) else {
+            return Err(anyhow!(
+                "trimmed Redis entries after the cursor should be a gap"
+            ));
+        };
+
+        assert!(error.to_string().contains("Redis replay gap"));
+        assert!(error.to_string().contains("retained no entries"));
+        Ok(())
+    }
+
+    #[test]
+    fn empty_redis_poll_detects_retention_gap_before_next_expected_entry() -> Result<()> {
+        let cursor = RedisReplayCursor::new(replay_boundary(3)?, Chain::Ethereum.id());
+        let stream_info = RedisStreamInfo {
+            last_generated_entry_id: "1-5".to_string(),
+            first_entry_id: Some("1-5".to_string()),
+            last_entry_id: Some("1-5".to_string()),
+        };
+
+        let Err(error) = redis_empty_poll_action(&cursor, Some(&stream_info), 3) else {
+            return Err(anyhow!(
+                "first retained Redis entry after the expected cursor should be a gap"
+            ));
+        };
+
+        assert!(error.to_string().contains("Redis replay gap"));
+        assert!(error.to_string().contains("first retained entry 1-5"));
+        Ok(())
+    }
+
+    #[test]
+    fn empty_redis_poll_waits_when_new_entry_arrives_after_timeout() -> Result<()> {
+        let cursor = RedisReplayCursor::new(replay_boundary(3)?, Chain::Ethereum.id());
+        let stream_info = RedisStreamInfo {
+            last_generated_entry_id: "1-4".to_string(),
+            first_entry_id: Some("1-4".to_string()),
+            last_entry_id: Some("1-4".to_string()),
+        };
+
+        let action = redis_empty_poll_action(&cursor, Some(&stream_info), 3)?;
+
+        assert_eq!(action, RedisEmptyPollAction::Pending);
+        Ok(())
+    }
+
+    #[test]
+    fn redis_xread_timeout_returns_empty_poll() -> Result<()> {
+        let timeout: redis::RedisError = std::io::Error::from(std::io::ErrorKind::TimedOut).into();
+
+        let messages =
+            redis_xread_messages("stream", Err(timeout)).map_err(|error| anyhow!("{error:?}"))?;
+
+        assert!(messages.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn redis_xread_broken_pipe_includes_command_context() -> Result<()> {
+        let broken_pipe: redis::RedisError =
+            std::io::Error::from(std::io::ErrorKind::BrokenPipe).into();
+
+        let error = redis_xread_messages("stream", Err(broken_pipe))
+            .err()
+            .ok_or_else(|| anyhow!("broken pipe should fail"))?;
+
+        assert!(format!("{error:#}").contains("Redis XREAD failed"));
+        Ok(())
+    }
+
+    #[test]
+    fn redis_xread_malformed_reply_reports_stream_key_mismatch() -> Result<()> {
+        let reply = StreamReadReply {
+            keys: vec![StreamKey {
+                key: "other-stream".to_string(),
+                ids: Vec::new(),
+            }],
+        };
+
+        let error = redis_xread_messages("stream", Ok(Some(reply)))
+            .err()
+            .ok_or_else(|| anyhow!("malformed stream reply should fail"))?;
+
+        assert!(error.to_string().contains("expected stream"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn redis_replay_boundary_rebases_processor_after_http_snapshot() -> Result<()> {
+        let controls = TestControls::new();
+        let mut processor =
+            BroadcasterSubscriptionProcessor::new(Chain::Ethereum.id(), controls.native(), None);
+        bootstrap(&mut processor).await?;
+
+        processor.align_redis_replay_boundary(&replay_boundary(18)?)?;
+        processor.observe(heartbeat_envelope_at(19)?).await?;
+
+        let snapshot = controls.native_subscription.snapshot().await;
+        assert!(snapshot.redis_gap_reason.is_none());
+        assert_eq!(controls.native_state_store.current_block().await, 14);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn redis_replay_skips_foreign_backend_scope_without_sequence_gap() -> Result<()> {
+        let controls = TestControls::new();
+        let mut processor =
+            BroadcasterSubscriptionProcessor::new(Chain::Ethereum.id(), controls.native(), None);
+        bootstrap(&mut processor).await?;
+
+        let rfq_envelope = rfq_heartbeat_envelope_at(4)?;
+        let rfq_entry = redis_entry_for_scope(&rfq_envelope, "rfq");
+        processor
+            .observe_redis_delta(&rfq_entry, &rfq_envelope)
+            .await?;
+
+        processor.observe(heartbeat_envelope_at(5)?).await?;
+
+        assert_eq!(controls.native_state_store.current_block().await, 14);
+        assert_eq!(controls.native_state_store.total_states().await, 1);
+        assert_eq!(controls.rfq_state_store.total_states().await, 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn redis_replay_status_cursor_does_not_move_behind_backend_boundary() -> Result<()> {
+        let controls = TestControls::new();
+        let native_boundary = replay_boundary(3)?;
+        let vm_boundary = replay_boundary(7)?;
+        controls
+            .native_subscription
+            .mark_bootstrap_complete_with_redis_boundary(native_boundary.clone())
+            .await;
+        controls
+            .vm_subscription
+            .mark_bootstrap_complete_with_redis_boundary(vm_boundary.clone())
+            .await;
+        let processors = vec![
+            PreparedRedisProcessor {
+                index: 0,
+                processor: BroadcasterSubscriptionProcessor::new(
+                    Chain::Ethereum.id(),
+                    controls.native(),
+                    None,
+                ),
+                replay_boundary: native_boundary,
+            },
+            PreparedRedisProcessor {
+                index: 1,
+                processor: BroadcasterSubscriptionProcessor::new(
+                    Chain::Ethereum.id(),
+                    controls.vm(),
+                    None,
+                ),
+                replay_boundary: vm_boundary,
+            },
+        ];
+
+        mark_redis_replay_cursors(&processors, "1-5", 5).await;
+
+        assert_eq!(
+            controls
+                .native_subscription
+                .snapshot()
+                .await
+                .redis_catch_up_cursor
+                .as_deref(),
+            Some("1-5")
+        );
+        assert_eq!(
+            controls
+                .vm_subscription
+                .snapshot()
+                .await
+                .redis_catch_up_cursor
+                .as_deref(),
+            Some("1-7")
+        );
+        Ok(())
+    }
+
+    fn redis_entry_for_scope(
+        envelope: &BroadcasterEnvelope,
+        backend_scope: &str,
+    ) -> BroadcasterRedisStreamEntry {
+        BroadcasterRedisStreamEntry {
+            schema_version: "1".to_string(),
+            chain_id: Chain::Ethereum.id(),
+            stream_id: envelope.stream_id.clone(),
+            message_seq: envelope.message_seq,
+            kind: envelope.kind(),
+            snapshot_id: Some("snapshot-1".to_string()),
+            backend_scope: backend_scope.to_string(),
+            block_number: None,
+            observed_timestamp_ms: None,
+            event_time_ms: 1_710_000_000_123,
+            payload_json: String::new(),
+        }
+    }
+
     fn native_component() -> ProtocolComponent {
         ProtocolComponent::new(
             Bytes::from([1u8; 20]),
@@ -1447,6 +2497,17 @@ mod tests {
                 .unwrap_or_else(|| unreachable!("valid timestamp"))
                 .naive_utc(),
         )
+    }
+
+    fn replay_boundary(exclusive_message_seq: u64) -> Result<BroadcasterRedisReplayBoundary> {
+        BroadcasterRedisReplayBoundary::new(
+            "dsolver:broadcaster:test:events",
+            "stream-1",
+            "snapshot-1",
+            1,
+            exclusive_message_seq,
+        )
+        .map_err(Into::into)
     }
 
     fn vm_component() -> ProtocolComponent {
@@ -1621,9 +2682,13 @@ mod tests {
     }
 
     fn update_envelope() -> Result<BroadcasterEnvelope> {
+        update_envelope_at(4)
+    }
+
+    fn update_envelope_at(message_seq: u64) -> Result<BroadcasterEnvelope> {
         Ok(BroadcasterEnvelope::new(
             "stream-1",
-            4,
+            message_seq,
             BroadcasterPayload::Update(BroadcasterUpdateMessage::new(vec![
                 BroadcasterUpdatePartition::new(
                     BroadcasterBackend::Native,
@@ -1689,9 +2754,13 @@ mod tests {
     }
 
     fn heartbeat_envelope() -> Result<BroadcasterEnvelope> {
+        heartbeat_envelope_at(4)
+    }
+
+    fn heartbeat_envelope_at(message_seq: u64) -> Result<BroadcasterEnvelope> {
         Ok(BroadcasterEnvelope::new(
             "stream-1",
-            4,
+            message_seq,
             BroadcasterPayload::Heartbeat(BroadcasterHeartbeat::new(
                 1,
                 "snapshot-1",
@@ -1699,6 +2768,18 @@ mod tests {
                     BroadcasterBackendHead::new(BroadcasterBackend::Native, 14),
                     BroadcasterBackendHead::new(BroadcasterBackend::Vm, 15),
                 ],
+            )?),
+        ))
+    }
+
+    fn rfq_heartbeat_envelope_at(message_seq: u64) -> Result<BroadcasterEnvelope> {
+        Ok(BroadcasterEnvelope::new(
+            "stream-1",
+            message_seq,
+            BroadcasterPayload::Heartbeat(BroadcasterHeartbeat::new(
+                1,
+                "snapshot-1",
+                vec![BroadcasterBackendHead::new(BroadcasterBackend::Rfq, 21)],
             )?),
         ))
     }
@@ -1782,7 +2863,7 @@ mod tests {
         });
 
         Ok((
-            format!("ws://{addr}/ws"),
+            format!("http://{addr}"),
             format!("http://{addr}/snapshot-sessions"),
             server_task,
         ))
@@ -1809,6 +2890,13 @@ mod tests {
                         .iter()
                         .filter(|payload| payload.contains("\"kind\":\"snapshot_chunk\""))
                         .count(),
+                    "redisReplayBoundary": {
+                        "streamKey": "dsolver:broadcaster:test:1:events",
+                        "streamId": "stream-1",
+                        "snapshotId": "snapshot-1",
+                        "generation": 1,
+                        "exclusiveMessageSeq": 0
+                    },
                     "expiresInMs": 300000
                 })
                 .to_string(),
@@ -2197,12 +3285,12 @@ mod tests {
             empty_snapshot_chunk_envelope()?,
             snapshot_end_envelope(),
         ];
-        let (ws_url, snapshot_sessions_url, server_task) =
+        let (broadcaster_url, snapshot_sessions_url, server_task) =
             spawn_snapshot_session_server(payloads).await?;
 
         let session = bootstrap_broadcaster_snapshot(
             &Client::new(),
-            &ws_url,
+            &broadcaster_url,
             &snapshot_sessions_url,
             &mut processor,
             &native_controls,
@@ -2225,6 +3313,54 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn prepare_redis_subscription_retries_all_backends_when_snapshot_omits_rfq_backend(
+    ) -> Result<()> {
+        let controls = TestControls::new();
+        let native_controls = controls.native();
+        let rfq_controls = controls.rfq();
+        let payloads = vec![
+            snapshot_start_envelope()?,
+            empty_snapshot_chunk_envelope()?,
+            snapshot_end_envelope(),
+        ];
+        let (broadcaster_url, _snapshot_sessions_url, server_task) =
+            spawn_snapshot_session_server(payloads).await?;
+
+        let Err(error) = prepare_broadcaster_redis_subscription(
+            &Client::new(),
+            &broadcaster_url,
+            Chain::Ethereum.id(),
+            &test_supervisor_config(),
+            &[native_controls, rfq_controls],
+            empty_rebuilds(2),
+        )
+        .await
+        else {
+            return Err(anyhow!(
+                "RFQ snapshot omission should abort this supervisor iteration"
+            ));
+        };
+        server_task.abort();
+
+        assert!(
+            error.message.contains("does not include rfq backend"),
+            "unexpected error: {}",
+            error.message
+        );
+        assert_eq!(error.rebuilds.len(), 2);
+        let rfq = controls.rfq_subscription.snapshot().await;
+        assert!(!rfq.bootstrap_complete);
+        assert!(
+            rfq.last_error
+                .as_deref()
+                .is_some_and(|error| error.contains("does not include rfq backend")),
+            "unexpected RFQ error: {:?}",
+            rfq.last_error
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn raw_snapshot_bootstrap_buffers_split_messages_until_snapshot_end() -> Result<()> {
         let controls = TestControls::new();
         let vm_controls = controls.vm();
@@ -2234,6 +3370,7 @@ mod tests {
             raw_decoder(),
             None,
         );
+        processor.set_bootstrap_redis_replay_boundary(super::default_test_redis_replay_boundary());
         let header = raw_block_header(21, 9);
         let sync_state = SynchronizerState::Ready(header.clone());
 
@@ -2351,12 +3488,12 @@ mod tests {
             )?,
             snapshot_end_envelope_at(3),
         ];
-        let (ws_url, snapshot_sessions_url, server_task) =
+        let (broadcaster_url, snapshot_sessions_url, server_task) =
             spawn_snapshot_session_server(payloads).await?;
 
         let session = bootstrap_broadcaster_snapshot(
             &Client::new(),
-            &ws_url,
+            &broadcaster_url,
             &snapshot_sessions_url,
             &mut processor,
             &vm_controls,

--- a/crates/runtime/src/services/quotes.rs
+++ b/crates/runtime/src/services/quotes.rs
@@ -2563,6 +2563,8 @@ mod tests {
     };
     use tycho_simulation::tycho_common::Bytes;
 
+    use simulator_core::broadcaster::BroadcasterRedisReplayBoundary;
+
     use crate::models::state::{
         BroadcasterSubscriptionStatus, ConfiguredBackends, StateStore, VmStreamStatus,
     };
@@ -3124,6 +3126,26 @@ mod tests {
         }
     }
 
+    async fn mark_broadcaster_subscription_redis_ready(
+        subscription: &BroadcasterSubscriptionStatus,
+    ) {
+        subscription
+            .mark_bootstrap_complete_with_redis_boundary(test_replay_boundary())
+            .await;
+        subscription.mark_redis_catch_up_cursor("1-1").await;
+    }
+
+    fn test_replay_boundary() -> BroadcasterRedisReplayBoundary {
+        BroadcasterRedisReplayBoundary::new(
+            "stream:test".to_string(),
+            "chain-1-stream-1".to_string(),
+            "chain-1-snapshot-1".to_string(),
+            1,
+            1,
+        )
+        .unwrap_or_else(|_| unreachable!("test replay boundary literals are valid"))
+    }
+
     fn make_test_state_stores(
         token_store: Arc<TokenStore>,
     ) -> (Arc<StateStore>, Arc<StateStore>, Arc<StateStore>) {
@@ -3520,10 +3542,7 @@ mod tests {
         ));
         assert_eq!(quote_calls.load(Ordering::SeqCst), 0);
 
-        app_state
-            .native_broadcaster_subscription
-            .mark_bootstrap_complete()
-            .await;
+        mark_broadcaster_subscription_redis_ready(&app_state.native_broadcaster_subscription).await;
 
         let ready = get_amounts_out(
             app_state,
@@ -3560,10 +3579,10 @@ mod tests {
         let bootstrap_state = app_state.clone();
         let bootstrap_task = tokio::spawn(async move {
             sleep(Duration::from_millis(60)).await;
-            bootstrap_state
-                .native_broadcaster_subscription
-                .mark_bootstrap_complete()
-                .await;
+            mark_broadcaster_subscription_redis_ready(
+                &bootstrap_state.native_broadcaster_subscription,
+            )
+            .await;
         });
 
         let ready = get_amounts_out(

--- a/crates/runtime/src/simulator_service.rs
+++ b/crates/runtime/src/simulator_service.rs
@@ -10,7 +10,10 @@ use tycho_simulation::tycho_common::{
     Bytes,
 };
 
-use crate::config::{init_logging, load_config, AppConfig, MemoryConfig};
+use crate::config::{
+    init_logging, load_broadcaster_redis_config, load_config, AppConfig, BroadcasterRedisConfig,
+    MemoryConfig,
+};
 use crate::memory::maybe_log_memory_snapshot;
 use crate::models::state::{AppState, BroadcasterSubscriptionStatus, StateStore, VmStreamStatus};
 use crate::models::stream_health::StreamHealth;
@@ -18,7 +21,7 @@ use crate::models::tokens::{
     derive_broadcaster_token_lookup_url, derive_broadcaster_token_snapshot_url, TokenStore,
 };
 use crate::services::broadcaster_subscription::{
-    supervise_broadcaster_subscription, BroadcasterSubscriptionControls,
+    supervise_broadcaster_redis_subscription, BroadcasterSubscriptionControls,
     NativeBroadcasterSubscriptionControls, RfqBroadcasterSubscriptionControls,
     VmBroadcasterSubscriptionControls,
 };
@@ -80,9 +83,16 @@ pub async fn build_simulator_service() -> anyhow::Result<SimulatorServiceParts> 
     let stream_resources = create_stream_resources(Arc::clone(&tokens));
     let app_state = build_app_state(&config, Arc::clone(&tokens), &stream_resources);
     let supervisor_cfg = build_supervisor_config(&config);
+    let redis_config = load_broadcaster_redis_config();
 
     log_rebuild_config(&config);
-    spawn_broadcaster_subscription_task(&config, &supervisor_cfg, &stream_resources, &app_state);
+    spawn_broadcaster_subscription_task(
+        &config,
+        &redis_config,
+        &supervisor_cfg,
+        &stream_resources,
+        &app_state,
+    );
 
     Ok(SimulatorServiceParts {
         config,
@@ -132,9 +142,9 @@ fn spawn_memory_snapshot_task(memory_cfg: MemoryConfig) {
 
 async fn load_token_store(config: &AppConfig) -> anyhow::Result<Arc<TokenStore>> {
     let chain = config.chain_profile.chain;
-    let lookup_url = derive_broadcaster_token_lookup_url(&config.tycho_broadcaster_ws_url)
+    let lookup_url = derive_broadcaster_token_lookup_url(&config.tycho_broadcaster_url)
         .map_err(|error| anyhow::anyhow!("{error}"))?;
-    let snapshot_url = derive_broadcaster_token_snapshot_url(&config.tycho_broadcaster_ws_url)
+    let snapshot_url = derive_broadcaster_token_snapshot_url(&config.tycho_broadcaster_url)
         .map_err(|error| anyhow::anyhow!("{error}"))?;
     let fetch_timeout = Duration::from_millis(config.token_refresh_timeout_ms);
     let snapshot_timeout = Duration::from_millis(config.token_snapshot_timeout_ms);
@@ -410,19 +420,32 @@ fn log_rebuild_config(config: &AppConfig) {
 
 fn spawn_broadcaster_subscription_task(
     config: &AppConfig,
+    redis_config: &BroadcasterRedisConfig,
     supervisor_cfg: &StreamSupervisorConfig,
     resources: &StreamResources,
     app_state: &AppState,
 ) {
-    for backend in broadcaster_subscription_plan(app_state) {
-        spawn_broadcaster_subscription_backend(
-            backend,
-            config,
-            supervisor_cfg,
-            resources,
-            app_state,
+    let controls = broadcaster_subscription_controls(config, resources, app_state);
+    let backend_count = controls.len();
+    let base_url = config.tycho_broadcaster_url.clone();
+    let expected_chain_id = config.chain_profile.chain.id();
+    let redis_config = redis_config.clone();
+    let supervisor_cfg = supervisor_cfg.clone();
+    tokio::spawn(async move {
+        info!(
+            backend_count,
+            "Starting broadcaster Redis subscription supervisor..."
         );
-    }
+        supervise_broadcaster_redis_subscription(
+            base_url,
+            expected_chain_id,
+            redis_config,
+            supervisor_cfg,
+            controls,
+        )
+        .await;
+    });
+    debug!("Broadcaster Redis subscription supervisor task spawned");
 }
 
 #[cfg(test)]
@@ -462,60 +485,58 @@ fn broadcaster_subscription_plan(app_state: &AppState) -> Vec<BroadcasterSubscri
     backends
 }
 
-fn spawn_broadcaster_subscription_backend(
-    backend: BroadcasterSubscriptionBackend,
+fn broadcaster_subscription_controls(
     config: &AppConfig,
-    supervisor_cfg: &StreamSupervisorConfig,
     resources: &StreamResources,
     app_state: &AppState,
-) {
+) -> Vec<BroadcasterSubscriptionControls> {
+    broadcaster_subscription_plan(app_state)
+        .into_iter()
+        .map(|backend| {
+            broadcaster_subscription_controls_for_backend(backend, config, resources, app_state)
+        })
+        .collect()
+}
+
+fn broadcaster_subscription_controls_for_backend(
+    backend: BroadcasterSubscriptionBackend,
+    config: &AppConfig,
+    resources: &StreamResources,
+    app_state: &AppState,
+) -> BroadcasterSubscriptionControls {
     match backend {
         BroadcasterSubscriptionBackend::Native => {
-            spawn_native_broadcaster_subscription_task(
-                config,
-                supervisor_cfg,
-                resources,
-                app_state,
-            );
+            native_broadcaster_subscription_controls(config, resources, app_state)
         }
         BroadcasterSubscriptionBackend::Vm => {
-            spawn_vm_broadcaster_subscription_task(config, supervisor_cfg, resources, app_state);
+            vm_broadcaster_subscription_controls(config, resources, app_state)
         }
         BroadcasterSubscriptionBackend::Rfq => {
-            spawn_rfq_broadcaster_subscription_task(config, supervisor_cfg, resources, app_state);
+            rfq_broadcaster_subscription_controls(config, resources, app_state)
         }
     }
 }
 
-fn spawn_native_broadcaster_subscription_task(
+fn native_broadcaster_subscription_controls(
     config: &AppConfig,
-    supervisor_cfg: &StreamSupervisorConfig,
     resources: &StreamResources,
     app_state: &AppState,
-) {
-    let controls = BroadcasterSubscriptionControls::Native(NativeBroadcasterSubscriptionControls {
+) -> BroadcasterSubscriptionControls {
+    BroadcasterSubscriptionControls::Native(NativeBroadcasterSubscriptionControls {
         broadcaster_subscription: app_state.native_broadcaster_subscription.clone(),
         state_store: Arc::clone(&resources.native_state_store),
         stream_health: Arc::clone(&resources.native_stream_health),
         tokens: Arc::clone(&app_state.tokens),
         protocols: config.chain_profile.native_protocols.clone(),
-    });
-    spawn_backend_broadcaster_subscription_task(
-        "native",
-        config.tycho_broadcaster_ws_url.clone(),
-        config.chain_profile.chain.id(),
-        supervisor_cfg.clone(),
-        controls,
-    );
+    })
 }
 
-fn spawn_vm_broadcaster_subscription_task(
+fn vm_broadcaster_subscription_controls(
     config: &AppConfig,
-    supervisor_cfg: &StreamSupervisorConfig,
     resources: &StreamResources,
     app_state: &AppState,
-) {
-    let controls = BroadcasterSubscriptionControls::Vm(VmBroadcasterSubscriptionControls {
+) -> BroadcasterSubscriptionControls {
+    BroadcasterSubscriptionControls::Vm(VmBroadcasterSubscriptionControls {
         broadcaster_subscription: app_state.vm_broadcaster_subscription.clone(),
         state_store: Arc::clone(&resources.vm_state_store),
         stream_health: Arc::clone(&resources.vm_stream_health),
@@ -523,52 +544,22 @@ fn spawn_vm_broadcaster_subscription_task(
         protocols: config.chain_profile.vm_protocols.clone(),
         vm_stream: Arc::clone(&resources.vm_stream),
         simulation_rebuild_gate: app_state.vm_simulation_rebuild_gate(),
-    });
-    spawn_backend_broadcaster_subscription_task(
-        "vm",
-        config.tycho_broadcaster_ws_url.clone(),
-        config.chain_profile.chain.id(),
-        supervisor_cfg.clone(),
-        controls,
-    );
+    })
 }
 
-fn spawn_rfq_broadcaster_subscription_task(
+fn rfq_broadcaster_subscription_controls(
     config: &AppConfig,
-    supervisor_cfg: &StreamSupervisorConfig,
     resources: &StreamResources,
     app_state: &AppState,
-) {
-    let controls = BroadcasterSubscriptionControls::Rfq(RfqBroadcasterSubscriptionControls {
+) -> BroadcasterSubscriptionControls {
+    BroadcasterSubscriptionControls::Rfq(RfqBroadcasterSubscriptionControls {
         broadcaster_subscription: app_state.rfq_broadcaster_subscription.clone(),
         state_store: Arc::clone(&resources.rfq_state_store),
         stream_health: Arc::clone(&resources.rfq_stream_health),
         tokens: Arc::clone(&app_state.tokens),
         protocols: config.chain_profile.rfq_protocols.clone(),
         simulation_rebuild_gate: app_state.rfq_simulation_rebuild_gate(),
-    });
-    spawn_backend_broadcaster_subscription_task(
-        "rfq",
-        config.tycho_broadcaster_ws_url.clone(),
-        config.chain_profile.chain.id(),
-        supervisor_cfg.clone(),
-        controls,
-    );
-}
-
-fn spawn_backend_broadcaster_subscription_task(
-    backend: &'static str,
-    ws_url: String,
-    expected_chain_id: u64,
-    supervisor_cfg: StreamSupervisorConfig,
-    controls: BroadcasterSubscriptionControls,
-) {
-    tokio::spawn(async move {
-        info!(backend, "Starting broadcaster subscription supervisor...");
-        supervise_broadcaster_subscription(ws_url, expected_chain_id, supervisor_cfg, controls)
-            .await;
-    });
-    debug!(backend, "Broadcaster subscription supervisor task spawned");
+    })
 }
 
 #[cfg(test)]
@@ -597,7 +588,7 @@ mod tests {
     };
 
     struct TokenAuthority {
-        ws_url: String,
+        base_url: String,
         lookup_hits: Arc<AtomicUsize>,
         snapshot_hits: Arc<AtomicUsize>,
         tycho_hits: Arc<AtomicUsize>,
@@ -639,7 +630,7 @@ mod tests {
             options: TokenAuthorityOptions,
         ) -> Result<Self> {
             let listener = TcpListener::bind("127.0.0.1:0").await?;
-            let ws_url = format!("ws://{}/ws", listener.local_addr()?);
+            let base_url = format!("http://{}", listener.local_addr()?);
             let lookup_hits = Arc::new(AtomicUsize::new(0));
             let snapshot_hits = Arc::new(AtomicUsize::new(0));
             let tycho_hits = Arc::new(AtomicUsize::new(0));
@@ -666,7 +657,7 @@ mod tests {
             });
 
             Ok(Self {
-                ws_url,
+                base_url,
                 lookup_hits,
                 snapshot_hits,
                 tycho_hits,
@@ -794,7 +785,7 @@ mod tests {
         AppConfig {
             chain_profile,
             tycho_url: "http://localhost:4242".to_string(),
-            tycho_broadcaster_ws_url: "ws://127.0.0.1:3001/ws".to_string(),
+            tycho_broadcaster_url: "http://127.0.0.1:3001".to_string(),
             bebop_url: "https://example.com/bebop".to_string(),
             hashflow_filename: "./hashflow.csv".to_string(),
             liquorice_url: Some("https://example.com/liquorice".to_string()),
@@ -894,12 +885,8 @@ mod tests {
         let authority =
             TokenAuthority::spawn(vec![test_token(&token_address, Chain::Ethereum)]).await?;
         let mut config = build_test_config(ethereum_chain_profile(), false, false, None);
-        config.tycho_url = authority
-            .ws_url
-            .replace("ws://", "http://")
-            .trim_end_matches("/ws")
-            .to_string();
-        config.tycho_broadcaster_ws_url = authority.ws_url.clone();
+        config.tycho_url = authority.base_url.clone();
+        config.tycho_broadcaster_url = authority.base_url.clone();
 
         let store = load_token_store(&config).await?;
         let resolved = store.ensure(&token_address).await?;
@@ -930,12 +917,8 @@ mod tests {
         let authority =
             TokenAuthority::spawn(vec![test_token(&cached_address, Chain::Ethereum)]).await?;
         let mut config = build_test_config(ethereum_chain_profile(), false, false, None);
-        config.tycho_url = authority
-            .ws_url
-            .replace("ws://", "http://")
-            .trim_end_matches("/ws")
-            .to_string();
-        config.tycho_broadcaster_ws_url = authority.ws_url.clone();
+        config.tycho_url = authority.base_url.clone();
+        config.tycho_broadcaster_url = authority.base_url.clone();
 
         let store = load_token_store(&config).await?;
         let resolved = store.ensure(&missed_address).await?;
@@ -967,7 +950,7 @@ mod tests {
         )
         .await?;
         let mut config = build_test_config(ethereum_chain_profile(), false, false, None);
-        config.tycho_broadcaster_ws_url = authority.ws_url.clone();
+        config.tycho_broadcaster_url = authority.base_url.clone();
         config.token_refresh_timeout_ms = 1;
         config.token_snapshot_timeout_ms = 500;
 
@@ -996,7 +979,7 @@ mod tests {
         )
         .await?;
         let mut config = build_test_config(ethereum_chain_profile(), false, false, None);
-        config.tycho_broadcaster_ws_url = authority.ws_url.clone();
+        config.tycho_broadcaster_url = authority.base_url.clone();
         config.token_snapshot_timeout_ms = 1_000;
 
         let store = load_token_store(&config).await?;
@@ -1023,7 +1006,7 @@ mod tests {
         )
         .await?;
         let mut config = build_test_config(ethereum_chain_profile(), false, false, None);
-        config.tycho_broadcaster_ws_url = authority.ws_url.clone();
+        config.tycho_broadcaster_url = authority.base_url.clone();
         config.token_snapshot_timeout_ms = 1_000;
 
         let store = load_token_store(&config).await?;
@@ -1050,7 +1033,7 @@ mod tests {
         )
         .await?;
         let mut config = build_test_config(ethereum_chain_profile(), false, false, None);
-        config.tycho_broadcaster_ws_url = authority.ws_url.clone();
+        config.tycho_broadcaster_url = authority.base_url.clone();
 
         let Err(error) = load_token_store(&config).await else {
             anyhow::bail!("chain mismatch should fail startup");
@@ -1073,7 +1056,7 @@ mod tests {
         )
         .await?;
         let mut config = build_test_config(ethereum_chain_profile(), false, false, None);
-        config.tycho_broadcaster_ws_url = authority.ws_url.clone();
+        config.tycho_broadcaster_url = authority.base_url.clone();
         config.token_snapshot_timeout_ms = 20;
 
         let Err(error) = load_token_store(&config).await else {

--- a/scripts/start_server.sh
+++ b/scripts/start_server.sh
@@ -66,13 +66,13 @@ read_metadata_value() {
 
 broadcaster_metadata_matches() {
   local metadata_file="$1"
-  local ws_url="$2"
+  local broadcaster_url="$2"
   local bind_host="$3"
   local bind_port="$4"
   local status_url="$5"
 
   [[ -f "$metadata_file" ]] \
-    && [[ "$(read_metadata_value "$metadata_file" "ws_url")" == "$ws_url" ]] \
+    && [[ "$(read_metadata_value "$metadata_file" "broadcaster_url")" == "$broadcaster_url" ]] \
     && [[ "$(read_metadata_value "$metadata_file" "bind_host")" == "$bind_host" ]] \
     && [[ "$(read_metadata_value "$metadata_file" "bind_port")" == "$bind_port" ]] \
     && [[ "$(read_metadata_value "$metadata_file" "status_url")" == "$status_url" ]]
@@ -80,13 +80,13 @@ broadcaster_metadata_matches() {
 
 write_broadcaster_metadata() {
   local metadata_file="$1"
-  local ws_url="$2"
+  local broadcaster_url="$2"
   local bind_host="$3"
   local bind_port="$4"
   local status_url="$5"
 
   {
-    printf 'ws_url=%s\n' "$ws_url"
+    printf 'broadcaster_url=%s\n' "$broadcaster_url"
     printf 'bind_host=%s\n' "$bind_host"
     printf 'bind_port=%s\n' "$bind_port"
     printf 'status_url=%s\n' "$status_url"
@@ -132,7 +132,7 @@ stop_broadcaster_pid() {
 }
 
 resolve_local_broadcaster() {
-  python3 - "$TYCHO_BROADCASTER_WS_URL" <<'PY'
+  python3 - "$TYCHO_BROADCASTER_URL" <<'PY'
 import sys
 from urllib.parse import urlparse
 
@@ -140,30 +140,30 @@ raw_url = sys.argv[1]
 url = urlparse(raw_url)
 scheme = url.scheme.lower()
 
-if scheme not in {"ws", "wss"}:
-    print("TYCHO_BROADCASTER_WS_URL must use ws:// or wss://", file=sys.stderr)
+if scheme not in {"http", "https"}:
+    print("TYCHO_BROADCASTER_URL must use http:// or https://", file=sys.stderr)
     raise SystemExit(2)
 
 host = url.hostname or ""
 local_hosts = {"localhost", "127.0.0.1", "::1"}
 
-if scheme != "ws" or host not in local_hosts:
+if scheme != "http" or host not in local_hosts:
     print("false\t\t\t")
     raise SystemExit(0)
 
 try:
     port = url.port
 except ValueError as error:
-    print(f"invalid TYCHO_BROADCASTER_WS_URL port: {error}", file=sys.stderr)
+    print(f"invalid TYCHO_BROADCASTER_URL port: {error}", file=sys.stderr)
     raise SystemExit(2)
 
 if port is None:
-    print("local TYCHO_BROADCASTER_WS_URL must include an explicit port", file=sys.stderr)
+    print("local TYCHO_BROADCASTER_URL must include an explicit port", file=sys.stderr)
     raise SystemExit(2)
 
-if url.path != "/ws":
+if url.path not in {"", "/"}:
     actual_path = url.path or "/"
-    print(f"local TYCHO_BROADCASTER_WS_URL must use /ws path, got {actual_path}", file=sys.stderr)
+    print(f"local TYCHO_BROADCASTER_URL must use the HTTP base path, got {actual_path}", file=sys.stderr)
     raise SystemExit(2)
 
 bind_host = "127.0.0.1" if host == "localhost" else host
@@ -179,7 +179,7 @@ start_broadcaster_if_local() {
   IFS=$'\t' read -r managed bind_host bind_port status_url < <(resolve_local_broadcaster)
 
   if [[ "$managed" != "true" ]]; then
-    echo "Broadcaster URL is not loopback ws://; assuming broadcaster is externally managed."
+    echo "Broadcaster URL is not loopback http://; assuming broadcaster is externally managed."
     return 0
   fi
 
@@ -194,8 +194,8 @@ start_broadcaster_if_local() {
     status_check="$(broadcaster_status_check "$status_url" "$CHAIN_ID")"
     read -r status_state status_code actual_chain <<<"$status_check"
     if [[ "$status_state" == "ok" ]]; then
-      if ! broadcaster_metadata_matches "$broadcaster_metadata_file" "$TYCHO_BROADCASTER_WS_URL" "$bind_host" "$bind_port" "$status_url"; then
-        write_broadcaster_metadata "$broadcaster_metadata_file" "$TYCHO_BROADCASTER_WS_URL" "$bind_host" "$bind_port" "$status_url"
+      if ! broadcaster_metadata_matches "$broadcaster_metadata_file" "$TYCHO_BROADCASTER_URL" "$bind_host" "$bind_port" "$status_url"; then
+        write_broadcaster_metadata "$broadcaster_metadata_file" "$TYCHO_BROADCASTER_URL" "$bind_host" "$bind_port" "$status_url"
       fi
       echo "Broadcaster service already running (pid $broadcaster_pid)."
       return 0
@@ -205,7 +205,7 @@ start_broadcaster_if_local() {
       return 1
     fi
 
-    if broadcaster_metadata_matches "$broadcaster_metadata_file" "$TYCHO_BROADCASTER_WS_URL" "$bind_host" "$bind_port" "$status_url"; then
+    if broadcaster_metadata_matches "$broadcaster_metadata_file" "$TYCHO_BROADCASTER_URL" "$bind_host" "$bind_port" "$status_url"; then
       echo "Broadcaster service already running (pid $broadcaster_pid)."
       wait_for_broadcaster_http "$status_url" "$broadcaster_pid_file" "$broadcaster_log_file"
       return 0
@@ -240,11 +240,11 @@ start_broadcaster_if_local() {
     HOST="$bind_host" PORT="$bind_port" nohup cargo run -p apps --bin dsolver-tycho-broadcaster-service --release > "$broadcaster_log_file" 2>&1 &
     echo $! > "$broadcaster_pid_file"
   )
-  write_broadcaster_metadata "$broadcaster_metadata_file" "$TYCHO_BROADCASTER_WS_URL" "$bind_host" "$bind_port" "$status_url"
+  write_broadcaster_metadata "$broadcaster_metadata_file" "$TYCHO_BROADCASTER_URL" "$bind_host" "$bind_port" "$status_url"
 
   echo "Started dsolver-tycho-broadcaster-service."
   echo "Broadcaster PID: $(cat "$broadcaster_pid_file")"
-  echo "Broadcaster URL: $TYCHO_BROADCASTER_WS_URL"
+  echo "Broadcaster URL: $TYCHO_BROADCASTER_URL"
   echo "Broadcaster log: $broadcaster_log_file"
 
   wait_for_broadcaster_http "$status_url" "$broadcaster_pid_file" "$broadcaster_log_file"
@@ -323,7 +323,7 @@ if (
     and isinstance(payload.get("chain_id"), int)
     and isinstance(payload.get("upstream"), dict)
     and isinstance(payload.get("snapshot"), dict)
-    and isinstance(payload.get("subscribers"), dict)
+    and isinstance(payload.get("snapshot_sessions"), dict)
     and isinstance(payload.get("backends"), dict)
 ):
     actual_chain_id = payload["chain_id"]
@@ -409,8 +409,8 @@ if [[ -n "$chain_id_arg" ]]; then
 fi
 
 if [[ "$simulator_already_running" == "true" ]]; then
-  if [[ -z "${TYCHO_BROADCASTER_WS_URL:-}" ]]; then
-    echo "TYCHO_BROADCASTER_WS_URL not set; skipping broadcaster startup for running simulator."
+  if [[ -z "${TYCHO_BROADCASTER_URL:-}" ]]; then
+    echo "TYCHO_BROADCASTER_URL not set; skipping broadcaster startup for running simulator."
   elif [[ -z "${CHAIN_ID:-}" ]]; then
     echo "Error: missing chain id. Pass --chain-id or set CHAIN_ID in env/.env." >&2
     exit 2
@@ -420,8 +420,8 @@ if [[ "$simulator_already_running" == "true" ]]; then
   exit 0
 fi
 
-if [[ -z "${TYCHO_BROADCASTER_WS_URL:-}" ]]; then
-  echo "Error: TYCHO_BROADCASTER_WS_URL is required for simulator startup." >&2
+if [[ -z "${TYCHO_BROADCASTER_URL:-}" ]]; then
+  echo "Error: TYCHO_BROADCASTER_URL is required for simulator startup." >&2
   exit 2
 fi
 
@@ -435,7 +435,7 @@ if [[ -z "$log_file" ]]; then
   log_file="$repo/logs/tycho-sim-server.log"
 fi
 
-if [[ -n "${TYCHO_BROADCASTER_WS_URL:-}" ]]; then
+if [[ -n "${TYCHO_BROADCASTER_URL:-}" ]]; then
   start_broadcaster_if_local
 fi
 

--- a/skills/simulation-service-analysis/SKILL.md
+++ b/skills/simulation-service-analysis/SKILL.md
@@ -10,8 +10,8 @@ metadata:
 ## Quick start
 
 1. Confirm the repo root (expect `Cargo.toml` and `crates/`).
-2. Ensure `.env` exists and contains `TYCHO_API_KEY` plus `TYCHO_BROADCASTER_WS_URL`.
-   The default loopback broadcaster URL lets the lifecycle helper start the broadcaster before the simulator.
+2. Ensure `.env` exists and contains `TYCHO_API_KEY`, `TYCHO_BROADCASTER_URL`, `BROADCASTER_REDIS_URL`, and `BROADCASTER_REDIS_STREAM_KEY`.
+   The default loopback broadcaster URL lets the lifecycle helper start the broadcaster before the simulator, while Redis carries deltas after each HTTP snapshot replay boundary.
    RFQ feeds default to off. For RFQ analysis, set `ENABLE_RFQ_POOLS=true`. Ethereum and Base currently need the Bebop and Hashflow credential pairs; Liquorice credentials are only needed after `rfq:liquorice` is added to an active chain profile.
 3. Pick a chain context for the run (`--chain-id 1` for Ethereum, `--chain-id 8453` for Base).
 4. Run the analyzer:
@@ -25,7 +25,7 @@ metadata:
 ## What the analyzer does
 
 - Reuses the existing local simulator if it is already responding, otherwise starts the local broadcaster plus simulator stack with the repo lifecycle scripts.
-- Starts `dsolver-tycho-broadcaster-service` first when `TYCHO_BROADCASTER_WS_URL` points at local loopback, then starts `dsolver-simulator-service`; non-local broadcaster URLs are treated as externally managed.
+- Starts `dsolver-tycho-broadcaster-service` first when `TYCHO_BROADCASTER_URL` points at local loopback, then starts `dsolver-simulator-service`; non-local broadcaster URLs are treated as externally managed.
 - Waits for `/status` service health, then confirms native readiness first and adds VM and RFQ readiness checks when those pool backends are enabled.
 - Fresh VM-pool or RFQ warmups can take much longer than native readiness. Budget up to 10 minutes before treating either backend as stuck.
 - Runs a balanced `/simulate` sweep across representative pairs.

--- a/skills/simulation-service-analysis/references/project.md
+++ b/skills/simulation-service-analysis/references/project.md
@@ -7,7 +7,7 @@
 
 ## Local run
 - Create `.env` from `.env.example` and set `TYCHO_API_KEY` (required).
-- Keep `TYCHO_BROADCASTER_WS_URL` pointed at the broadcaster websocket. The local default lets the lifecycle helper start the broadcaster on port `3001` before the simulator.
+- Keep `TYCHO_BROADCASTER_URL` pointed at the broadcaster HTTP base URL and configure `BROADCASTER_REDIS_URL` plus `BROADCASTER_REDIS_STREAM_KEY` for Redis deltas. The local default lets the lifecycle helper start the broadcaster on port `3001` before the simulator.
 - RFQ feeds default to off. For RFQ analysis, set `ENABLE_RFQ_POOLS=true`. Ethereum and Base currently need the Bebop and Hashflow credential pairs; Liquorice credentials are only needed after `rfq:liquorice` is added to an active chain profile.
 - Set `CHAIN_ID` (`1` for Ethereum, `8453` for Base) or pass `--chain-id` to the analyzer.
 - Tycho health checks expect `Authorization: <TYCHO_API_KEY>` (no `Bearer` prefix).


### PR DESCRIPTION
Replays broadcaster Redis deltas in the simulator after the HTTP snapshot bootstrap. The simulator now opens the broadcaster snapshot session over HTTP, uses the Redis boundary from that session, and then follows Redis for accepted deltas across all configured backends. While it is catching up, or if the stream has a gap, readiness/status reflects that directly so the simulator does not serve incomplete state. This also moves simulator config to the broadcaster HTTP base URL plus Redis stream settings.