### PR TITLE
Add local Redis replay validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,12 +25,14 @@ logs/
 .tycho-sim-server.pid
 .tycho-broadcaster-service.pid
 .tycho-broadcaster-service.meta
+.tycho-redis-service.meta
 .cursorrules
 AGENTS.md
 CLAUDE.md
 tycho_node.log
 review_guide.md
 review-viewer/
+docs/superpowers/
 
 # Environment
 .env

--- a/README.md
+++ b/README.md
@@ -224,8 +224,12 @@ cargo run -p apps --bin sim-analysis -- --chain-id 8453 --stop
 ```
 
 When `TYCHO_BROADCASTER_URL` points at local loopback, the analyzer uses the repo lifecycle
-helper to start the broadcaster before the simulator. Non-local broadcaster URLs are treated as
-externally managed.
+helper to start Redis, the broadcaster, then the simulator. Non-local broadcaster or Redis URLs
+are treated as externally managed. To verify the Redis replay path while services are running:
+
+```bash
+scripts/verify_broadcaster_redis.sh --repo .
+```
 
 Container builds:
 
@@ -238,10 +242,11 @@ Useful helpers:
 
 - `scripts/start_server.sh` to start the local broadcaster plus simulator stack with repo-local PID and log files
 - `scripts/wait_ready.sh` to poll `/status` and enforce chain, native, VM, and RFQ readiness expectations; native readiness remains the default gate
+- `scripts/verify_broadcaster_redis.sh` to check the broadcaster replay boundary, Redis stream retention, and simulator catch-up status
 - `scripts/stop_server.sh` to stop services started by the repo helper
 - `cargo run -p apps --bin sim-analysis -- ...` to generate a JSON and markdown local behavior report
 
-The analyzer is intentionally reporting-first. It exercises representative `/simulate` and `/encode` flows, plus latency and light stress probes, then writes artifacts under `logs/simulation-reports/`, including simulator and broadcaster log excerpts, so agents can inspect anomalies, compare against previous local runs, and decide what matters instead of relying on a rigid pass or fail harness.
+The analyzer is intentionally reporting-first. It exercises representative `/simulate` and `/encode` flows, plus latency and light stress probes, then writes artifacts under `logs/simulation-reports/`, including simulator and broadcaster log excerpts, so reviewers can inspect anomalies, compare against previous local runs, and decide what matters instead of relying on a rigid pass or fail harness.
 
 ## Docs Map
 

--- a/STRESS_TEST_README.md
+++ b/STRESS_TEST_README.md
@@ -22,6 +22,12 @@ Keep the helper-managed local services running after the analysis:
 cargo run -p apps --bin sim-analysis -- --chain-id 1
 ```
 
+Verify the broadcaster HTTP snapshot plus Redis delta replay path while services are still running:
+
+```bash
+scripts/verify_broadcaster_redis.sh --repo .
+```
+
 Disable baseline comparison for a one-off run:
 
 ```bash
@@ -31,7 +37,7 @@ cargo run -p apps --bin sim-analysis -- --chain-id 1 --baseline none --stop
 ## What the analyzer does
 
 - reuses the existing local simulator if it is already responding, otherwise starts the local stack with the repo lifecycle helper
-- starts `dsolver-tycho-broadcaster-service` first when `TYCHO_BROADCASTER_URL` points at local loopback, then starts `dsolver-simulator-service`; non-local broadcaster URLs are treated as externally managed, and Redis carries broadcaster deltas after each HTTP snapshot replay boundary
+- starts helper-managed Redis first when `BROADCASTER_REDIS_URL` is loopback `redis://`, then starts `dsolver-tycho-broadcaster-service` when `TYCHO_BROADCASTER_URL` points at local loopback, then starts `dsolver-simulator-service`; non-local broadcaster or Redis URLs are treated as externally managed, and Redis carries broadcaster deltas after each HTTP snapshot replay boundary
 - waits for `/status` service health, then confirms native readiness first and includes VM and RFQ readiness when those backends are enabled
 - allows longer VM or RFQ warmups on fresh starts; budget up to about 10 minutes before assuming either backend is stuck
 - runs a balanced `/simulate` sweep across representative pairs
@@ -53,12 +59,13 @@ Main artifacts:
 - `report.json`: machine-readable run summary
 - `summary.md`: human-readable findings and investigation hints
 - `evidence/`: readiness snapshots, sampled request/response bodies, and simulator/broadcaster log excerpts
+- Redis replay status from simulator `/status` subscriptions is preserved in `report.json` and summarized in `summary.md` when present.
 
 ## Behavior model
 
 - Non-zero exit codes are reserved for harness/runtime failures such as startup failures, readiness timeouts, transport failures that prevent analysis, or report-writing issues.
 - Degraded protocol behavior, request-level failures, odd pool visibility, and latency regressions are reported as findings, not hard failures.
-- The analyzer is meant to help agents investigate, not to decide prod-readiness by itself.
+- The analyzer is meant to help local reviewers investigate, not to decide prod-readiness by itself.
 
 ## Investigation flow
 

--- a/crates/apps/src/sim_analysis/report.rs
+++ b/crates/apps/src/sim_analysis/report.rs
@@ -72,6 +72,22 @@ pub struct ReadinessBackendSnapshot {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ReadinessRedisReplayBoundarySnapshot {
+    pub stream_key: String,
+    pub stream_id: String,
+    pub snapshot_id: String,
+    pub generation: u64,
+    pub exclusive_message_seq: u64,
+}
+
+impl ReadinessRedisReplayBoundarySnapshot {
+    fn exclusive_entry_id(&self) -> String {
+        format!("{}-{}", self.generation, self.exclusive_message_seq)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ReadinessSubscriptionSnapshot {
     pub connected: bool,
     pub bootstrap_complete: bool,
@@ -79,6 +95,14 @@ pub struct ReadinessSubscriptionSnapshot {
     pub stream_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub snapshot_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub redis_replay_boundary: Option<ReadinessRedisReplayBoundarySnapshot>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub redis_catch_up_cursor: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub redis_replay_caught_up: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub redis_gap_reason: Option<String>,
     pub restart_count: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_error: Option<String>,
@@ -505,6 +529,29 @@ fn append_readiness_snapshot(lines: &mut Vec<String>, label: &str, snapshot: &Re
             snapshot.backend_status("rfq")
         )
     ));
+    append_redis_replay_status(lines, snapshot);
+}
+
+fn append_redis_replay_status(lines: &mut Vec<String>, snapshot: &ReadinessSnapshot) {
+    for (kind, backend) in &snapshot.backends {
+        let Some(subscription) = &backend.subscription else {
+            continue;
+        };
+        if !subscription.has_redis_replay_status() {
+            continue;
+        }
+        lines.push(format!(
+            "  redis {}: boundary={} cursor={} caught_up={} gap={}",
+            kind,
+            subscription.redis_boundary_label(),
+            subscription
+                .redis_catch_up_cursor
+                .as_deref()
+                .unwrap_or("unknown"),
+            fmt_optional_bool(subscription.redis_replay_caught_up),
+            subscription.redis_gap_reason.as_deref().unwrap_or("none")
+        ));
+    }
 }
 
 fn append_evidence_section(lines: &mut Vec<String>, report: &AnalysisReport) {
@@ -573,6 +620,14 @@ fn fmt_optional_u64(value: Option<u64>) -> String {
     value.map_or_else(|| "unknown".to_string(), |value| value.to_string())
 }
 
+fn fmt_optional_bool(value: Option<bool>) -> &'static str {
+    match value {
+        Some(true) => "true",
+        Some(false) => "false",
+        None => "unknown",
+    }
+}
+
 fn display_status(value: Option<&str>) -> &str {
     value.unwrap_or("unknown")
 }
@@ -598,13 +653,32 @@ fn readiness_component_status(enabled: bool, status: Option<&str>) -> &str {
     }
 }
 
+impl ReadinessSubscriptionSnapshot {
+    fn has_redis_replay_status(&self) -> bool {
+        self.redis_replay_boundary.is_some()
+            || self.redis_catch_up_cursor.is_some()
+            || self.redis_replay_caught_up.is_some()
+            || self.redis_gap_reason.is_some()
+    }
+
+    fn redis_boundary_label(&self) -> String {
+        self.redis_replay_boundary
+            .as_ref()
+            .map(ReadinessRedisReplayBoundarySnapshot::exclusive_entry_id)
+            .unwrap_or_else(|| "unknown".to_string())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         build_findings, render_summary, AnalysisReport, Finding, LatencySummary, LogSourceSummary,
         LogSummary, ReadinessReport, EXPECTED_RFQ_PROTOCOL_VISIBILITY_NOTE,
     };
-    use super::{ReadinessBackendSnapshot, ReadinessSnapshot, RunMetadata, ScenarioReport};
+    use super::{
+        ReadinessBackendSnapshot, ReadinessSnapshot, ReadinessSubscriptionSnapshot, RunMetadata,
+        ScenarioReport,
+    };
     use std::collections::BTreeMap;
 
     fn scenario(label: &str, degraded_count: usize, error_count: usize) -> ScenarioReport {
@@ -768,6 +842,38 @@ mod tests {
     }
 
     #[test]
+    fn readiness_subscription_snapshot_preserves_redis_replay_fields() -> serde_json::Result<()> {
+        let snapshot: ReadinessSubscriptionSnapshot = serde_json::from_value(serde_json::json!({
+            "connected": true,
+            "bootstrap_complete": true,
+            "stream_id": "chain-8453-stream-2",
+            "snapshot_id": "chain-8453-snapshot-2",
+            "redis_replay_boundary": {
+                "streamKey": "dsolver:broadcaster:local:8453:events",
+                "streamId": "chain-8453-stream-2",
+                "snapshotId": "chain-8453-snapshot-2",
+                "generation": 2,
+                "exclusiveMessageSeq": 14
+            },
+            "redis_catch_up_cursor": "2-16",
+            "redis_replay_caught_up": true,
+            "restart_count": 0
+        }))?;
+
+        let value = serde_json::to_value(snapshot)?;
+
+        assert_eq!(
+            value["redis_replay_boundary"]["streamKey"],
+            "dsolver:broadcaster:local:8453:events"
+        );
+        assert_eq!(value["redis_replay_boundary"]["exclusiveMessageSeq"], 14);
+        assert_eq!(value["redis_catch_up_cursor"], "2-16");
+        assert!(value["redis_replay_caught_up"].as_bool().unwrap_or(false));
+        assert!(value.get("redis_gap_reason").is_none());
+        Ok(())
+    }
+
+    #[test]
     fn build_findings_marks_broadcaster_log_matches() {
         let mut analysis = report(Vec::new(), vec![scenario("core simulate", 0, 0)]);
         let broadcaster = analysis
@@ -833,6 +939,38 @@ mod tests {
         assert!(summary.contains("vm=disabled rfq=ready"));
         assert!(summary.contains("native=ready"));
         assert!(summary.contains("vm=disabled rfq=rebuilding"));
+    }
+
+    #[test]
+    fn render_summary_includes_redis_replay_state() -> serde_json::Result<()> {
+        let mut analysis = report(Vec::new(), vec![scenario("core simulate", 0, 0)]);
+        let native = analysis
+            .readiness
+            .initial
+            .backends
+            .get_mut("native")
+            .unwrap_or_else(|| unreachable!("test report includes native backend"));
+        native.subscription = Some(serde_json::from_value(serde_json::json!({
+            "connected": true,
+            "bootstrap_complete": true,
+            "stream_id": "chain-8453-stream-2",
+            "snapshot_id": "chain-8453-snapshot-2",
+            "redis_replay_boundary": {
+                "streamKey": "dsolver:broadcaster:local:8453:events",
+                "streamId": "chain-8453-stream-2",
+                "snapshotId": "chain-8453-snapshot-2",
+                "generation": 2,
+                "exclusiveMessageSeq": 14
+            },
+            "redis_catch_up_cursor": "2-16",
+            "redis_replay_caught_up": true,
+            "restart_count": 0
+        }))?);
+
+        let summary = render_summary(&analysis);
+
+        assert!(summary.contains("redis native: boundary=2-14 cursor=2-16 caught_up=true gap=none"));
+        Ok(())
     }
 
     #[test]

--- a/docker-compose.redis.yml
+++ b/docker-compose.redis.yml
@@ -1,0 +1,13 @@
+services:
+  redis:
+    image: redis:7-alpine
+    command: ["redis-server", "--save", "", "--appendonly", "no"]
+    ports:
+      - target: 6379
+        published: "${LOCAL_REDIS_PORT:-6379}"
+        host_ip: "${LOCAL_REDIS_BIND:-127.0.0.1}"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 2s
+      timeout: 1s
+      retries: 30

--- a/scripts/start_server.sh
+++ b/scripts/start_server.sh
@@ -6,6 +6,8 @@ usage() {
 Usage: start_server.sh [--repo <path>] [--log-file <path>] [--chain-id <id>] [--env KEY=VALUE] [--enable-vm-pools]
 
 Start the local DSolver simulator service stack from a repo checkout.
+When the broadcaster and Redis URLs point at loopback, the helper starts Redis first,
+then the broadcaster, then the simulator.
 
 Options:
   --repo             Path to repo root (default: current directory)
@@ -22,6 +24,7 @@ log_file=""
 chain_id_arg=""
 env_overrides=()
 local_broadcaster_start_timeout=300
+local_redis_start_timeout=60
 
 pid_is_running() {
   local pid="$1"
@@ -62,6 +65,22 @@ read_metadata_value() {
       exit
     }
   ' "$metadata_file" 2>/dev/null || true
+}
+
+redis_compose_project_name() {
+  python3 - "$repo" <<'PY'
+import hashlib
+import os
+import re
+import sys
+
+repo = os.path.realpath(sys.argv[1])
+name = re.sub(r"[^a-z0-9_-]+", "-", os.path.basename(repo).lower()).strip("-_")
+if not name:
+    name = "dsolver-simulator"
+digest = hashlib.sha1(repo.encode("utf-8")).hexdigest()[:12]
+print(f"{name}-redis-{digest}")
+PY
 }
 
 broadcaster_metadata_matches() {
@@ -174,6 +193,145 @@ print(f"true\t{bind_host}\t{port}\t{status_url}")
 PY
 }
 
+resolve_local_redis() {
+  python3 - "${BROADCASTER_REDIS_URL:-}" <<'PY'
+import sys
+from urllib.parse import urlparse
+
+raw_url = sys.argv[1]
+if not raw_url:
+    print("BROADCASTER_REDIS_URL is required when starting the local broadcaster", file=sys.stderr)
+    raise SystemExit(2)
+
+url = urlparse(raw_url)
+scheme = url.scheme.lower()
+
+if scheme not in {"redis", "rediss"}:
+    print("BROADCASTER_REDIS_URL must use redis:// or rediss://", file=sys.stderr)
+    raise SystemExit(2)
+
+if scheme == "rediss":
+    print("false\t\t")
+    raise SystemExit(0)
+
+host = url.hostname or ""
+local_hosts = {"localhost", "127.0.0.1", "::1"}
+
+if host not in local_hosts:
+    print("false\t\t")
+    raise SystemExit(0)
+
+try:
+    port = url.port or 6379
+except ValueError as error:
+    print(f"invalid BROADCASTER_REDIS_URL port: {error}", file=sys.stderr)
+    raise SystemExit(2)
+
+bind_host = "127.0.0.1" if host == "localhost" else host
+print(f"true\t{bind_host}\t{port}")
+PY
+}
+
+redis_tcp_ready() {
+  local host="$1"
+  local port="$2"
+
+  python3 - "$host" "$port" <<'PY'
+import socket
+import sys
+
+host = sys.argv[1]
+port = int(sys.argv[2])
+
+try:
+    with socket.create_connection((host, port), timeout=1):
+        raise SystemExit(0)
+except OSError:
+    raise SystemExit(1)
+PY
+}
+
+write_redis_metadata() {
+  local metadata_file="$1"
+  local redis_url="$2"
+  local bind_host="$3"
+  local bind_port="$4"
+  local compose_file="$5"
+  local compose_project="$6"
+
+  {
+    printf 'redis_url=%s\n' "$redis_url"
+    printf 'bind_host=%s\n' "$bind_host"
+    printf 'bind_port=%s\n' "$bind_port"
+    printf 'compose_file=%s\n' "$compose_file"
+    printf 'compose_project=%s\n' "$compose_project"
+  } > "$metadata_file"
+}
+
+wait_for_redis_tcp() {
+  local bind_host="$1"
+  local bind_port="$2"
+  local start_time
+  start_time="$(date +%s)"
+
+  while true; do
+    if redis_tcp_ready "$bind_host" "$bind_port"; then
+      echo "Redis is reachable at $bind_host:$bind_port."
+      return 0
+    fi
+
+    local now
+    now="$(date +%s)"
+    if ((now - start_time >= local_redis_start_timeout)); then
+      echo "Timed out waiting for Redis at $bind_host:$bind_port." >&2
+      return 1
+    fi
+
+    sleep 1
+  done
+}
+
+start_redis_if_local() {
+  local managed bind_host bind_port
+  IFS=$'\t' read -r managed bind_host bind_port < <(resolve_local_redis)
+
+  if [[ "$managed" != "true" ]]; then
+    echo "Redis URL is not loopback redis://; assuming Redis is externally managed."
+    return 0
+  fi
+
+  if redis_tcp_ready "$bind_host" "$bind_port"; then
+    echo "Redis already reachable at $bind_host:$bind_port."
+    return 0
+  fi
+
+  local compose_file="$repo/docker-compose.redis.yml"
+  local redis_metadata_file="$repo/.tycho-redis-service.meta"
+  local compose_project
+  compose_project="$(redis_compose_project_name)"
+
+  if [[ ! -f "$compose_file" ]]; then
+    echo "Local Redis compose file not found at $compose_file." >&2
+    return 1
+  fi
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "Docker is required to start local Redis for BROADCASTER_REDIS_URL." >&2
+    return 1
+  fi
+  if ! docker compose version >/dev/null 2>&1; then
+    echo "Docker Compose v2 is required to start local Redis." >&2
+    return 1
+  fi
+
+  echo "Starting local Redis on $bind_host:$bind_port..."
+  (
+    cd "$repo"
+    LOCAL_REDIS_BIND="$bind_host" LOCAL_REDIS_PORT="$bind_port" docker compose -p "$compose_project" -f "$compose_file" up -d redis
+  )
+  write_redis_metadata "$redis_metadata_file" "$BROADCASTER_REDIS_URL" "$bind_host" "$bind_port" "$compose_file" "$compose_project"
+  wait_for_redis_tcp "$bind_host" "$bind_port"
+}
+
 start_broadcaster_if_local() {
   local managed bind_host bind_port status_url
   IFS=$'\t' read -r managed bind_host bind_port status_url < <(resolve_local_broadcaster)
@@ -186,6 +344,8 @@ start_broadcaster_if_local() {
   local broadcaster_pid_file="$repo/.tycho-broadcaster-service.pid"
   local broadcaster_metadata_file="$repo/.tycho-broadcaster-service.meta"
   local broadcaster_log_file="$repo/logs/tycho-broadcaster-service.log"
+
+  start_redis_if_local
 
   local broadcaster_pid
   broadcaster_pid="$(read_pid_file "$broadcaster_pid_file")"
@@ -203,6 +363,11 @@ start_broadcaster_if_local() {
     if [[ "$status_state" == "chain-mismatch" ]]; then
       echo "Broadcaster already responding at $status_url for chain_id=$actual_chain, expected CHAIN_ID=$CHAIN_ID." >&2
       return 1
+    fi
+    if [[ "$status_state" == "redis-unhealthy" ]]; then
+      echo "Broadcaster service is running but Redis publisher is unhealthy; waiting for recovery."
+      wait_for_broadcaster_http "$status_url" "$broadcaster_pid_file" "$broadcaster_log_file"
+      return 0
     fi
 
     if broadcaster_metadata_matches "$broadcaster_metadata_file" "$TYCHO_BROADCASTER_URL" "$bind_host" "$bind_port" "$status_url"; then
@@ -231,6 +396,11 @@ start_broadcaster_if_local() {
   if [[ "$status_state" == "chain-mismatch" ]]; then
     echo "Broadcaster already responding at $status_url for chain_id=$actual_chain, expected CHAIN_ID=$CHAIN_ID." >&2
     return 1
+  fi
+  if [[ "$status_state" == "redis-unhealthy" ]]; then
+    echo "Broadcaster already responding at $status_url but Redis publisher is unhealthy; waiting for recovery."
+    wait_for_broadcaster_http "$status_url" "" "$broadcaster_log_file"
+    return 0
   fi
 
   mkdir -p "$repo/logs"
@@ -270,12 +440,14 @@ wait_for_broadcaster_http() {
       return 1
     fi
 
-    local pid
-    pid="$(cat "$pid_file" 2>/dev/null || true)"
-    if ! pid_is_running "$pid"; then
-      echo "Broadcaster service exited before HTTP was reachable. See $log_file." >&2
-      rm -f "$pid_file"
-      return 1
+    if [[ -n "$pid_file" ]]; then
+      local pid
+      pid="$(cat "$pid_file" 2>/dev/null || true)"
+      if ! pid_is_running "$pid"; then
+        echo "Broadcaster service exited before HTTP was reachable. See $log_file." >&2
+        rm -f "$pid_file"
+        return 1
+      fi
     fi
 
     local now
@@ -327,12 +499,18 @@ if (
     and isinstance(payload.get("backends"), dict)
 ):
     actual_chain_id = payload["chain_id"]
-    if actual_chain_id == expected_chain_id:
-        print(f"ok {http_code}")
-    else:
+    if actual_chain_id != expected_chain_id:
         print(f"chain-mismatch {http_code} {actual_chain_id}")
+    elif payload["status"] == "redis_publisher_unhealthy":
+        print(f"redis-unhealthy {http_code}")
+    else:
+        print(f"ok {http_code}")
 PY
 }
+
+if [[ "${DSOLVER_START_SERVER_SOURCE_ONLY:-}" == "1" ]]; then
+  return 0 2>/dev/null || exit 0
+fi
 
 while [[ $# -gt 0 ]]; do
   case "$1" in

--- a/scripts/stop_server.sh
+++ b/scripts/stop_server.sh
@@ -87,6 +87,48 @@ stop_process() {
   return 1
 }
 
+read_metadata_value() {
+  local metadata_file="$1"
+  local key="$2"
+
+  awk -v key="$key" '
+    index($0, key "=") == 1 {
+      print substr($0, length(key) + 2)
+      exit
+    }
+  ' "$metadata_file" 2>/dev/null || true
+}
+
+stop_redis_service() {
+  local metadata_file="$repo/.tycho-redis-service.meta"
+
+  if [[ ! -f "$metadata_file" ]]; then
+    echo "No Redis service metadata found at $metadata_file."
+    return 0
+  fi
+
+  local compose_file compose_project
+  compose_file="$(read_metadata_value "$metadata_file" "compose_file")"
+  compose_project="$(read_metadata_value "$metadata_file" "compose_project")"
+
+  if [[ -z "$compose_file" || -z "$compose_project" || ! -f "$compose_file" ]]; then
+    echo "Redis service metadata is stale; removing $metadata_file." >&2
+    rm -f "$metadata_file"
+    return 0
+  fi
+  if ! command -v docker >/dev/null 2>&1 || ! docker compose version >/dev/null 2>&1; then
+    echo "Docker Compose is required to stop helper-managed Redis from $metadata_file." >&2
+    return 1
+  fi
+
+  echo "Stopping Redis service..."
+  (
+    cd "$repo"
+    docker compose -p "$compose_project" -f "$compose_file" down
+  )
+  rm -f "$metadata_file"
+}
+
 status=0
 if ! stop_process "simulator service" "$repo/.tycho-sim-server.pid"; then
   status=1
@@ -98,6 +140,13 @@ fi
 if stop_process "broadcaster service" "$repo/.tycho-broadcaster-service.pid"; then
   rm -f "$repo/.tycho-broadcaster-service.meta"
 else
+  status=1
+  if [[ "$force" != "true" ]]; then
+    echo "Preserving Redis service because broadcaster service did not stop." >&2
+    exit "$status"
+  fi
+fi
+if ! stop_redis_service; then
   status=1
 fi
 

--- a/scripts/test_start_server_redis.sh
+++ b/scripts/test_start_server_redis.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+DSOLVER_START_SERVER_SOURCE_ONLY=1
+# shellcheck disable=SC1091
+source "$repo/scripts/start_server.sh"
+
+assert_local_redis() {
+  local redis_url="$1"
+  local expected_host="$2"
+  local expected_port="$3"
+  local managed host port
+
+  BROADCASTER_REDIS_URL="$redis_url"
+  IFS=$'\t' read -r managed host port < <(resolve_local_redis)
+  unset BROADCASTER_REDIS_URL
+
+  [[ "$managed" == "true" ]] || {
+    echo "expected $redis_url to be managed locally, got managed=$managed" >&2
+    return 1
+  }
+  [[ "$host" == "$expected_host" ]] || {
+    echo "expected host $expected_host for $redis_url, got $host" >&2
+    return 1
+  }
+  [[ "$port" == "$expected_port" ]] || {
+    echo "expected port $expected_port for $redis_url, got $port" >&2
+    return 1
+  }
+}
+
+assert_external_redis() {
+  local redis_url="$1"
+  local managed
+
+  BROADCASTER_REDIS_URL="$redis_url"
+  IFS=$'\t' read -r managed _ < <(resolve_local_redis)
+  unset BROADCASTER_REDIS_URL
+
+  [[ "$managed" == "false" ]] || {
+    echo "expected $redis_url to be externally managed, got managed=$managed" >&2
+    return 1
+  }
+}
+
+assert_local_broadcaster() {
+  local broadcaster_url="$1"
+  local expected_host="$2"
+  local expected_port="$3"
+  local expected_status_url="$4"
+  local managed host port status_url
+
+  TYCHO_BROADCASTER_URL="$broadcaster_url"
+  IFS=$'\t' read -r managed host port status_url < <(resolve_local_broadcaster)
+  unset TYCHO_BROADCASTER_URL
+
+  [[ "$managed" == "true" ]] || {
+    echo "expected $broadcaster_url to be managed locally, got managed=$managed" >&2
+    return 1
+  }
+  [[ "$host" == "$expected_host" ]] || {
+    echo "expected host $expected_host for $broadcaster_url, got $host" >&2
+    return 1
+  }
+  [[ "$port" == "$expected_port" ]] || {
+    echo "expected port $expected_port for $broadcaster_url, got $port" >&2
+    return 1
+  }
+  [[ "$status_url" == "$expected_status_url" ]] || {
+    echo "expected status URL $expected_status_url for $broadcaster_url, got $status_url" >&2
+    return 1
+  }
+}
+
+assert_external_broadcaster() {
+  local broadcaster_url="$1"
+  local managed
+
+  TYCHO_BROADCASTER_URL="$broadcaster_url"
+  IFS=$'\t' read -r managed _ < <(resolve_local_broadcaster)
+  unset TYCHO_BROADCASTER_URL
+
+  [[ "$managed" == "false" ]] || {
+    echo "expected $broadcaster_url to be externally managed, got managed=$managed" >&2
+    return 1
+  }
+}
+
+assert_local_redis "redis://localhost:6380/0" "127.0.0.1" "6380"
+assert_local_redis "redis://127.0.0.1:6379/0" "127.0.0.1" "6379"
+assert_local_redis "redis://[::1]:6381/0" "::1" "6381"
+assert_external_redis "rediss://localhost:6379/0"
+assert_external_redis "redis://redis.internal:6379/0"
+
+unset BROADCASTER_REDIS_URL
+if resolve_local_redis >/dev/null 2>&1; then
+  echo "expected missing BROADCASTER_REDIS_URL to fail" >&2
+  exit 1
+fi
+
+assert_local_broadcaster "http://localhost:3001" "127.0.0.1" "3001" "http://127.0.0.1:3001/status"
+assert_local_broadcaster "http://[::1]:3001" "::1" "3001" "http://[::1]:3001/status"
+assert_external_broadcaster "https://broadcaster.example/prod/base"
+
+TYCHO_BROADCASTER_URL="http://127.0.0.1:3001/snapshot-sessions"
+if resolve_local_broadcaster >/dev/null 2>&1; then
+  echo "expected local broadcaster URL with a path to fail" >&2
+  exit 1
+fi
+unset TYCHO_BROADCASTER_URL
+
+repo="/tmp/dsolver-simulator-a"
+compose_project_a="$(redis_compose_project_name)"
+repo="/tmp/another-checkout/dsolver-simulator"
+compose_project_b="$(redis_compose_project_name)"
+[[ "$compose_project_a" != "$compose_project_b" ]] || {
+  echo "expected Redis Compose project name to differ by repo path" >&2
+  exit 1
+}
+
+curl() {
+  printf '%s\n%s' "$TEST_STATUS_BODY" "$TEST_STATUS_CODE"
+}
+
+TEST_STATUS_CODE=503
+TEST_STATUS_BODY='{"status":"redis_publisher_unhealthy","chain_id":8453,"upstream":{},"snapshot":{},"snapshot_sessions":{},"backends":{},"redis_publisher":{"healthy":false}}'
+status_check="$(broadcaster_status_check "http://127.0.0.1:3001/status" "8453")"
+[[ "$status_check" == "redis-unhealthy 503" ]] || {
+  echo "expected redis-unhealthy status check, got $status_check" >&2
+  exit 1
+}
+
+echo "start_server Redis helper tests passed"

--- a/scripts/test_verify_broadcaster_redis.sh
+++ b/scripts/test_verify_broadcaster_redis.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+DSOLVER_VERIFY_BROADCASTER_REDIS_SOURCE_ONLY=1
+# shellcheck disable=SC1091
+source "$repo/scripts/verify_broadcaster_redis.sh"
+
+TYCHO_BROADCASTER_URL=http://127.0.0.1:3001
+[[ "$(derive_status_url)" == "http://127.0.0.1:3001/status" ]]
+TYCHO_BROADCASTER_URL=https://broadcaster.example/prod/base
+[[ "$(derive_status_url)" == "https://broadcaster.example/prod/base/status" ]]
+unset TYCHO_BROADCASTER_URL
+
+status_body='{"status":"ready","chain_id":8453,"redis_publisher":{"healthy":true,"stream_key":"dsolver:broadcaster:local:8453:events","stream_id":"chain-8453-stream-2","snapshot_id":"chain-8453-snapshot-2","replay_boundary":{"streamKey":"dsolver:broadcaster:local:8453:events","streamId":"chain-8453-stream-2","snapshotId":"chain-8453-snapshot-2","generation":2,"exclusiveMessageSeq":14}}}'
+boundary_json="$(extract_replay_boundary "$status_body")"
+[[ "$(boundary_entry_id "$boundary_json")" == "2-14" ]]
+
+if extract_replay_boundary "${status_body/exclusiveMessageSeq/missingMessageSeq}" >/dev/null 2>&1; then
+  echo "expected missing exclusiveMessageSeq to fail replay boundary parsing" >&2
+  exit 1
+fi
+
+assert_entry_retained "2-14" "2-14"
+if assert_entry_retained "" "2-14" 2>/dev/null; then
+  echo "expected empty XRANGE result to fail exact retention check" >&2
+  exit 1
+fi
+if assert_entry_retained "2-15" "2-14" 2>/dev/null; then
+  echo "expected mismatched XRANGE result to fail exact retention check" >&2
+  exit 1
+fi
+
+BROADCASTER_REDIS_URL=redis://127.0.0.1:6379/1
+[[ "$(redis_db_number)" == "1" ]]
+BROADCASTER_REDIS_URL=redis://127.0.0.1:6379
+[[ "$(redis_db_number)" == "0" ]]
+
+metadata_file="$(mktemp)"
+trap 'rm -f "$metadata_file"' EXIT
+{
+  printf 'redis_url=%s\n' 'redis://127.0.0.1:6379/0'
+  printf 'compose_file=%s\n' "$repo/docker-compose.redis.yml"
+  printf 'compose_project=%s\n' 'dsolver-simulator-redis-test'
+} > "$metadata_file"
+BROADCASTER_REDIS_URL=redis://127.0.0.1:6379/0
+redis_metadata_matches_current "$metadata_file" || {
+  echo "expected Redis metadata to match current BROADCASTER_REDIS_URL" >&2
+  exit 1
+}
+BROADCASTER_REDIS_URL=redis://127.0.0.1:6380/0
+if redis_metadata_matches_current "$metadata_file"; then
+  echo "expected stale Redis metadata to be ignored" >&2
+  exit 1
+fi
+
+echo "verify_broadcaster_redis helper tests passed"

--- a/scripts/verify_broadcaster_redis.sh
+++ b/scripts/verify_broadcaster_redis.sh
@@ -1,0 +1,347 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: verify_broadcaster_redis.sh [--repo <path>] [--status-url <url>] [--simulator-status-url <url>]
+
+Verify that the local broadcaster Redis replay path is live.
+
+The script reads BROADCASTER_REDIS_URL and BROADCASTER_REDIS_STREAM_KEY from
+.env or the current environment. It checks:
+  - broadcaster /status includes a healthy redis_publisher with replay_boundary
+  - the Redis stream has at least one entry
+  - the replay boundary cursor still has enough retained Redis history
+  - simulator /status subscriptions caught up from the Redis replay boundary
+
+Options:
+  --repo                  Path to repo root (default: current directory)
+  --status-url            Broadcaster status URL (default: derived from TYCHO_BROADCASTER_URL)
+  --simulator-status-url  Simulator status URL (default: http://127.0.0.1:${PORT:-3000}/status)
+  -h, --help              Show this help
+USAGE
+}
+
+repo="."
+status_url=""
+simulator_status_url=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      repo="$2"
+      shift 2
+      ;;
+    --status-url)
+      status_url="$2"
+      shift 2
+      ;;
+    --simulator-status-url)
+      simulator_status_url="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+repo="$(cd "$repo" && pwd)"
+
+redis_db_number() {
+  python3 - "${BROADCASTER_REDIS_URL:-}" <<'PY'
+import sys
+from urllib.parse import urlparse
+
+raw_url = sys.argv[1]
+url = urlparse(raw_url)
+db_path = url.path.lstrip("/")
+if not db_path:
+    print("0")
+    raise SystemExit(0)
+if not db_path.isdigit():
+    print(f"BROADCASTER_REDIS_URL database must be numeric, got {url.path}", file=sys.stderr)
+    raise SystemExit(2)
+print(db_path)
+PY
+}
+
+read_metadata_value() {
+  local metadata_file="$1"
+  local key="$2"
+
+  awk -v key="$key" '
+    index($0, key "=") == 1 {
+      print substr($0, length(key) + 2)
+      exit
+    }
+  ' "$metadata_file" 2>/dev/null || true
+}
+
+redis_metadata_matches_current() {
+  local metadata_file="$1"
+
+  [[ -f "$metadata_file" ]] \
+    && [[ "$(read_metadata_value "$metadata_file" "redis_url")" == "${BROADCASTER_REDIS_URL:-}" ]]
+}
+
+derive_status_url() {
+  python3 - "${TYCHO_BROADCASTER_URL:-}" <<'PY'
+import sys
+from urllib.parse import urlparse, urlunparse
+
+raw_url = sys.argv[1]
+if not raw_url:
+    print("TYCHO_BROADCASTER_URL is required when --status-url is omitted", file=sys.stderr)
+    raise SystemExit(2)
+
+url = urlparse(raw_url)
+if url.scheme not in {"http", "https"}:
+    print("TYCHO_BROADCASTER_URL must use http:// or https://", file=sys.stderr)
+    raise SystemExit(2)
+if not url.netloc:
+    print("TYCHO_BROADCASTER_URL must include a host", file=sys.stderr)
+    raise SystemExit(2)
+
+base_path = url.path.rstrip("/")
+status_path = f"{base_path}/status" if base_path else "/status"
+print(urlunparse((url.scheme, url.netloc, status_path, "", "", "")))
+PY
+}
+
+extract_replay_boundary() {
+  local status_body="$1"
+
+  STATUS_BODY="$status_body" python3 <<'PY'
+import json
+import os
+
+payload = json.loads(os.environ["STATUS_BODY"])
+publisher = payload.get("redis_publisher")
+if not isinstance(publisher, dict):
+    raise SystemExit("broadcaster /status did not include redis_publisher")
+if publisher.get("healthy") is not True:
+    raise SystemExit("broadcaster redis_publisher is not healthy")
+boundary = publisher.get("replay_boundary")
+if not isinstance(boundary, dict):
+    raise SystemExit("broadcaster redis_publisher has no replay_boundary")
+
+string_fields = ["streamKey", "streamId", "snapshotId"]
+for field in string_fields:
+    value = boundary.get(field)
+    if not isinstance(value, str) or not value:
+        raise SystemExit(f"broadcaster replay_boundary is missing {field}")
+
+for field in ["generation", "exclusiveMessageSeq"]:
+    value = boundary.get(field)
+    if not isinstance(value, int) or value < 0:
+        raise SystemExit(f"broadcaster replay_boundary has invalid {field}")
+
+if boundary["generation"] == 0:
+    raise SystemExit("broadcaster replay_boundary generation must be positive")
+
+publisher_matches = {
+    "stream_key": "streamKey",
+    "stream_id": "streamId",
+    "snapshot_id": "snapshotId",
+}
+for publisher_field, boundary_field in publisher_matches.items():
+    value = publisher.get(publisher_field)
+    if isinstance(value, str) and value and value != boundary[boundary_field]:
+        raise SystemExit(
+            f"broadcaster redis_publisher {publisher_field}={value} does not match replay_boundary {boundary_field}={boundary[boundary_field]}"
+        )
+
+print(json.dumps(boundary, sort_keys=True))
+PY
+}
+
+boundary_entry_id() {
+  local boundary_json="$1"
+
+  BOUNDARY_JSON="$boundary_json" python3 <<'PY'
+import json
+import os
+
+boundary = json.loads(os.environ["BOUNDARY_JSON"])
+print(f"{boundary['generation']}-{boundary['exclusiveMessageSeq']}")
+PY
+}
+
+boundary_message_seq() {
+  local boundary_json="$1"
+
+  BOUNDARY_JSON="$boundary_json" python3 <<'PY'
+import json
+import os
+
+boundary = json.loads(os.environ["BOUNDARY_JSON"])
+print(boundary["exclusiveMessageSeq"])
+PY
+}
+
+boundary_stream_key() {
+  local boundary_json="$1"
+
+  BOUNDARY_JSON="$boundary_json" python3 <<'PY'
+import json
+import os
+
+boundary = json.loads(os.environ["BOUNDARY_JSON"])
+print(boundary["streamKey"])
+PY
+}
+
+assert_entry_retained() {
+  local range_output="$1"
+  local expected_entry_id="$2"
+
+  RANGE_OUTPUT="$range_output" EXPECTED_ENTRY_ID="$expected_entry_id" python3 <<'PY'
+import os
+
+range_output = os.environ["RANGE_OUTPUT"]
+expected_entry_id = os.environ["EXPECTED_ENTRY_ID"]
+if not range_output:
+    raise SystemExit(f"Redis entry {expected_entry_id} is not retained")
+
+first_line = range_output.splitlines()[0]
+if first_line != expected_entry_id:
+    raise SystemExit(
+        f"Redis entry check returned {first_line}, expected {expected_entry_id}"
+    )
+PY
+}
+
+verify_simulator_replay_status() {
+  local status_body="$1"
+
+  SIMULATOR_STATUS_BODY="$status_body" python3 <<'PY'
+import json
+import os
+
+payload = json.loads(os.environ["SIMULATOR_STATUS_BODY"])
+backends = payload.get("backends")
+if not isinstance(backends, dict):
+    raise SystemExit("simulator /status did not include backends")
+
+checked = []
+for kind, backend in sorted(backends.items()):
+    if not isinstance(backend, dict) or backend.get("enabled") is not True:
+        continue
+    subscription = backend.get("subscription")
+    if not isinstance(subscription, dict):
+        raise SystemExit(f"simulator /status backend {kind} has no subscription")
+    boundary = subscription.get("redis_replay_boundary")
+    if not isinstance(boundary, dict):
+        raise SystemExit(f"simulator /status backend {kind} has no redis_replay_boundary")
+    for field in ["streamKey", "streamId", "snapshotId", "generation", "exclusiveMessageSeq"]:
+        if field not in boundary:
+            raise SystemExit(f"simulator /status backend {kind} replay boundary is missing {field}")
+    cursor = subscription.get("redis_catch_up_cursor")
+    if not isinstance(cursor, str) or not cursor:
+        raise SystemExit(f"simulator /status backend {kind} has no redis_catch_up_cursor")
+    if subscription.get("redis_replay_caught_up") is not True:
+        raise SystemExit(f"simulator /status backend {kind} has not caught up from Redis replay")
+    gap = subscription.get("redis_gap_reason")
+    if gap is not None:
+        raise SystemExit(f"simulator /status backend {kind} has redis_gap_reason={gap}")
+    checked.append(kind)
+
+if not checked:
+    raise SystemExit("simulator /status had no enabled backends to verify")
+
+print(",".join(checked))
+PY
+}
+
+if [[ "${DSOLVER_VERIFY_BROADCASTER_REDIS_SOURCE_ONLY:-}" == "1" ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+
+if [[ -f "$repo/.env" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$repo/.env"
+  set +a
+fi
+
+if [[ -z "${BROADCASTER_REDIS_URL:-}" ]]; then
+  echo "BROADCASTER_REDIS_URL is required." >&2
+  exit 2
+fi
+if [[ -z "${BROADCASTER_REDIS_STREAM_KEY:-}" ]]; then
+  echo "BROADCASTER_REDIS_STREAM_KEY is required." >&2
+  exit 2
+fi
+
+if [[ -z "$status_url" ]]; then
+  status_url="$(derive_status_url)"
+fi
+if [[ -z "$simulator_status_url" ]]; then
+  simulator_status_url="http://127.0.0.1:${PORT:-3000}/status"
+fi
+
+redis_cli() {
+  local metadata_file="$repo/.tycho-redis-service.meta"
+  local db_number
+  db_number="$(redis_db_number)"
+  if [[ -f "$metadata_file" ]]; then
+    local compose_file compose_project
+    compose_file="$(read_metadata_value "$metadata_file" "compose_file")"
+    compose_project="$(read_metadata_value "$metadata_file" "compose_project")"
+    if redis_metadata_matches_current "$metadata_file" \
+      && [[ -n "$compose_file" && -f "$compose_file" && -n "$compose_project" ]] \
+      && command -v docker >/dev/null 2>&1 \
+      && docker compose version >/dev/null 2>&1; then
+      (
+        cd "$repo"
+        docker compose -p "$compose_project" -f "$compose_file" exec -T redis redis-cli -n "$db_number" "$@"
+      )
+      return
+    fi
+  fi
+
+  if ! command -v redis-cli >/dev/null 2>&1; then
+    echo "redis-cli is required when helper-managed Docker Redis is unavailable." >&2
+    return 1
+  fi
+  redis-cli -u "$BROADCASTER_REDIS_URL" "$@"
+}
+
+status_body="$(curl -sS --max-time 5 "$status_url")"
+boundary_json="$(extract_replay_boundary "$status_body")"
+boundary_stream_key="$(boundary_stream_key "$boundary_json")"
+if [[ "$boundary_stream_key" != "$BROADCASTER_REDIS_STREAM_KEY" ]]; then
+  echo "Replay boundary streamKey=$boundary_stream_key does not match BROADCASTER_REDIS_STREAM_KEY=$BROADCASTER_REDIS_STREAM_KEY." >&2
+  exit 1
+fi
+
+stream_len="$(redis_cli --raw XLEN "$BROADCASTER_REDIS_STREAM_KEY")"
+if ! [[ "$stream_len" =~ ^[0-9]+$ ]] || ((stream_len == 0)); then
+  echo "Redis stream $BROADCASTER_REDIS_STREAM_KEY has no entries." >&2
+  exit 1
+fi
+
+boundary_entry_id="$(boundary_entry_id "$boundary_json")"
+boundary_message_seq="$(boundary_message_seq "$boundary_json")"
+if ((boundary_message_seq > 0)); then
+  boundary_probe="$(redis_cli --raw XRANGE "$BROADCASTER_REDIS_STREAM_KEY" "$boundary_entry_id" "$boundary_entry_id" COUNT 1)"
+  assert_entry_retained "$boundary_probe" "$boundary_entry_id"
+fi
+
+simulator_status_body="$(curl -sS --max-time 5 "$simulator_status_url")"
+checked_backends="$(verify_simulator_replay_status "$simulator_status_body")"
+
+echo "Broadcaster Redis replay path is healthy."
+echo "Broadcaster status URL: $status_url"
+echo "Simulator status URL: $simulator_status_url"
+echo "Redis stream key: $BROADCASTER_REDIS_STREAM_KEY"
+echo "Redis stream entries: $stream_len"
+echo "Replay boundary entry: $boundary_entry_id"
+echo "Simulator replay backends: $checked_backends"

--- a/skills/simulation-service-analysis/SKILL.md
+++ b/skills/simulation-service-analysis/SKILL.md
@@ -18,14 +18,20 @@ metadata:
    ```bash
    cargo run -p apps --bin sim-analysis -- --chain-id 1 --stop
    ```
-5. Read:
+5. For a Redis replay self-check, keep the services running, verify the replay path, then stop them:
+   ```bash
+   cargo run -p apps --bin sim-analysis -- --chain-id 1 --baseline none
+   scripts/verify_broadcaster_redis.sh --repo .
+   scripts/stop_server.sh --repo .
+   ```
+6. Read:
    - `logs/simulation-reports/<chain-id>/balanced/<timestamp>/summary.md`
    - `logs/simulation-reports/<chain-id>/balanced/<timestamp>/report.json`
 
 ## What the analyzer does
 
 - Reuses the existing local simulator if it is already responding, otherwise starts the local broadcaster plus simulator stack with the repo lifecycle scripts.
-- Starts `dsolver-tycho-broadcaster-service` first when `TYCHO_BROADCASTER_URL` points at local loopback, then starts `dsolver-simulator-service`; non-local broadcaster URLs are treated as externally managed.
+- Starts helper-managed Redis first when `BROADCASTER_REDIS_URL` is loopback `redis://`, then starts `dsolver-tycho-broadcaster-service` when `TYCHO_BROADCASTER_URL` points at local loopback, then starts `dsolver-simulator-service`; non-local broadcaster or Redis URLs are treated as externally managed.
 - Waits for `/status` service health, then confirms native readiness first and adds VM and RFQ readiness checks when those pool backends are enabled.
 - Fresh VM-pool or RFQ warmups can take much longer than native readiness. Budget up to 10 minutes before treating either backend as stuck.
 - Runs a balanced `/simulate` sweep across representative pairs.
@@ -39,7 +45,7 @@ metadata:
 
 - Non-zero exit codes are reserved for harness/runtime failures such as startup failures, readiness timeouts, transport failures that prevent analysis, or report-writing failures.
 - Degraded protocol behavior, request-level failures, odd pool visibility, and latency regressions are reported as findings, not hard failures.
-- The analyzer is meant to help the agent investigate local behavior, not to decide prod-readiness by itself.
+- The analyzer is meant to help local reviewers investigate behavior, not to decide prod-readiness by itself.
 
 ## Useful commands
 
@@ -56,6 +62,11 @@ cargo run -p apps --bin sim-analysis -- --chain-id 1
 Disable baseline comparison:
 ```bash
 cargo run -p apps --bin sim-analysis -- --chain-id 1 --baseline none --stop
+```
+
+Verify the current broadcaster HTTP snapshot plus Redis delta replay path while services are still running:
+```bash
+scripts/verify_broadcaster_redis.sh --repo .
 ```
 
 Manual VM-ready wait when you want to confirm the service itself before rerunning the analyzer:

--- a/skills/simulation-service-analysis/references/project.md
+++ b/skills/simulation-service-analysis/references/project.md
@@ -15,6 +15,7 @@
   ```bash
   scripts/start_server.sh --repo . --chain-id 1
   ```
+- When `BROADCASTER_REDIS_URL` is loopback `redis://`, the lifecycle helper starts Redis from `docker-compose.redis.yml` before the local broadcaster. Use `scripts/verify_broadcaster_redis.sh --repo .` while services are running to confirm the broadcaster replay boundary, Redis stream retention, and simulator catch-up status.
 - Default bind: `127.0.0.1:3000` (override with `HOST`/`PORT`).
 
 ## Readiness
@@ -40,9 +41,10 @@
   - `summary.md` for the narrative overview
   - `report.json` for exact metrics and scenario breakdowns
   - `evidence/` for sampled request/response bodies, readiness snapshots, and simulator/broadcaster log excerpts
+- Redis replay fields from simulator `/status` subscriptions are preserved in `report.json` and summarized in `summary.md` when present.
 - RFQ-enabled Ethereum runs should also surface RFQ readiness and any RFQ-visibility findings in `summary.md` and `report.json`.
 - Baseline comparison is meant to be flexible. Use the latest saved run when it helps, disable it with `--baseline none` when you want a clean one-off read.
-- The analyzer does not act like a branch gate. It reports healthy, degraded, and errored behavior so the agent can investigate.
+- The analyzer does not act like a branch gate. It reports healthy, degraded, and errored behavior so a reviewer can investigate.
 
 ## Useful commands
 - Format: `cargo fmt --all`
@@ -53,6 +55,7 @@
 - Manual lifecycle:
   - `scripts/start_server.sh --repo . --chain-id 1`
   - `scripts/wait_ready.sh --url http://localhost:3000/status --expect-chain-id 1`
+  - `scripts/verify_broadcaster_redis.sh --repo .`
   - `scripts/wait_ready.sh --url http://localhost:3000/status --expect-chain-id 1 --require-rfq-ready --timeout 600`
   - `scripts/stop_server.sh --repo .`
 


### PR DESCRIPTION
Adds the local Redis replay validation harness on top of the broadcaster refactor. The lifecycle scripts now start helper-managed Redis and the local broadcaster when the configured URLs point at loopback, then verify the Redis replay boundary, stream length, and simulator state after the HTTP snapshot bootstrap. This also keeps the sim-analysis report carrying the replay boundary and cursor fields, and refreshes the local simulation-service-analysis docs so the workflow can be rerun from this branch.