### PR TITLE
feat: add broadcaster active writer guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Required runtime inputs:
 
 - `TYCHO_API_KEY` for Tycho access
 - `CHAIN_ID` for chain selection from `simulator-manifest.toml`
-- `TYCHO_BROADCASTER_URL` pointing at the broadcaster HTTP base URL, for example `http://127.0.0.1:3001`
+- `TYCHO_BROADCASTER_URL` pointing at the active broadcaster HTTP base URL, for example `http://127.0.0.1:3001`
 - `BROADCASTER_REDIS_URL` and `BROADCASTER_REDIS_STREAM_KEY` for the Redis stream that carries broadcaster deltas after each HTTP snapshot replay boundary
 
 Common optional inputs:
@@ -106,6 +106,19 @@ Common optional inputs:
 
 `crates/runtime/src/config/mod.rs` is the authoritative source for runtime defaults. `.env.example`
 is an example setup, not the source of truth for every default.
+
+## Runtime Handoff Contract
+
+The simulator bootstraps local state from the active broadcaster's HTTP snapshot session, then replays Redis Stream deltas after the snapshot replay boundary returned by that session. Redis is not the full-state bootstrap store.
+
+Broadcaster deployments use four modes:
+
+- `Passive` warms upstream/cache state, but does not append Redis deltas or serve snapshot sessions.
+- `Active` is the only Redis writer and the only snapshot-session authority for an environment and chain.
+- `Retired` rejects appends and snapshot sessions after it has been replaced.
+- `Unhealthy` fails closed until it recovers or is replaced.
+
+Redis append and snapshot-session creation are fenced so stale writers cannot publish after promotion. Simulators that hit a replay gap or need to cross Redis generations create a fresh HTTP snapshot session from the current active broadcaster instead of stitching generations from Redis. The handoff uses independent `XREAD` cursors per simulator process; it does not use Redis consumer groups or per-deployment stream keys.
 
 ## API Surface
 

--- a/STRESS_TEST_README.md
+++ b/STRESS_TEST_README.md
@@ -28,6 +28,8 @@ Verify the broadcaster HTTP snapshot plus Redis delta replay path while services
 scripts/verify_broadcaster_redis.sh --repo .
 ```
 
+The replay contract is: simulators bootstrap from the active broadcaster HTTP snapshot session, then read Redis deltas after the returned replay boundary. Only the active broadcaster should append deltas or serve snapshot sessions; passive, retired, and unhealthy broadcasters fail closed for those operations.
+
 Disable baseline comparison for a one-off run:
 
 ```bash
@@ -37,7 +39,7 @@ cargo run -p apps --bin sim-analysis -- --chain-id 1 --baseline none --stop
 ## What the analyzer does
 
 - reuses the existing local simulator if it is already responding, otherwise starts the local stack with the repo lifecycle helper
-- starts helper-managed Redis first when `BROADCASTER_REDIS_URL` is loopback `redis://`, then starts `dsolver-tycho-broadcaster-service` when `TYCHO_BROADCASTER_URL` points at local loopback, then starts `dsolver-simulator-service`; non-local broadcaster or Redis URLs are treated as externally managed, and Redis carries broadcaster deltas after each HTTP snapshot replay boundary
+- starts helper-managed Redis first when `BROADCASTER_REDIS_URL` is loopback `redis://`, then starts `dsolver-tycho-broadcaster-service` when `TYCHO_BROADCASTER_URL` points at local loopback, then starts `dsolver-simulator-service`; non-local broadcaster or Redis URLs are treated as externally managed, and Redis carries active-broadcaster deltas after each HTTP snapshot replay boundary
 - waits for `/status` service health, then confirms native readiness first and includes VM and RFQ readiness when those backends are enabled
 - allows longer VM or RFQ warmups on fresh starts; budget up to about 10 minutes before assuming either backend is stuck
 - runs a balanced `/simulate` sweep across representative pairs
@@ -60,6 +62,7 @@ Main artifacts:
 - `summary.md`: human-readable findings and investigation hints
 - `evidence/`: readiness snapshots, sampled request/response bodies, and simulator/broadcaster log excerpts
 - Redis replay status from simulator `/status` subscriptions is preserved in `report.json` and summarized in `summary.md` when present.
+- Replay gaps or Redis generation crossings should surface as readiness issues and fresh active-broadcaster snapshot bootstrap attempts, not as stitched Redis-only recovery.
 
 ## Behavior model
 

--- a/crates/rpc/src/api/broadcaster.rs
+++ b/crates/rpc/src/api/broadcaster.rs
@@ -1043,6 +1043,7 @@ mod tests {
             chain_id: Chain::Ethereum.id(),
             append_retry_window: Duration::from_millis(1),
             maxlen: None,
+            writer_lease_ttl: Duration::from_secs(30),
         }
     }
 

--- a/crates/rpc/src/api/broadcaster.rs
+++ b/crates/rpc/src/api/broadcaster.rs
@@ -50,7 +50,7 @@ mod tests {
         broadcaster::state::{BroadcasterSnapshotCache, BroadcasterUpstreamState},
         models::tokens::TokenStore,
     };
-    use simulator_core::broadcaster::{BroadcasterBackend, BroadcasterRedisStreamEntry};
+    use simulator_core::broadcaster::BroadcasterBackend;
     use tokio::{
         sync::{Barrier, Mutex},
         task::JoinHandle,
@@ -179,9 +179,24 @@ mod tests {
 
         assert_eq!(status, StatusCode::OK);
         assert_eq!(body["status"], "ready");
+        assert_eq!(body["redis_publisher"]["mode"], "active");
         assert_eq!(body["snapshot"]["ready"], true);
         assert_eq!(body["backends"]["native"]["block_number"], 10);
         assert_eq!(body["backends"]["native"]["pool_count"], 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn status_reports_passive_publisher_as_not_ready() -> Result<()> {
+        let app = create_broadcaster_router(build_passive_ready_state().await?);
+        let (status, body) = get_json(app, "/status").await?;
+
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(body["status"], "redis_publisher_passive");
+        assert_eq!(body["snapshot"]["ready"], true);
+        assert_eq!(body["redis_publisher"]["healthy"], true);
+        assert_eq!(body["redis_publisher"]["mode"], "passive");
+        assert!(body["redis_publisher"]["replay_boundary"].is_null());
         Ok(())
     }
 
@@ -195,10 +210,26 @@ mod tests {
         assert_eq!(status, StatusCode::OK);
         assert_eq!(body["status"], "ready");
         assert_eq!(body["redis_publisher"]["healthy"], true);
+        assert_eq!(body["redis_publisher"]["mode"], "active");
         let Some(stream_id) = body["redis_publisher"]["stream_id"].as_str() else {
             bail!("expected redis publisher stream_id");
         };
         assert!(stream_id.starts_with("chain-1-stream-"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn status_fences_stale_active_publisher_before_reporting_ready() -> Result<()> {
+        let writer = RpcFakeRedisWriter::healthy();
+        let app = create_broadcaster_router(build_stale_active_state(writer).await?);
+
+        let (status, body) = get_json(app, "/status").await?;
+
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(body["status"], "redis_publisher_retired");
+        assert_eq!(body["redis_publisher"]["healthy"], false);
+        assert_eq!(body["redis_publisher"]["mode"], "retired");
+        assert!(body["redis_publisher"]["replay_boundary"].is_null());
         Ok(())
     }
 
@@ -211,6 +242,7 @@ mod tests {
         assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(body["status"], "redis_publisher_unhealthy");
         assert_eq!(body["redis_publisher"]["healthy"], false);
+        assert_eq!(body["redis_publisher"]["mode"], "unhealthy");
         Ok(())
     }
 
@@ -223,6 +255,18 @@ mod tests {
         assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(body["status"], "snapshot_warming_up");
         assert_eq!(body["redis_publisher"]["healthy"], true);
+        assert_eq!(body["redis_publisher"]["mode"], "passive");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn snapshot_session_create_rejects_when_publisher_is_passive() -> Result<()> {
+        let app = create_broadcaster_router(build_passive_ready_state().await?);
+        let (status, body) = post_json(app, "/snapshot-sessions", serde_json::json!({})).await?;
+
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(body["status"], "redis_publisher_passive");
+        assert_eq!(body["redis_publisher"]["mode"], "passive");
         Ok(())
     }
 
@@ -655,6 +699,13 @@ mod tests {
         let rfq_service =
             service_with_backend(rfq_mode, BroadcasterBackend::Rfq, publisher.clone(), gate)
                 .await?;
+        if matches!(raw_mode, SeedMode::Ready) && matches!(rfq_mode, SeedMode::Ready) {
+            BroadcasterServiceState::promote_when_ready(
+                &[raw_service.clone(), rfq_service.clone()],
+                "active_writer_promoted",
+            )
+            .await?;
+        }
         Ok(BroadcasterAppState::with_snapshot_session_ttl(
             raw_service,
             Some(rfq_service),
@@ -687,6 +738,11 @@ mod tests {
             SeedMode::Ready => {
                 service.mark_upstream_connected().await;
                 service.apply_update(&native_only_update()).await?;
+                BroadcasterServiceState::promote_when_ready(
+                    std::slice::from_ref(&service),
+                    "active_writer_promoted",
+                )
+                .await?;
             }
         }
 
@@ -713,6 +769,11 @@ mod tests {
         );
         service.mark_upstream_connected().await;
         service.apply_update(&native_only_update()).await?;
+        BroadcasterServiceState::promote_when_ready(
+            std::slice::from_ref(&service),
+            "active_writer_promoted",
+        )
+        .await?;
         Ok(BroadcasterAppState::with_snapshot_session_ttl(
             service,
             None,
@@ -720,6 +781,38 @@ mod tests {
             Chain::Ethereum.id(),
             Duration::from_secs(300),
             publisher,
+        ))
+    }
+
+    async fn build_stale_active_state(writer: RpcFakeRedisWriter) -> Result<BroadcasterAppState> {
+        let cache = BroadcasterSnapshotCache::new(1, vec![BroadcasterBackend::Native]);
+        let upstream = BroadcasterUpstreamState::default();
+        let (old_publisher, gate) = publisher_and_gate(writer.clone());
+        let service = BroadcasterServiceState::with_lifecycle_gate(
+            8_388_608,
+            cache,
+            upstream,
+            old_publisher.clone(),
+            gate,
+        );
+        service.mark_upstream_connected().await;
+        service.apply_update(&native_only_update()).await?;
+        BroadcasterServiceState::promote_when_ready(std::slice::from_ref(&service), "old_active")
+            .await?;
+
+        let new_publisher =
+            BroadcasterRedisPublisher::new(redis_publisher_config(), Arc::new(writer));
+        new_publisher
+            .promote(vec![BroadcasterBackend::Native], "new_active")
+            .await?;
+
+        Ok(BroadcasterAppState::with_snapshot_session_ttl(
+            service,
+            None,
+            token_store(vec![], "http://127.0.0.1:1".to_string(), Chain::Ethereum),
+            Chain::Ethereum.id(),
+            Duration::from_secs(300),
+            old_publisher,
         ))
     }
 
@@ -737,6 +830,11 @@ mod tests {
         );
         service.mark_upstream_connected().await;
         service.apply_update(&native_only_update()).await?;
+        BroadcasterServiceState::promote_when_ready(
+            std::slice::from_ref(&service),
+            "active_writer_promoted",
+        )
+        .await?;
         let Err(_error) = service.broadcast_heartbeat().await else {
             bail!("expected heartbeat to mark Redis publisher unhealthy");
         };
@@ -762,6 +860,29 @@ mod tests {
             gate,
         );
         service.mark_upstream_connected().await;
+        Ok(BroadcasterAppState::with_snapshot_session_ttl(
+            service,
+            None,
+            token_store(vec![], "http://127.0.0.1:1".to_string(), Chain::Ethereum),
+            Chain::Ethereum.id(),
+            Duration::from_secs(300),
+            publisher,
+        ))
+    }
+
+    async fn build_passive_ready_state() -> Result<BroadcasterAppState> {
+        let cache = BroadcasterSnapshotCache::new(1, vec![BroadcasterBackend::Native]);
+        let upstream = BroadcasterUpstreamState::default();
+        let (publisher, gate) = publisher_and_gate(RpcFakeRedisWriter::healthy());
+        let service = BroadcasterServiceState::with_lifecycle_gate(
+            8_388_608,
+            cache,
+            upstream,
+            publisher.clone(),
+            gate,
+        );
+        service.mark_upstream_connected().await;
+        service.apply_update(&native_only_update()).await?;
         Ok(BroadcasterAppState::with_snapshot_session_ttl(
             service,
             None,
@@ -810,10 +931,9 @@ mod tests {
         writer: RpcFakeRedisWriter,
     ) -> (Arc<BroadcasterRedisPublisher>, Arc<Mutex<()>>) {
         (
-            Arc::new(BroadcasterRedisPublisher::new_with_initial_generation(
+            Arc::new(BroadcasterRedisPublisher::new(
                 redis_publisher_config(),
                 Arc::new(writer),
-                1,
             )),
             Arc::new(Mutex::new(())),
         )
@@ -822,43 +942,97 @@ mod tests {
     #[derive(Debug, Clone)]
     struct RpcFakeRedisWriter {
         fail_after_successes: Option<usize>,
-        append_count: Arc<Mutex<usize>>,
+        state: Arc<Mutex<RpcFakeRedisWriterState>>,
+    }
+
+    #[derive(Debug, Default)]
+    struct RpcFakeRedisWriterState {
+        append_count: usize,
+        active_token: Option<String>,
+        active_generation: u64,
     }
 
     impl RpcFakeRedisWriter {
         fn healthy() -> Self {
             Self {
                 fail_after_successes: None,
-                append_count: Arc::new(Mutex::new(0)),
+                state: Arc::new(Mutex::new(RpcFakeRedisWriterState::default())),
             }
         }
 
         fn failing_after_first_append() -> Self {
             Self {
                 fail_after_successes: Some(1),
-                append_count: Arc::new(Mutex::new(0)),
+                state: Arc::new(Mutex::new(RpcFakeRedisWriterState::default())),
             }
         }
     }
 
     impl RedisStreamWriter for RpcFakeRedisWriter {
-        fn append<'a>(
+        fn promote<'a>(
             &'a self,
-            _stream_key: &'a str,
-            _maxlen: Option<u64>,
-            _entry: &'a BroadcasterRedisStreamEntry,
+            command: runtime::broadcaster::redis_publisher::RedisPromotionCommand<'a>,
+        ) -> futures::future::BoxFuture<
+            'a,
+            Result<runtime::broadcaster::redis_publisher::RedisPromotionResult>,
+        > {
+            Box::pin(async move {
+                let mut state = self.state.lock().await;
+                if let Some(expected_token) = command.expected_writer_token {
+                    if state.active_token.as_deref() != Some(expected_token)
+                        || Some(state.active_generation) != command.expected_generation
+                    {
+                        bail!("stale Redis broadcaster writer token");
+                    }
+                }
+                state.active_generation = state.active_generation.saturating_add(1);
+                state.active_token = Some(command.writer_token.to_string());
+                let generation = state.active_generation;
+                state.append_count = state.append_count.saturating_add(1);
+                Ok(
+                    runtime::broadcaster::redis_publisher::RedisPromotionResult {
+                        generation,
+                        entry_id: format!("{generation}-1"),
+                    },
+                )
+            })
+        }
+
+        fn append_fenced<'a>(
+            &'a self,
+            command: runtime::broadcaster::redis_publisher::RedisAppendCommand<'a>,
         ) -> futures::future::BoxFuture<'a, Result<String>> {
             Box::pin(async move {
-                let mut append_count = self.append_count.lock().await;
+                let mut state = self.state.lock().await;
+                if state.active_token.as_deref() != Some(command.writer_token)
+                    || state.active_generation != command.generation
+                {
+                    bail!("stale Redis broadcaster writer token");
+                }
                 if self
                     .fail_after_successes
-                    .is_some_and(|threshold| *append_count >= threshold)
+                    .is_some_and(|threshold| state.append_count >= threshold)
                 {
                     bail!("planned append failure");
                 }
-                let entry_id = format!("1000-{append_count}");
-                *append_count = append_count.saturating_add(1);
+                let entry_id = format!("{}-{}", command.generation, command.entry.message_seq);
+                state.append_count = state.append_count.saturating_add(1);
                 Ok(entry_id)
+            })
+        }
+
+        fn renew_writer<'a>(
+            &'a self,
+            command: runtime::broadcaster::redis_publisher::RedisRenewCommand<'a>,
+        ) -> futures::future::BoxFuture<'a, Result<()>> {
+            Box::pin(async move {
+                let state = self.state.lock().await;
+                if state.active_token.as_deref() != Some(command.writer_token)
+                    || state.active_generation != command.generation
+                {
+                    bail!("stale Redis broadcaster writer token");
+                }
+                Ok(())
             })
         }
     }

--- a/crates/runtime/src/broadcaster/app.rs
+++ b/crates/runtime/src/broadcaster/app.rs
@@ -152,7 +152,8 @@ pub async fn build_broadcaster_service() -> Result<BroadcasterServiceParts> {
 
     let tokens = load_token_store(&config).await?;
     let raw_backends = raw_configured_backends(&config);
-    let redis_publisher = build_redis_publisher(chain.id()).await?;
+    let heartbeat_interval = Duration::from_secs(config.tuning.heartbeat_interval_secs);
+    let redis_publisher = build_redis_publisher(chain.id(), heartbeat_interval).await?;
     let raw_cache = BroadcasterSnapshotCache::new(chain.id(), raw_backends.clone());
     let raw_upstream_state = BroadcasterUpstreamState::default();
     let rfq_backends = rfq_configured_backends(&config);
@@ -219,10 +220,7 @@ pub async fn build_broadcaster_service() -> Result<BroadcasterServiceParts> {
         raw_service.clone(),
         reset_services.clone(),
     );
-    spawn_heartbeat_task(
-        reset_services,
-        Duration::from_secs(config.tuning.heartbeat_interval_secs),
-    );
+    spawn_heartbeat_task(reset_services, heartbeat_interval);
     let snapshot_session_ttl = Duration::from_secs(config.tuning.snapshot_session_ttl_secs);
     let app_state = BroadcasterAppState::with_snapshot_session_ttl(
         raw_service,
@@ -293,11 +291,18 @@ fn redis_readiness(mode: &str) -> BroadcasterReadiness {
     }
 }
 
-async fn build_redis_publisher(chain_id: u64) -> Result<Arc<BroadcasterRedisPublisher>> {
+async fn build_redis_publisher(
+    chain_id: u64,
+    heartbeat_interval: Duration,
+) -> Result<Arc<BroadcasterRedisPublisher>> {
     let redis_config = load_broadcaster_redis_config();
     let writer = Arc::new(TokioRedisStreamWriter::connect(&redis_config.redis_url).await?);
     let publisher = Arc::new(BroadcasterRedisPublisher::new(
-        BroadcasterRedisPublisherConfig::from_redis_config(&redis_config, chain_id),
+        BroadcasterRedisPublisherConfig::from_redis_config(
+            &redis_config,
+            chain_id,
+            heartbeat_interval,
+        ),
         writer,
     ));
     Ok(publisher)

--- a/crates/runtime/src/broadcaster/app.rs
+++ b/crates/runtime/src/broadcaster/app.rs
@@ -92,9 +92,9 @@ impl BroadcasterAppState {
         if let Some(rfq_service) = &self.rfq_service {
             snapshot = combine_status_snapshots(snapshot, rfq_service.status_snapshot().await);
         }
-        let redis_status = self.redis_publisher.status_snapshot().await;
-        if !redis_status.healthy && snapshot.readiness == BroadcasterReadiness::Ready {
-            snapshot.readiness = BroadcasterReadiness::RedisPublisherUnhealthy;
+        let redis_status = self.redis_publisher.verified_status_snapshot().await;
+        if snapshot.readiness == BroadcasterReadiness::Ready {
+            snapshot.readiness = redis_readiness(redis_status.mode);
         }
         snapshot.redis_publisher = Some(redis_status);
         snapshot
@@ -152,21 +152,13 @@ pub async fn build_broadcaster_service() -> Result<BroadcasterServiceParts> {
 
     let tokens = load_token_store(&config).await?;
     let raw_backends = raw_configured_backends(&config);
-    let (redis_publisher, initial_generation) = build_redis_publisher(chain.id()).await?;
-    let raw_cache = BroadcasterSnapshotCache::new_with_initial_generation(
-        chain.id(),
-        raw_backends.clone(),
-        initial_generation,
-    );
+    let redis_publisher = build_redis_publisher(chain.id()).await?;
+    let raw_cache = BroadcasterSnapshotCache::new(chain.id(), raw_backends.clone());
     let raw_upstream_state = BroadcasterUpstreamState::default();
     let rfq_backends = rfq_configured_backends(&config);
-    let rfq_cache = rfq_backends.as_ref().map(|backends| {
-        BroadcasterSnapshotCache::new_with_initial_generation(
-            chain.id(),
-            backends.clone(),
-            initial_generation,
-        )
-    });
+    let rfq_cache = rfq_backends
+        .as_ref()
+        .map(|backends| BroadcasterSnapshotCache::new(chain.id(), backends.clone()));
     let rfq_upstream_state = rfq_cache
         .as_ref()
         .map(|_| BroadcasterUpstreamState::default());
@@ -217,6 +209,9 @@ pub async fn build_broadcaster_service() -> Result<BroadcasterServiceParts> {
         Some(rfq_service) => vec![raw_service.clone(), rfq_service.clone()],
         None => vec![raw_service.clone()],
     };
+    // New broadcasters start passive and warm their caches first. This task is
+    // the local promotion loop; /status stays non-ready until it wins the fence.
+    spawn_promotion_task(reset_services.clone(), Duration::from_secs(1));
     spawn_broadcaster_stream_task(
         &config,
         supervisor_cfg.clone(),
@@ -289,16 +284,23 @@ fn combine_readiness(
     left.max(right)
 }
 
-async fn build_redis_publisher(chain_id: u64) -> Result<(Arc<BroadcasterRedisPublisher>, u64)> {
+fn redis_readiness(mode: &str) -> BroadcasterReadiness {
+    match mode {
+        "active" => BroadcasterReadiness::Ready,
+        "passive" => BroadcasterReadiness::RedisPublisherPassive,
+        "retired" => BroadcasterReadiness::RedisPublisherRetired,
+        _ => BroadcasterReadiness::RedisPublisherUnhealthy,
+    }
+}
+
+async fn build_redis_publisher(chain_id: u64) -> Result<Arc<BroadcasterRedisPublisher>> {
     let redis_config = load_broadcaster_redis_config();
     let writer = Arc::new(TokioRedisStreamWriter::connect(&redis_config.redis_url).await?);
-    let initial_generation = writer.next_generation(&redis_config.stream_key).await?;
-    let publisher = Arc::new(BroadcasterRedisPublisher::new_with_initial_generation(
+    let publisher = Arc::new(BroadcasterRedisPublisher::new(
         BroadcasterRedisPublisherConfig::from_redis_config(&redis_config, chain_id),
         writer,
-        initial_generation,
     ));
-    Ok((publisher, initial_generation))
+    Ok(publisher)
 }
 
 fn log_memory_config(memory: MemoryConfig) {
@@ -479,6 +481,33 @@ fn spawn_heartbeat_task(services: Vec<BroadcasterServiceState>, interval: Durati
                     )
                     .await;
                     break;
+                }
+            }
+        }
+    });
+}
+
+fn spawn_promotion_task(services: Vec<BroadcasterServiceState>, interval: Duration) {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+            match BroadcasterServiceState::promote_when_ready(&services, "active_writer_promoted")
+                .await
+            {
+                Ok(Some(boundary)) => {
+                    info!(
+                        stream_id = boundary.stream_id.as_str(),
+                        snapshot_id = boundary.snapshot_id.as_str(),
+                        generation = boundary.generation,
+                        "Broadcaster active writer promoted"
+                    );
+                    return;
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    info!(error = %error, "Broadcaster active writer promotion skipped");
                 }
             }
         }

--- a/crates/runtime/src/broadcaster/redis_publisher.rs
+++ b/crates/runtime/src/broadcaster/redis_publisher.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use anyhow::{anyhow, Context, Result};
 use futures::future::BoxFuture;
 use rand::Rng;
-use redis::streams::{StreamInfoStreamReply, StreamRangeReply};
+use redis::streams::StreamRangeReply;
 use serde_json::Value;
 use tokio::sync::Mutex;
 use tokio::time::{timeout, Instant};
@@ -23,6 +23,129 @@ use simulator_core::broadcaster::{
 const APPEND_EXHAUSTED_MESSAGE: &str = "Redis broadcaster stream append retry window exhausted";
 const RETRY_BACKOFF_BASE: Duration = Duration::from_millis(5);
 const RETRY_BACKOFF_CAP: Duration = Duration::from_millis(200);
+const WRITER_LEASE_TTL: Duration = Duration::from_secs(30);
+const STALE_WRITER_MESSAGE: &str = "stale Redis broadcaster writer";
+pub(super) const GENERATION_PLACEHOLDER: &str = "__GENERATION__";
+
+// Redis has no native "check active writer, then XADD" command. These small Lua
+// scripts keep the fence and stream mutation in one Redis operation.
+const PROMOTE_WRITER_SCRIPT: &str = r#"
+local stream_key = KEYS[1]
+local writer_key = KEYS[2]
+local generation_key = KEYS[3]
+local writer_token = ARGV[1]
+local lease_ttl_ms = ARGV[2]
+local maxlen = ARGV[3]
+local expected_writer_token = ARGV[4]
+local expected_generation = ARGV[5]
+
+-- Generation resets are only allowed by the current active writer. A passive
+-- promotion passes no expectation and claims the next Redis generation.
+if expected_writer_token ~= "" then
+  if redis.call("GET", writer_key) ~= expected_writer_token then
+    return redis.error_reply("stale Redis broadcaster writer token")
+  end
+  if tostring(redis.call("GET", generation_key) or "") ~= expected_generation then
+    return redis.error_reply("stale Redis broadcaster writer generation")
+  end
+end
+
+local current_generation = tonumber(redis.call("GET", generation_key) or "0")
+local stream_generation = 0
+-- If the generation key was lost but the stream still exists, continue after
+-- the stream's highest generation instead of reusing Redis entry ids.
+local info = redis.pcall("XINFO", "STREAM", stream_key)
+if type(info) == "table" and info["err"] then
+  if not string.find(info["err"], "no such key") then
+    return redis.error_reply(info["err"])
+  end
+elseif type(info) == "table" then
+  for index = 1, #info - 1, 2 do
+    if info[index] == "last-generated-id" then
+      local last_id = tostring(info[index + 1])
+      local generation = string.match(last_id, "^(%d+)-")
+      if generation then
+        stream_generation = tonumber(generation)
+      end
+      break
+    end
+  end
+end
+
+if current_generation < stream_generation then
+  redis.call("SET", generation_key, stream_generation)
+end
+local generation = redis.call("INCR", generation_key)
+-- The new writer token and generation marker move together. A stale writer can
+-- either append before this script runs, or be rejected after it.
+redis.call("SET", writer_key, writer_token, "PX", lease_ttl_ms)
+
+local entry_id = tostring(generation) .. "-1"
+local command = {"XADD", stream_key}
+if maxlen ~= "" then
+  table.insert(command, "MAXLEN")
+  table.insert(command, "~")
+  table.insert(command, maxlen)
+end
+table.insert(command, entry_id)
+
+for index = 6, #ARGV, 2 do
+  table.insert(command, ARGV[index])
+  local value = string.gsub(ARGV[index + 1], "__GENERATION__", tostring(generation))
+  table.insert(command, value)
+end
+
+redis.call(unpack(command))
+return {tostring(generation), entry_id}
+"#;
+
+const APPEND_FENCED_SCRIPT: &str = r#"
+local stream_key = KEYS[1]
+local writer_key = KEYS[2]
+local generation_key = KEYS[3]
+local writer_token = ARGV[1]
+local generation = ARGV[2]
+local lease_ttl_ms = ARGV[3]
+local maxlen = ARGV[4]
+local entry_id = ARGV[5]
+
+-- This is the actual fence. A separate GET before XADD would still leave a
+-- race, so the ownership check and append stay in the same script.
+if redis.call("GET", writer_key) ~= writer_token then
+  return redis.error_reply("stale Redis broadcaster writer token")
+end
+if tostring(redis.call("GET", generation_key) or "") ~= generation then
+  return redis.error_reply("stale Redis broadcaster writer generation")
+end
+
+-- Successful writes keep the lease alive. Idle periods use the renew script.
+redis.call("PEXPIRE", writer_key, lease_ttl_ms)
+local command = {"XADD", stream_key}
+if maxlen ~= "" then
+  table.insert(command, "MAXLEN")
+  table.insert(command, "~")
+  table.insert(command, maxlen)
+end
+table.insert(command, entry_id)
+for index = 6, #ARGV, 2 do
+  table.insert(command, ARGV[index])
+  table.insert(command, ARGV[index + 1])
+end
+return redis.call(unpack(command))
+"#;
+
+const RENEW_WRITER_SCRIPT: &str = r#"
+-- Used by status checks, heartbeats without payloads, and snapshot serving to
+-- prove this process still owns the active writer before exposing state.
+if redis.call("GET", KEYS[1]) ~= ARGV[1] then
+  return redis.error_reply("stale Redis broadcaster writer token")
+end
+if tostring(redis.call("GET", KEYS[2]) or "") ~= ARGV[2] then
+  return redis.error_reply("stale Redis broadcaster writer generation")
+end
+redis.call("PEXPIRE", KEYS[1], ARGV[3])
+return "OK"
+"#;
 
 #[derive(Debug, Clone)]
 pub struct BroadcasterRedisPublisherConfig {
@@ -44,12 +167,76 @@ impl BroadcasterRedisPublisherConfig {
 }
 
 pub trait RedisStreamWriter: Send + Sync {
-    fn append<'a>(
+    fn promote<'a>(
         &'a self,
-        stream_key: &'a str,
-        maxlen: Option<u64>,
-        entry: &'a BroadcasterRedisStreamEntry,
-    ) -> BoxFuture<'a, Result<String>>;
+        command: RedisPromotionCommand<'a>,
+    ) -> BoxFuture<'a, Result<RedisPromotionResult>> {
+        Box::pin(async move {
+            let _ = command;
+            Err(anyhow!(
+                "Redis writer does not support active writer promotion"
+            ))
+        })
+    }
+
+    fn append_fenced<'a>(
+        &'a self,
+        command: RedisAppendCommand<'a>,
+    ) -> BoxFuture<'a, Result<String>> {
+        Box::pin(async move {
+            let _ = command;
+            Err(anyhow!("Redis writer does not support fenced appends"))
+        })
+    }
+
+    fn renew_writer<'a>(&'a self, command: RedisRenewCommand<'a>) -> BoxFuture<'a, Result<()>> {
+        Box::pin(async move {
+            let _ = command;
+            Err(anyhow!(
+                "Redis writer does not support active writer lease renewal"
+            ))
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RedisPromotionCommand<'a> {
+    pub stream_key: &'a str,
+    pub writer_key: &'a str,
+    pub writer_generation_key: &'a str,
+    pub maxlen: Option<u64>,
+    pub writer_token: &'a str,
+    pub expected_writer_token: Option<&'a str>,
+    pub expected_generation: Option<u64>,
+    pub lease_ttl: Duration,
+    pub marker_fields: &'a [(String, String)],
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RedisAppendCommand<'a> {
+    pub stream_key: &'a str,
+    pub writer_key: &'a str,
+    pub writer_generation_key: &'a str,
+    pub maxlen: Option<u64>,
+    pub writer_token: &'a str,
+    pub generation: u64,
+    pub lease_ttl: Duration,
+    pub entry: &'a BroadcasterRedisStreamEntry,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RedisRenewCommand<'a> {
+    pub writer_key: &'a str,
+    pub writer_generation_key: &'a str,
+    pub writer_token: &'a str,
+    pub generation: u64,
+    pub lease_ttl: Duration,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RedisPromotionResult {
+    pub generation: u64,
+    pub entry_id: String,
 }
 
 pub struct TokioRedisStreamWriter {
@@ -66,35 +253,100 @@ impl TokioRedisStreamWriter {
             .context("failed to connect to broadcaster Redis")?;
         Ok(Self { connection })
     }
-
-    pub async fn next_generation(&self, stream_key: &str) -> Result<u64> {
-        let mut connection = self.connection.clone();
-        let reply = redis::cmd("XINFO")
-            .arg("STREAM")
-            .arg(stream_key)
-            .query_async::<StreamInfoStreamReply>(&mut connection)
-            .await;
-        next_generation_from_xinfo_reply(reply)
-    }
 }
 
 impl RedisStreamWriter for TokioRedisStreamWriter {
-    fn append<'a>(
+    fn promote<'a>(
         &'a self,
-        stream_key: &'a str,
-        maxlen: Option<u64>,
-        entry: &'a BroadcasterRedisStreamEntry,
+        request: RedisPromotionCommand<'a>,
+    ) -> BoxFuture<'a, Result<RedisPromotionResult>> {
+        Box::pin(async move {
+            let mut command = redis::cmd("EVAL");
+            command
+                .arg(PROMOTE_WRITER_SCRIPT)
+                .arg(3)
+                .arg(request.stream_key)
+                .arg(request.writer_key)
+                .arg(request.writer_generation_key)
+                .arg(request.writer_token)
+                .arg(lease_ttl_ms(request.lease_ttl))
+                .arg(
+                    request
+                        .maxlen
+                        .map(|value| value.to_string())
+                        .unwrap_or_default(),
+                )
+                .arg(request.expected_writer_token.unwrap_or_default())
+                .arg(
+                    request
+                        .expected_generation
+                        .map(|value| value.to_string())
+                        .unwrap_or_default(),
+                );
+            for (field, value) in request.marker_fields {
+                command.arg(field).arg(value);
+            }
+
+            let mut connection = self.connection.clone();
+            let reply = command
+                .query_async::<Vec<String>>(&mut connection)
+                .await
+                .context("Redis active writer promotion failed")?;
+            let [generation, entry_id] = reply.as_slice() else {
+                return Err(anyhow!(
+                    "Redis active writer promotion returned invalid reply"
+                ));
+            };
+            Ok(RedisPromotionResult {
+                generation: generation.parse::<u64>().with_context(|| {
+                    format!(
+                        "Redis active writer promotion returned invalid generation: {generation}"
+                    )
+                })?,
+                entry_id: entry_id.clone(),
+            })
+        })
+    }
+
+    fn append_fenced<'a>(
+        &'a self,
+        request: RedisAppendCommand<'a>,
     ) -> BoxFuture<'a, Result<String>> {
         Box::pin(async move {
-            let entry_id = redis_entry_id(entry)?;
-            let fields = redis_entry_fields(entry)?;
-            let command = redis_xadd_command_from_fields(stream_key, maxlen, &entry_id, &fields);
+            let entry_id = redis_entry_id(request.entry)?;
+            let fields = redis_entry_fields(request.entry)?;
             let mut connection = self.connection.clone();
-            match command.query_async::<String>(&mut connection).await {
+            let mut command = redis::cmd("EVAL");
+            command
+                .arg(APPEND_FENCED_SCRIPT)
+                .arg(3)
+                .arg(request.stream_key)
+                .arg(request.writer_key)
+                .arg(request.writer_generation_key)
+                .arg(request.writer_token)
+                .arg(request.generation)
+                .arg(lease_ttl_ms(request.lease_ttl))
+                .arg(
+                    request
+                        .maxlen
+                        .map(|value| value.to_string())
+                        .unwrap_or_default(),
+                )
+                .arg(&entry_id);
+            for (field, value) in &fields {
+                command.arg(field).arg(value);
+            }
+            let result = command.query_async::<String>(&mut connection).await;
+            match result {
                 Ok(entry_id) => Ok(entry_id),
                 Err(error) => {
-                    if redis_stream_entry_matches(&mut connection, stream_key, &entry_id, &fields)
-                        .await?
+                    if redis_stream_entry_matches(
+                        &mut connection,
+                        request.stream_key,
+                        &entry_id,
+                        &fields,
+                    )
+                    .await?
                     {
                         Ok(entry_id)
                     } else {
@@ -104,11 +356,32 @@ impl RedisStreamWriter for TokioRedisStreamWriter {
             }
         })
     }
+
+    fn renew_writer<'a>(&'a self, request: RedisRenewCommand<'a>) -> BoxFuture<'a, Result<()>> {
+        Box::pin(async move {
+            let mut connection = self.connection.clone();
+            redis::cmd("EVAL")
+                .arg(RENEW_WRITER_SCRIPT)
+                .arg(2)
+                .arg(request.writer_key)
+                .arg(request.writer_generation_key)
+                .arg(request.writer_token)
+                .arg(request.generation)
+                .arg(lease_ttl_ms(request.lease_ttl))
+                .query_async::<String>(&mut connection)
+                .await
+                .context("Redis active writer lease renewal failed")?;
+            Ok(())
+        })
+    }
 }
 
 pub struct BroadcasterRedisPublisher {
     config: BroadcasterRedisPublisherConfig,
     writer: Arc<dyn RedisStreamWriter>,
+    writer_key: String,
+    writer_generation_key: String,
+    writer_token: String,
     inner: Arc<Mutex<BroadcasterRedisPublisherState>>,
 }
 
@@ -123,6 +396,7 @@ impl fmt::Debug for BroadcasterRedisPublisher {
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct BroadcasterRedisPublisherStatus {
     pub healthy: bool,
+    pub mode: &'static str,
     pub stream_key: String,
     pub stream_id: String,
     pub snapshot_id: String,
@@ -138,8 +412,32 @@ pub struct BroadcasterRedisPublisherStatus {
     pub last_error: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BroadcasterRedisPublisherMode {
+    Passive,
+    Active,
+    Retired,
+    Unhealthy,
+}
+
+impl BroadcasterRedisPublisherMode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Passive => "passive",
+            Self::Active => "active",
+            Self::Retired => "retired",
+            Self::Unhealthy => "unhealthy",
+        }
+    }
+
+    const fn is_healthy(self) -> bool {
+        matches!(self, Self::Passive | Self::Active)
+    }
+}
+
 #[derive(Debug)]
 struct BroadcasterRedisPublisherState {
+    mode: BroadcasterRedisPublisherMode,
     generation: u64,
     stream_id: String,
     snapshot_id: String,
@@ -168,36 +466,60 @@ impl BroadcasterRedisPublisherState {
         if retry_exhausted {
             self.retry_exhaustion_count = self.retry_exhaustion_count.saturating_add(1);
         }
+        self.mode = BroadcasterRedisPublisherMode::Unhealthy;
         self.last_error = Some(last_error);
     }
 
-    fn advance_generation(&mut self, chain_id: u64) -> Result<()> {
-        self.generation_reset_count = self.generation_reset_count.saturating_add(1);
-        self.generation = self
-            .generation
-            .checked_add(1)
-            .ok_or_else(|| anyhow!("Redis broadcaster generation overflow"))?;
+    fn record_retired(&mut self, last_error: String) {
+        self.mode = BroadcasterRedisPublisherMode::Retired;
+        self.last_error = Some(last_error);
+    }
+
+    fn activate_generation(
+        &mut self,
+        chain_id: u64,
+        generation: u64,
+        count_generation_reset: bool,
+    ) {
+        if count_generation_reset {
+            self.generation_reset_count = self.generation_reset_count.saturating_add(1);
+        }
+        self.mode = BroadcasterRedisPublisherMode::Active;
+        self.generation = generation;
         self.stream_id = format_redis_stream_id(chain_id, self.generation);
         self.snapshot_id = format_redis_snapshot_id(chain_id, self.generation);
-        self.next_message_seq = 1;
-        self.latest_entry_id = None;
+        self.next_message_seq = 2;
+        self.latest_entry_id = Some(format!("{}-1", self.generation));
         self.last_error = None;
-        Ok(())
     }
 }
 
 impl BroadcasterRedisPublisher {
-    pub fn new_with_initial_generation(
+    pub fn new(
+        config: BroadcasterRedisPublisherConfig,
+        writer: Arc<dyn RedisStreamWriter>,
+    ) -> Self {
+        Self::new_with_mode(config, writer, 1, BroadcasterRedisPublisherMode::Passive)
+    }
+
+    fn new_with_mode(
         config: BroadcasterRedisPublisherConfig,
         writer: Arc<dyn RedisStreamWriter>,
         generation: u64,
+        mode: BroadcasterRedisPublisherMode,
     ) -> Self {
         let stream_id = format_redis_stream_id(config.chain_id, generation);
         let snapshot_id = format_redis_snapshot_id(config.chain_id, generation);
+        let writer_key = redis_writer_key(&config.stream_key);
+        let writer_generation_key = redis_writer_generation_key(&config.stream_key);
         Self {
             config,
             writer,
+            writer_key,
+            writer_generation_key,
+            writer_token: new_writer_token(),
             inner: Arc::new(Mutex::new(BroadcasterRedisPublisherState {
+                mode,
                 generation,
                 stream_id,
                 snapshot_id,
@@ -214,6 +536,24 @@ impl BroadcasterRedisPublisher {
 
     pub async fn publish_accepted_payload(&self, payload: BroadcasterPayload) -> Result<()> {
         let mut guard = self.inner.lock().await;
+        match guard.mode {
+            BroadcasterRedisPublisherMode::Passive => return Ok(()),
+            BroadcasterRedisPublisherMode::Retired => {
+                return Err(anyhow!(
+                    "Redis broadcaster publisher is retired; this process is no longer the active writer"
+                ))
+            }
+            BroadcasterRedisPublisherMode::Unhealthy => {
+                let error = guard
+                    .last_error
+                    .as_deref()
+                    .unwrap_or("publisher is unhealthy");
+                return Err(anyhow!(
+                    "Redis broadcaster publisher is unhealthy; shared broadcaster generation reset is required before publishing more deltas: {error}"
+                ));
+            }
+            BroadcasterRedisPublisherMode::Active => {}
+        }
         if let Some(error) = &guard.last_error {
             return Err(anyhow!(
                 "Redis broadcaster publisher is unhealthy; shared broadcaster generation reset is required before publishing more deltas: {error}"
@@ -225,76 +565,89 @@ impl BroadcasterRedisPublisher {
             Ok(_) => Ok(()),
             Err(error) => {
                 let message = format!("{error:#}");
-                let retry_exhausted = guard.append_failure_count > append_failures_before;
-                guard.record_unhealthy(message, retry_exhausted);
+                if is_stale_writer_error(&error) {
+                    guard.record_retired(message);
+                } else {
+                    let retry_exhausted = guard.append_failure_count > append_failures_before;
+                    guard.record_unhealthy(message, retry_exhausted);
+                }
                 Err(error)
             }
         }
     }
 
-    pub async fn replay_boundary(&self) -> Result<BroadcasterRedisReplayBoundary> {
-        let guard = self.inner.lock().await;
-        if let Some(error) = &guard.last_error {
-            return Err(anyhow!(
-                "Redis broadcaster replay boundary is unavailable while publisher is unhealthy: {error}"
-            ));
+    pub async fn promote(
+        &self,
+        backends: Vec<BroadcasterBackend>,
+        reason: impl Into<String>,
+    ) -> Result<BroadcasterRedisReplayBoundary> {
+        self.promote_locked(backends, reason.into(), false, false)
+            .await
+    }
+
+    pub async fn renew_lease(&self) -> Result<()> {
+        let mut guard = self.inner.lock().await;
+        if guard.mode == BroadcasterRedisPublisherMode::Passive {
+            return Ok(());
         }
+        self.verify_writer_fence_locked(&mut guard, "active writer lease renewal")
+            .await
+    }
+
+    pub async fn verify_active_writer(&self) -> Result<()> {
+        let mut guard = self.inner.lock().await;
+        self.verify_writer_fence_locked(&mut guard, "active writer verification")
+            .await
+    }
+
+    pub async fn replay_boundary(&self) -> Result<BroadcasterRedisReplayBoundary> {
+        let mut guard = self.inner.lock().await;
+        self.verify_writer_fence_locked(&mut guard, "replay boundary")
+            .await?;
         self.replay_boundary_locked(&guard)
     }
 
-    pub async fn reset_generation(
+    pub async fn reset_generation_boundary(
         &self,
         reason: impl Into<String>,
         backends: Vec<BroadcasterBackend>,
-    ) {
-        let mut guard = self.inner.lock().await;
-        let reason = reason.into();
-        if let Err(error) = reset_redis_generation(&mut guard, self.config.chain_id, &reason) {
-            warn!(
-                event = "redis_generation_reset_failed",
-                error = %error,
-                "Redis broadcaster generation reset failed"
-            );
-            return;
-        }
-
-        let marker = match BroadcasterProgress::new(
-            self.config.chain_id,
-            guard.snapshot_id.clone(),
-            backends,
-            reason,
-        ) {
-            Ok(marker) => marker,
-            Err(error) => {
-                guard.record_unhealthy(error.to_string(), false);
-                warn!(
-                    event = "redis_generation_reset_marker_invalid",
-                    error = %error,
-                    "Redis broadcaster generation reset marker was invalid"
-                );
-                return;
-            }
-        };
-        let append_failures_before = guard.append_failure_count;
-        if let Err(error) = self
-            .append_payload_locked(&mut guard, BroadcasterPayload::Progress(marker))
+    ) -> Result<BroadcasterRedisReplayBoundary> {
+        self.promote_locked(backends, reason.into(), true, true)
             .await
-        {
-            let message = format!("{error:#}");
-            let retry_exhausted = guard.append_failure_count > append_failures_before;
-            guard.record_unhealthy(message, retry_exhausted);
-        }
+    }
+
+    pub async fn mode(&self) -> BroadcasterRedisPublisherMode {
+        self.inner.lock().await.mode
     }
 
     pub async fn status_snapshot(&self) -> BroadcasterRedisPublisherStatus {
         let guard = self.inner.lock().await;
-        let replay_boundary = if guard.last_error.is_none() {
-            self.replay_boundary_locked(&guard).ok()
-        } else {
-            None
-        };
+        self.status_snapshot_locked(&guard)
+    }
+
+    pub async fn verified_status_snapshot(&self) -> BroadcasterRedisPublisherStatus {
+        let mut guard = self.inner.lock().await;
+        if guard.mode == BroadcasterRedisPublisherMode::Active && guard.last_error.is_none() {
+            let _ = self
+                .verify_writer_fence_locked(&mut guard, "status snapshot")
+                .await;
+        }
+        self.status_snapshot_locked(&guard)
+    }
+
+    fn status_snapshot_locked(
+        &self,
+        guard: &BroadcasterRedisPublisherState,
+    ) -> BroadcasterRedisPublisherStatus {
+        let replay_boundary =
+            if guard.mode == BroadcasterRedisPublisherMode::Active && guard.last_error.is_none() {
+                self.replay_boundary_locked(guard).ok()
+            } else {
+                None
+            };
         BroadcasterRedisPublisherStatus {
-            healthy: guard.last_error.is_none(),
+            healthy: guard.mode.is_healthy() && guard.last_error.is_none(),
+            mode: guard.mode.as_str(),
             stream_key: self.config.stream_key.clone(),
             stream_id: guard.stream_id.clone(),
             snapshot_id: guard.snapshot_id.clone(),
@@ -306,6 +659,142 @@ impl BroadcasterRedisPublisher {
             retry_exhaustion_count: guard.retry_exhaustion_count,
             last_error: guard.last_error.clone(),
         }
+    }
+
+    async fn verify_writer_fence_locked(
+        &self,
+        guard: &mut BroadcasterRedisPublisherState,
+        context: &str,
+    ) -> Result<()> {
+        match guard.mode {
+            BroadcasterRedisPublisherMode::Active => {}
+            BroadcasterRedisPublisherMode::Passive => {
+                return Err(anyhow!(
+                    "Redis broadcaster {context} is unavailable while publisher mode is passive"
+                ));
+            }
+            BroadcasterRedisPublisherMode::Retired => {
+                return Err(anyhow!(
+                    "Redis broadcaster publisher is retired; this process is no longer the active writer"
+                ));
+            }
+            BroadcasterRedisPublisherMode::Unhealthy => {
+                let error = guard
+                    .last_error
+                    .as_deref()
+                    .unwrap_or("publisher is unhealthy");
+                return Err(anyhow!(
+                    "Redis broadcaster publisher is unhealthy; {context} is unavailable: {error}"
+                ));
+            }
+        }
+        if let Some(error) = &guard.last_error {
+            return Err(anyhow!(
+                "Redis broadcaster {context} is unavailable while publisher is unhealthy: {error}"
+            ));
+        }
+
+        if let Err(error) = self
+            .writer
+            .renew_writer(RedisRenewCommand {
+                writer_key: &self.writer_key,
+                writer_generation_key: &self.writer_generation_key,
+                writer_token: &self.writer_token,
+                generation: guard.generation,
+                lease_ttl: WRITER_LEASE_TTL,
+            })
+            .await
+        {
+            let message = format!("{error:#}");
+            if is_stale_writer_error(&error) {
+                guard.record_retired(message);
+            } else {
+                guard.record_unhealthy(message, false);
+            }
+            return Err(error);
+        }
+
+        guard.last_error = None;
+        Ok(())
+    }
+
+    async fn promote_locked(
+        &self,
+        backends: Vec<BroadcasterBackend>,
+        reason: String,
+        count_generation_reset: bool,
+        require_current_writer: bool,
+    ) -> Result<BroadcasterRedisReplayBoundary> {
+        let mut guard = self.inner.lock().await;
+        if guard.mode == BroadcasterRedisPublisherMode::Retired {
+            return Err(anyhow!(
+                "Redis broadcaster publisher is retired; this process cannot promote a writer generation"
+            ));
+        }
+        if require_current_writer {
+            match guard.mode {
+                BroadcasterRedisPublisherMode::Active
+                | BroadcasterRedisPublisherMode::Unhealthy => {}
+                BroadcasterRedisPublisherMode::Passive => {
+                    return Err(anyhow!(
+                        "Redis broadcaster publisher is passive; this process cannot reset a writer generation"
+                    ));
+                }
+                BroadcasterRedisPublisherMode::Retired => {
+                    unreachable!("retired publisher returned above")
+                }
+            }
+        }
+
+        let marker_fields =
+            generation_marker_template_fields(self.config.chain_id, backends, reason.clone())?;
+        let expected_writer_token = require_current_writer.then_some(self.writer_token.as_str());
+        let expected_generation = require_current_writer.then_some(guard.generation);
+        let promotion = self
+            .writer
+            .promote(RedisPromotionCommand {
+                stream_key: &self.config.stream_key,
+                writer_key: &self.writer_key,
+                writer_generation_key: &self.writer_generation_key,
+                maxlen: self.config.maxlen,
+                writer_token: &self.writer_token,
+                expected_writer_token,
+                expected_generation,
+                lease_ttl: WRITER_LEASE_TTL,
+                marker_fields: &marker_fields,
+            })
+            .await;
+
+        let promotion = match promotion {
+            Ok(promotion) => promotion,
+            Err(error) => {
+                let message = format!("{error:#}");
+                if is_stale_writer_error(&error) {
+                    guard.record_retired(message);
+                } else {
+                    guard.record_unhealthy(message, false);
+                }
+                return Err(error);
+            }
+        };
+
+        guard.activate_generation(
+            self.config.chain_id,
+            promotion.generation,
+            count_generation_reset,
+        );
+        if count_generation_reset {
+            emit_broadcaster_redis_generation_reset();
+        }
+        warn!(
+            event = "redis_generation_reset",
+            stream_id = guard.stream_id.as_str(),
+            snapshot_id = guard.snapshot_id.as_str(),
+            generation = guard.generation,
+            reason,
+            "Redis broadcaster generation promoted"
+        );
+        self.replay_boundary_locked(&guard)
     }
 
     async fn append_payload_locked(
@@ -379,8 +868,16 @@ impl BroadcasterRedisPublisher {
             attempts = attempts.saturating_add(1);
             match timeout(
                 remaining,
-                self.writer
-                    .append(&self.config.stream_key, self.config.maxlen, entry),
+                self.writer.append_fenced(RedisAppendCommand {
+                    stream_key: &self.config.stream_key,
+                    writer_key: &self.writer_key,
+                    writer_generation_key: &self.writer_generation_key,
+                    maxlen: self.config.maxlen,
+                    writer_token: &self.writer_token,
+                    generation: guard.generation,
+                    lease_ttl: WRITER_LEASE_TTL,
+                    entry,
+                }),
             )
             .await
             {
@@ -391,6 +888,10 @@ impl BroadcasterRedisPublisher {
                 }
                 Ok(Ok(result)) => return Ok(result),
                 Ok(Err(error)) => {
+                    if is_stale_writer_error(&error) {
+                        self.record_write_failure(guard, entry, attempts, &error);
+                        return Err(error);
+                    }
                     if started_at.elapsed() >= self.config.append_retry_window {
                         self.record_write_failure(guard, entry, attempts, &error);
                         return Err(error);
@@ -461,81 +962,43 @@ fn format_redis_snapshot_id(chain_id: u64, generation: u64) -> String {
     format!("chain-{chain_id}-snapshot-{generation}")
 }
 
-fn reset_redis_generation(
-    guard: &mut BroadcasterRedisPublisherState,
+fn generation_marker_template_fields(
     chain_id: u64,
-    reason: &str,
-) -> Result<()> {
-    guard.advance_generation(chain_id)?;
-    emit_broadcaster_redis_generation_reset();
-    warn!(
-        event = "redis_generation_reset",
-        stream_id = guard.stream_id.as_str(),
-        snapshot_id = guard.snapshot_id.as_str(),
-        generation = guard.generation,
-        reason,
-        "Redis broadcaster generation reset"
-    );
-    Ok(())
+    backends: Vec<BroadcasterBackend>,
+    reason: String,
+) -> Result<Vec<(String, String)>> {
+    let stream_id = format!("chain-{chain_id}-stream-{GENERATION_PLACEHOLDER}");
+    let snapshot_id = format!("chain-{chain_id}-snapshot-{GENERATION_PLACEHOLDER}");
+    let marker = BroadcasterProgress::new(chain_id, snapshot_id.clone(), backends, reason)?;
+    let envelope = BroadcasterEnvelope::new(stream_id, 1, BroadcasterPayload::Progress(marker));
+    let entry = BroadcasterRedisStreamEntry::from_envelope(chain_id, current_time_ms(), &envelope)?;
+    redis_entry_fields(&entry)
 }
 
-fn next_generation_from_xinfo_reply(
-    reply: std::result::Result<StreamInfoStreamReply, redis::RedisError>,
-) -> Result<u64> {
-    match reply {
-        Ok(reply) => next_generation_after_entry_id(&reply.last_generated_id),
-        Err(error) if redis_stream_missing_key(&error) => Ok(1),
-        Err(error) => Err(anyhow!(error).context("Redis XINFO STREAM failed")),
-    }
+fn redis_writer_key(stream_key: &str) -> String {
+    // Keep deployment config to one public stream key; ownership keys follow it.
+    format!("{stream_key}:writer")
 }
 
-pub(super) fn next_generation_after_entry_id(entry_id: &str) -> Result<u64> {
-    let generation = entry_id
-        .split_once('-')
-        .map(|(generation, _)| generation)
-        .ok_or_else(|| anyhow!("Redis stream last-generated-id is invalid: {entry_id}"))?
-        .parse::<u64>()
-        .with_context(|| format!("Redis stream last-generated-id is invalid: {entry_id}"))?;
-    generation
-        .checked_add(1)
-        .ok_or_else(|| anyhow!("Redis broadcaster generation overflow"))
+fn redis_writer_generation_key(stream_key: &str) -> String {
+    format!("{stream_key}:writer_generation")
 }
 
-fn redis_stream_missing_key(error: &redis::RedisError) -> bool {
-    error
-        .detail()
-        .is_some_and(|detail| detail.contains("no such key"))
+fn new_writer_token() -> String {
+    format!(
+        "{}-{}-{:016x}",
+        std::process::id(),
+        current_time_ms(),
+        rand::thread_rng().gen::<u64>()
+    )
 }
 
-#[cfg(test)]
-pub(super) fn redis_xadd_command(
-    stream_key: &str,
-    maxlen: Option<u64>,
-    entry: &BroadcasterRedisStreamEntry,
-) -> Result<redis::Cmd> {
-    let entry_id = redis_entry_id(entry)?;
-    let fields = redis_entry_fields(entry)?;
-    Ok(redis_xadd_command_from_fields(
-        stream_key, maxlen, &entry_id, &fields,
-    ))
+fn lease_ttl_ms(lease_ttl: Duration) -> u64 {
+    lease_ttl.as_millis().try_into().unwrap_or(u64::MAX)
 }
 
-fn redis_xadd_command_from_fields(
-    stream_key: &str,
-    maxlen: Option<u64>,
-    entry_id: &str,
-    fields: &[(String, String)],
-) -> redis::Cmd {
-    let mut command = redis::cmd("XADD");
-    command.arg(stream_key);
-    if let Some(maxlen) = maxlen {
-        command.arg("MAXLEN").arg("~").arg(maxlen);
-    }
-    command.arg(entry_id);
-    for (field, value) in fields {
-        command.arg(field).arg(value);
-    }
-    command
+fn is_stale_writer_error(error: &anyhow::Error) -> bool {
+    format!("{error:#}").contains(STALE_WRITER_MESSAGE)
 }
 
 pub(super) fn redis_entry_id(entry: &BroadcasterRedisStreamEntry) -> Result<String> {

--- a/crates/runtime/src/broadcaster/redis_publisher.rs
+++ b/crates/runtime/src/broadcaster/redis_publisher.rs
@@ -23,7 +23,8 @@ use simulator_core::broadcaster::{
 const APPEND_EXHAUSTED_MESSAGE: &str = "Redis broadcaster stream append retry window exhausted";
 const RETRY_BACKOFF_BASE: Duration = Duration::from_millis(5);
 const RETRY_BACKOFF_CAP: Duration = Duration::from_millis(200);
-const WRITER_LEASE_TTL: Duration = Duration::from_secs(30);
+const MIN_WRITER_LEASE_TTL: Duration = Duration::from_secs(30);
+const WRITER_LEASE_HEARTBEAT_MULTIPLIER: u32 = 3;
 const STALE_WRITER_MESSAGE: &str = "stale Redis broadcaster writer";
 pub(super) const GENERATION_PLACEHOLDER: &str = "__GENERATION__";
 
@@ -153,15 +154,21 @@ pub struct BroadcasterRedisPublisherConfig {
     pub chain_id: u64,
     pub append_retry_window: Duration,
     pub maxlen: Option<u64>,
+    pub writer_lease_ttl: Duration,
 }
 
 impl BroadcasterRedisPublisherConfig {
-    pub fn from_redis_config(redis_config: &BroadcasterRedisConfig, chain_id: u64) -> Self {
+    pub fn from_redis_config(
+        redis_config: &BroadcasterRedisConfig,
+        chain_id: u64,
+        heartbeat_interval: Duration,
+    ) -> Self {
         Self {
             stream_key: redis_config.stream_key.clone(),
             chain_id,
             append_retry_window: Duration::from_millis(redis_config.append_retry_window_ms),
             maxlen: redis_config.maxlen,
+            writer_lease_ttl: writer_lease_ttl_for_heartbeat_interval(heartbeat_interval),
         }
     }
 }
@@ -701,7 +708,7 @@ impl BroadcasterRedisPublisher {
                 writer_generation_key: &self.writer_generation_key,
                 writer_token: &self.writer_token,
                 generation: guard.generation,
-                lease_ttl: WRITER_LEASE_TTL,
+                lease_ttl: self.config.writer_lease_ttl,
             })
             .await
         {
@@ -760,7 +767,7 @@ impl BroadcasterRedisPublisher {
                 writer_token: &self.writer_token,
                 expected_writer_token,
                 expected_generation,
-                lease_ttl: WRITER_LEASE_TTL,
+                lease_ttl: self.config.writer_lease_ttl,
                 marker_fields: &marker_fields,
             })
             .await;
@@ -875,7 +882,7 @@ impl BroadcasterRedisPublisher {
                     maxlen: self.config.maxlen,
                     writer_token: &self.writer_token,
                     generation: guard.generation,
-                    lease_ttl: WRITER_LEASE_TTL,
+                    lease_ttl: self.config.writer_lease_ttl,
                     entry,
                 }),
             )
@@ -991,6 +998,12 @@ fn new_writer_token() -> String {
         current_time_ms(),
         rand::thread_rng().gen::<u64>()
     )
+}
+
+pub(super) fn writer_lease_ttl_for_heartbeat_interval(heartbeat_interval: Duration) -> Duration {
+    heartbeat_interval
+        .saturating_mul(WRITER_LEASE_HEARTBEAT_MULTIPLIER)
+        .max(MIN_WRITER_LEASE_TTL)
 }
 
 fn lease_ttl_ms(lease_ttl: Duration) -> u64 {

--- a/crates/runtime/src/broadcaster/redis_publisher/tests.rs
+++ b/crates/runtime/src/broadcaster/redis_publisher/tests.rs
@@ -18,9 +18,9 @@ use tycho_simulation::tycho_common::simulation::protocol_sim::{
 use tycho_simulation::tycho_common::Bytes;
 
 use super::{
-    next_generation_after_entry_id, redis_entry_fields, redis_entry_id,
-    redis_stream_entry_matches_reply, redis_xadd_command, BroadcasterRedisPublisher,
-    BroadcasterRedisPublisherConfig, RedisStreamWriter,
+    redis_entry_fields, redis_entry_id, redis_stream_entry_matches_reply,
+    BroadcasterRedisPublisher, BroadcasterRedisPublisherConfig, BroadcasterRedisPublisherMode,
+    RedisStreamWriter,
 };
 use crate::broadcaster::state::BroadcasterSnapshotCache;
 use simulator_core::broadcaster::{
@@ -93,13 +93,283 @@ impl ProtocolSim for DummySim {
 }
 
 #[tokio::test]
+async fn passive_publisher_skips_appends_and_has_no_replay_boundary() -> Result<()> {
+    let raw_cache = ready_cache(BroadcasterBackend::Native, 10, "native-1").await?;
+    let writer = FakeRedisWriter::default();
+    let publisher = BroadcasterRedisPublisher::new(publisher_config(), Arc::new(writer.clone()));
+
+    let update = raw_cache
+        .apply_update(&update(BroadcasterBackend::Native, 11, "native-2"))
+        .await?;
+    publisher
+        .publish_accepted_payload(BroadcasterPayload::Update(update))
+        .await?;
+
+    let status = publisher.status_snapshot().await;
+    assert_eq!(status.mode, "passive");
+    assert!(status.healthy);
+    assert!(status.replay_boundary.is_none());
+    assert!(publisher.replay_boundary().await.is_err());
+    assert!(
+        writer.appends().await.is_empty(),
+        "passive warmup must not append Redis entries"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn promotion_allocates_generation_and_appends_marker_before_live_updates() -> Result<()> {
+    let raw_cache = ready_cache(BroadcasterBackend::Native, 10, "native-1").await?;
+    let writer = FakeRedisWriter::default();
+    let publisher = BroadcasterRedisPublisher::new(publisher_config(), Arc::new(writer.clone()));
+
+    let boundary = publisher
+        .promote(vec![BroadcasterBackend::Native], "active_writer_promoted")
+        .await?;
+
+    assert_eq!(boundary.stream_key, "dsolver:broadcaster:test:events");
+    assert_eq!(boundary.stream_id, "chain-1-stream-1");
+    assert_eq!(boundary.snapshot_id, "chain-1-snapshot-1");
+    assert_eq!(boundary.generation, 1);
+    assert_eq!(boundary.exclusive_message_seq, 1);
+    assert_eq!(boundary.exclusive_entry_id(), "1-1");
+
+    let marker = writer
+        .appends()
+        .await
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow!("promotion should append a generation marker"))?;
+    assert_eq!(marker.entry.stream_id, "chain-1-stream-1");
+    assert_eq!(marker.entry.message_seq, 1);
+    assert_eq!(marker.entry.kind, BroadcasterMessageKind::Progress);
+
+    let update = raw_cache
+        .apply_update(&update(BroadcasterBackend::Native, 11, "native-2"))
+        .await?;
+    publisher
+        .publish_accepted_payload(BroadcasterPayload::Update(update))
+        .await?;
+
+    let appends = writer.appends().await;
+    assert_eq!(
+        appends
+            .iter()
+            .map(|append| append.entry.message_seq)
+            .collect::<Vec<_>>(),
+        vec![1, 2]
+    );
+    assert_eq!(publisher.status_snapshot().await.mode, "active");
+    Ok(())
+}
+
+#[tokio::test]
+async fn second_promoted_writer_fences_old_writer_before_append() -> Result<()> {
+    let raw_cache = ready_cache(BroadcasterBackend::Native, 10, "native-1").await?;
+    let writer = FakeRedisWriter::default();
+    let old = BroadcasterRedisPublisher::new(publisher_config(), Arc::new(writer.clone()));
+    let new = BroadcasterRedisPublisher::new(publisher_config(), Arc::new(writer.clone()));
+    old.promote(vec![BroadcasterBackend::Native], "old_active")
+        .await?;
+
+    new.promote(vec![BroadcasterBackend::Native], "new_active")
+        .await?;
+    let stale_update = raw_cache
+        .apply_update(&update(BroadcasterBackend::Native, 11, "native-2"))
+        .await?;
+    let Err(error) = old
+        .publish_accepted_payload(BroadcasterPayload::Update(stale_update))
+        .await
+    else {
+        return Err(anyhow!("old writer append should be fenced"));
+    };
+
+    assert!(
+        format!("{error:#}").contains("stale Redis broadcaster writer"),
+        "unexpected stale-writer error: {error:#}"
+    );
+    assert_eq!(old.status_snapshot().await.mode, "retired");
+    assert_eq!(
+        writer
+            .appends()
+            .await
+            .iter()
+            .map(|append| (append.entry.stream_id.clone(), append.entry.message_seq))
+            .collect::<Vec<_>>(),
+        vec![
+            ("chain-1-stream-1".to_string(), 1),
+            ("chain-1-stream-2".to_string(), 1)
+        ],
+        "the fenced writer must not append its stale update"
+    );
+
+    let active_update = raw_cache
+        .apply_update(&update(BroadcasterBackend::Native, 12, "native-3"))
+        .await?;
+    new.publish_accepted_payload(BroadcasterPayload::Update(active_update))
+        .await?;
+    let appends = writer.appends().await;
+    assert_eq!(
+        appends.last().map(|append| append.entry.message_seq),
+        Some(2)
+    );
+    assert_eq!(
+        appends.last().map(|append| append.entry.stream_id.as_str()),
+        Some("chain-1-stream-2")
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn lease_loss_retires_active_writer_without_appending() -> Result<()> {
+    let raw_cache = ready_cache(BroadcasterBackend::Native, 10, "native-1").await?;
+    let writer = FakeRedisWriter::default();
+    let publisher = BroadcasterRedisPublisher::new(publisher_config(), Arc::new(writer.clone()));
+    publisher
+        .promote(vec![BroadcasterBackend::Native], "active_writer_promoted")
+        .await?;
+    writer.expire_active_writer().await;
+
+    let update = raw_cache
+        .apply_update(&update(BroadcasterBackend::Native, 11, "native-2"))
+        .await?;
+    let Err(error) = publisher
+        .publish_accepted_payload(BroadcasterPayload::Update(update))
+        .await
+    else {
+        return Err(anyhow!(
+            "lost writer lease should fence the active publisher"
+        ));
+    };
+
+    assert!(format!("{error:#}").contains("stale Redis broadcaster writer"));
+    assert_eq!(publisher.status_snapshot().await.mode, "retired");
+    assert_eq!(writer.appends().await.len(), 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn retired_publisher_does_not_run_generation_reset() -> Result<()> {
+    let writer = FakeRedisWriter::default();
+    let old = BroadcasterRedisPublisher::new(publisher_config(), Arc::new(writer.clone()));
+    let new = BroadcasterRedisPublisher::new(publisher_config(), Arc::new(writer.clone()));
+    old.promote(vec![BroadcasterBackend::Native], "old_active")
+        .await?;
+    new.promote(vec![BroadcasterBackend::Native], "new_active")
+        .await?;
+    writer.expire_active_writer().await;
+    let _ = old.renew_lease().await;
+
+    let _ = old
+        .reset_generation_boundary(
+            "shared broadcaster generation reset",
+            vec![BroadcasterBackend::Native],
+        )
+        .await;
+
+    assert_eq!(old.status_snapshot().await.mode, "retired");
+    assert_eq!(
+        writer.appends().await.len(),
+        2,
+        "retired publishers must not append reset markers"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn stale_active_writer_cannot_return_replay_boundary_after_new_promotion() -> Result<()> {
+    let writer = FakeRedisWriter::default();
+    let old = BroadcasterRedisPublisher::new(publisher_config(), Arc::new(writer.clone()));
+    let new = BroadcasterRedisPublisher::new(publisher_config(), Arc::new(writer.clone()));
+    old.promote(vec![BroadcasterBackend::Native], "old_active")
+        .await?;
+    new.promote(vec![BroadcasterBackend::Native], "new_active")
+        .await?;
+
+    let Err(error) = old.replay_boundary().await else {
+        return Err(anyhow!("stale old writer must not serve a replay boundary"));
+    };
+
+    assert!(format!("{error:#}").contains("stale Redis broadcaster writer"));
+    assert_eq!(old.status_snapshot().await.mode, "retired");
+    assert_eq!(
+        writer.appends().await.len(),
+        2,
+        "replay-boundary fencing must not append Redis entries"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn stale_active_writer_cannot_reset_generation_or_repromote() -> Result<()> {
+    let writer = FakeRedisWriter::default();
+    let old = BroadcasterRedisPublisher::new(publisher_config(), Arc::new(writer.clone()));
+    let new = BroadcasterRedisPublisher::new(publisher_config(), Arc::new(writer.clone()));
+    old.promote(vec![BroadcasterBackend::Native], "old_active")
+        .await?;
+    new.promote(vec![BroadcasterBackend::Native], "new_active")
+        .await?;
+
+    let Err(error) = old
+        .reset_generation_boundary(
+            "shared broadcaster generation reset",
+            vec![BroadcasterBackend::Native],
+        )
+        .await
+    else {
+        return Err(anyhow!(
+            "stale old writer must not reset or re-promote a writer generation"
+        ));
+    };
+
+    assert!(format!("{error:#}").contains("stale Redis broadcaster writer"));
+    assert_eq!(old.status_snapshot().await.mode, "retired");
+    assert_eq!(
+        writer
+            .appends()
+            .await
+            .iter()
+            .map(|append| (append.entry.stream_id.clone(), append.entry.message_seq))
+            .collect::<Vec<_>>(),
+        vec![
+            ("chain-1-stream-1".to_string(), 1),
+            ("chain-1-stream-2".to_string(), 1)
+        ],
+        "stale reset must not append a new generation marker"
+    );
+    Ok(())
+}
+
+#[test]
+fn promotion_lua_stores_gsub_result_before_table_insert() {
+    assert!(
+        super::PROMOTE_WRITER_SCRIPT.contains("local value = string.gsub"),
+        "Lua string.gsub returns value and replacement count; promotion must store only the value"
+    );
+    assert!(
+        !super::PROMOTE_WRITER_SCRIPT.contains("table.insert(command, string.gsub"),
+        "passing string.gsub directly to table.insert expands both Lua return values"
+    );
+}
+
+#[test]
+fn publisher_modes_serialize_as_stable_lowercase_strings() {
+    assert_eq!(BroadcasterRedisPublisherMode::Passive.as_str(), "passive");
+    assert_eq!(BroadcasterRedisPublisherMode::Active.as_str(), "active");
+    assert_eq!(BroadcasterRedisPublisherMode::Retired.as_str(), "retired");
+    assert_eq!(
+        BroadcasterRedisPublisherMode::Unhealthy.as_str(),
+        "unhealthy"
+    );
+}
+
+#[tokio::test]
 async fn replay_boundary_starts_before_first_delta_without_publishing_snapshot() -> Result<()> {
     let writer = FakeRedisWriter::default();
-    let publisher = BroadcasterRedisPublisher::new_with_initial_generation(
-        publisher_config(),
-        Arc::new(writer.clone()),
-        1,
-    );
+    let publisher = BroadcasterRedisPublisher::new(publisher_config(), Arc::new(writer.clone()));
+    publisher
+        .promote(vec![BroadcasterBackend::Native], "active_writer_promoted")
+        .await?;
 
     let boundary = publisher.replay_boundary().await?;
 
@@ -107,10 +377,14 @@ async fn replay_boundary_starts_before_first_delta_without_publishing_snapshot()
     assert_eq!(boundary.stream_id, "chain-1-stream-1");
     assert_eq!(boundary.snapshot_id, "chain-1-snapshot-1");
     assert_eq!(boundary.generation, 1);
-    assert_eq!(boundary.exclusive_message_seq, 0);
-    assert_eq!(boundary.exclusive_entry_id(), "1-0");
+    assert_eq!(boundary.exclusive_message_seq, 1);
+    assert_eq!(boundary.exclusive_entry_id(), "1-1");
     assert!(
-        writer.appends().await.is_empty(),
+        writer
+            .appends()
+            .await
+            .iter()
+            .all(|append| append.entry.kind == BroadcasterMessageKind::Progress),
         "HTTP snapshots are the bootstrap source; Redis must not receive full snapshot entries"
     );
     Ok(())
@@ -121,11 +395,13 @@ async fn publishes_live_updates_and_heartbeats_as_deltas_after_replay_boundary()
     let raw_cache = ready_cache(BroadcasterBackend::Native, 10, "native-1").await?;
     let rfq_cache = ready_cache(BroadcasterBackend::Rfq, 20, "rfq-1").await?;
     let writer = FakeRedisWriter::default();
-    let publisher = BroadcasterRedisPublisher::new_with_initial_generation(
-        publisher_config(),
-        Arc::new(writer.clone()),
-        1,
-    );
+    let publisher = BroadcasterRedisPublisher::new(publisher_config(), Arc::new(writer.clone()));
+    publisher
+        .promote(
+            vec![BroadcasterBackend::Native, BroadcasterBackend::Rfq],
+            "active_writer_promoted",
+        )
+        .await?;
     let boundary = publisher.replay_boundary().await?;
 
     let native_update = raw_cache
@@ -152,19 +428,20 @@ async fn publishes_live_updates_and_heartbeats_as_deltas_after_replay_boundary()
             .iter()
             .map(|append| append.entry.message_seq)
             .collect::<Vec<_>>(),
-        vec![1, 2, 3]
+        vec![1, 2, 3, 4]
     );
-    assert_eq!(appends[0].entry.kind.as_str(), "update");
-    assert_eq!(appends[0].entry.backend_scope, "native");
-    assert_eq!(appends[0].entry.block_number, Some(11));
+    assert_eq!(appends[0].entry.kind.as_str(), "progress");
     assert_eq!(appends[1].entry.kind.as_str(), "update");
-    assert_eq!(appends[1].entry.backend_scope, "rfq");
-    assert_eq!(appends[1].entry.block_number, None);
-    assert_eq!(appends[2].entry.kind.as_str(), "heartbeat");
-    assert_eq!(appends[2].entry.backend_scope, "native");
-    assert_eq!(appends[2].entry.stream_id, boundary.stream_id);
+    assert_eq!(appends[1].entry.backend_scope, "native");
+    assert_eq!(appends[1].entry.block_number, Some(11));
+    assert_eq!(appends[2].entry.kind.as_str(), "update");
+    assert_eq!(appends[2].entry.backend_scope, "rfq");
+    assert_eq!(appends[2].entry.block_number, None);
+    assert_eq!(appends[3].entry.kind.as_str(), "heartbeat");
+    assert_eq!(appends[3].entry.backend_scope, "native");
+    assert_eq!(appends[3].entry.stream_id, boundary.stream_id);
     assert_eq!(
-        appends[2].entry.snapshot_id.as_deref(),
+        appends[3].entry.snapshot_id.as_deref(),
         Some(boundary.snapshot_id.as_str())
     );
     Ok(())
@@ -175,11 +452,10 @@ async fn append_retry_success_preserves_message_sequence_order() -> Result<()> {
     let raw_cache = ready_cache(BroadcasterBackend::Native, 10, "native-1").await?;
     let writer = FakeRedisWriter::default();
     writer.fail_next_appends(1).await;
-    let publisher = BroadcasterRedisPublisher::new_with_initial_generation(
-        publisher_config(),
-        Arc::new(writer.clone()),
-        1,
-    );
+    let publisher = BroadcasterRedisPublisher::new(publisher_config(), Arc::new(writer.clone()));
+    publisher
+        .promote(vec![BroadcasterBackend::Native], "active_writer_promoted")
+        .await?;
 
     let update = raw_cache
         .apply_update(&update(BroadcasterBackend::Native, 11, "native-2"))
@@ -195,9 +471,9 @@ async fn append_retry_success_preserves_message_sequence_order() -> Result<()> {
             .iter()
             .map(|append| append.entry.message_seq)
             .collect::<Vec<_>>(),
-        vec![1]
+        vec![1, 2]
     );
-    assert_eq!(appends[0].entry.kind.as_str(), "update");
+    assert_eq!(appends[1].entry.kind.as_str(), "update");
     Ok(())
 }
 
@@ -206,11 +482,10 @@ async fn readiness_triggering_update_is_published_as_a_delta() -> Result<()> {
     let rfq_cache =
         BroadcasterSnapshotCache::new(Chain::Ethereum.id(), vec![BroadcasterBackend::Rfq]);
     let writer = FakeRedisWriter::default();
-    let publisher = BroadcasterRedisPublisher::new_with_initial_generation(
-        publisher_config(),
-        Arc::new(writer.clone()),
-        1,
-    );
+    let publisher = BroadcasterRedisPublisher::new(publisher_config(), Arc::new(writer.clone()));
+    publisher
+        .promote(vec![BroadcasterBackend::Rfq], "active_writer_promoted")
+        .await?;
     let rfq_update = rfq_cache
         .apply_update(&update(BroadcasterBackend::Rfq, 20, "rfq-1"))
         .await?;
@@ -220,9 +495,9 @@ async fn readiness_triggering_update_is_published_as_a_delta() -> Result<()> {
         .await?;
 
     let appends = writer.appends().await;
-    assert_eq!(appends.len(), 1);
-    assert_eq!(appends[0].entry.kind.as_str(), "update");
-    assert_eq!(appends[0].entry.backend_scope, "rfq");
+    assert_eq!(appends.len(), 2);
+    assert_eq!(appends[1].entry.kind.as_str(), "update");
+    assert_eq!(appends[1].entry.backend_scope, "rfq");
     Ok(())
 }
 
@@ -230,12 +505,11 @@ async fn readiness_triggering_update_is_published_as_a_delta() -> Result<()> {
 async fn retry_exhaustion_marks_unhealthy_until_generation_reset() -> Result<()> {
     let raw_cache = ready_cache(BroadcasterBackend::Native, 10, "native-1").await?;
     let writer = FakeRedisWriter::default();
+    let publisher = BroadcasterRedisPublisher::new(publisher_config(), Arc::new(writer.clone()));
+    publisher
+        .promote(vec![BroadcasterBackend::Native], "active_writer_promoted")
+        .await?;
     writer.fail_next_appends(100).await;
-    let publisher = BroadcasterRedisPublisher::new_with_initial_generation(
-        publisher_config(),
-        Arc::new(writer.clone()),
-        1,
-    );
 
     let failed_update = raw_cache
         .apply_update(&update(BroadcasterBackend::Native, 11, "native-2"))
@@ -279,16 +553,16 @@ async fn retry_exhaustion_marks_unhealthy_until_generation_reset() -> Result<()>
     assert!(format!("{error:#}").contains("publisher is unhealthy"));
     assert_eq!(
         writer.appends().await.len(),
-        0,
+        1,
         "a blocked publisher must not append into a Redis-only generation"
     );
 
     publisher
-        .reset_generation(
+        .reset_generation_boundary(
             "shared broadcaster generation reset",
             vec![BroadcasterBackend::Native],
         )
-        .await;
+        .await?;
     let reset_status = publisher.status_snapshot().await;
     assert!(reset_status.healthy);
     assert_eq!(reset_status.generation_reset_count, 1);
@@ -342,11 +616,10 @@ async fn stalled_append_exhausts_retry_window() -> Result<()> {
     let raw_cache = ready_cache(BroadcasterBackend::Native, 10, "native-1").await?;
     let writer = FakeRedisWriter::default();
     writer.delay_appends(Duration::from_millis(50)).await;
-    let publisher = BroadcasterRedisPublisher::new_with_initial_generation(
-        publisher_config(),
-        Arc::new(writer.clone()),
-        1,
-    );
+    let publisher = BroadcasterRedisPublisher::new(publisher_config(), Arc::new(writer.clone()));
+    publisher
+        .promote(vec![BroadcasterBackend::Native], "active_writer_promoted")
+        .await?;
 
     let update = raw_cache
         .apply_update(&update(BroadcasterBackend::Native, 11, "native-2"))
@@ -365,7 +638,7 @@ async fn stalled_append_exhausts_retry_window() -> Result<()> {
     assert_eq!(failed_status.generation_reset_count, 0);
     assert_eq!(failed_status.retry_exhaustion_count, 1);
     assert!(failed_status.replay_boundary.is_none());
-    assert!(writer.appends().await.is_empty());
+    assert_eq!(writer.appends().await.len(), 1);
     Ok(())
 }
 
@@ -373,11 +646,10 @@ async fn stalled_append_exhausts_retry_window() -> Result<()> {
 async fn publish_rejects_message_sequence_overflow() -> Result<()> {
     let raw_cache = ready_cache(BroadcasterBackend::Native, 10, "native-1").await?;
     let writer = FakeRedisWriter::default();
-    let publisher = BroadcasterRedisPublisher::new_with_initial_generation(
-        publisher_config(),
-        Arc::new(writer.clone()),
-        1,
-    );
+    let publisher = BroadcasterRedisPublisher::new(publisher_config(), Arc::new(writer.clone()));
+    publisher
+        .promote(vec![BroadcasterBackend::Native], "active_writer_promoted")
+        .await?;
     publisher.inner.lock().await.next_message_seq = u64::MAX;
 
     let update = raw_cache
@@ -394,7 +666,7 @@ async fn publish_rejects_message_sequence_overflow() -> Result<()> {
     let failed_status = publisher.status_snapshot().await;
     assert!(!failed_status.healthy);
     assert_eq!(failed_status.retry_exhaustion_count, 0);
-    assert!(writer.appends().await.is_empty());
+    assert_eq!(writer.appends().await.len(), 1);
     Ok(())
 }
 
@@ -415,39 +687,6 @@ fn redis_entry_id_uses_generation_and_message_sequence() -> Result<()> {
     };
 
     assert_eq!(redis_entry_id(&entry)?, "42-7");
-    Ok(())
-}
-
-#[test]
-fn next_generation_starts_after_retained_redis_stream_top() -> Result<()> {
-    assert_eq!(next_generation_after_entry_id("42-7")?, 43);
-    assert_eq!(next_generation_after_entry_id("0-0")?, 1);
-    assert!(next_generation_after_entry_id("not-an-entry-id").is_err());
-    Ok(())
-}
-
-#[test]
-fn redis_xadd_command_uses_configured_maxlen() -> Result<()> {
-    let entry = BroadcasterRedisStreamEntry {
-        schema_version: "1".to_string(),
-        chain_id: Chain::Ethereum.id(),
-        stream_id: "chain-1-stream-42".to_string(),
-        message_seq: 7,
-        kind: simulator_core::broadcaster::BroadcasterMessageKind::Update,
-        snapshot_id: None,
-        backend_scope: "native".to_string(),
-        block_number: Some(11),
-        observed_timestamp_ms: None,
-        event_time_ms: 1_710_000_000_123,
-        payload_json: "{}".to_string(),
-    };
-
-    let command = redis_xadd_command("stream:test", Some(1_000), &entry)?;
-    let packed = String::from_utf8(command.get_packed_command())?;
-
-    assert!(packed.contains("MAXLEN"));
-    assert!(packed.contains("\r\n~\r\n"));
-    assert!(packed.contains("\r\n1000\r\n"));
     Ok(())
 }
 
@@ -542,6 +781,9 @@ struct FakeRedisWriter {
 #[derive(Debug, Default)]
 struct FakeRedisWriterState {
     appends: Vec<CapturedAppend>,
+    active_token: Option<String>,
+    active_generation: u64,
+    lease_expired: bool,
     fail_next_appends: usize,
     append_delay: Option<Duration>,
     append_attempt_count: usize,
@@ -563,14 +805,55 @@ impl FakeRedisWriter {
     async fn appends(&self) -> Vec<CapturedAppend> {
         self.inner.lock().await.appends.clone()
     }
+
+    async fn expire_active_writer(&self) {
+        let mut guard = self.inner.lock().await;
+        guard.active_token = None;
+        guard.lease_expired = true;
+    }
 }
 
 impl RedisStreamWriter for FakeRedisWriter {
-    fn append<'a>(
+    fn promote<'a>(
         &'a self,
-        _stream_key: &'a str,
-        _maxlen: Option<u64>,
-        entry: &'a BroadcasterRedisStreamEntry,
+        command: super::RedisPromotionCommand<'a>,
+    ) -> futures::future::BoxFuture<'a, Result<super::RedisPromotionResult>> {
+        Box::pin(async move {
+            let mut guard = self.inner.lock().await;
+            if let Some(expected_token) = command.expected_writer_token {
+                if guard.lease_expired {
+                    return Err(anyhow!("stale Redis broadcaster writer token"));
+                }
+                if guard.active_token.is_some()
+                    && (guard.active_token.as_deref() != Some(expected_token)
+                        || Some(guard.active_generation) != command.expected_generation)
+                {
+                    return Err(anyhow!("stale Redis broadcaster writer token"));
+                }
+                if guard.active_token.is_none() {
+                    guard.active_generation = guard
+                        .active_generation
+                        .max(command.expected_generation.unwrap_or_default());
+                }
+            }
+            guard.active_generation = guard.active_generation.saturating_add(1);
+            guard.active_token = Some(command.writer_token.to_string());
+            guard.lease_expired = false;
+            let generation = guard.active_generation;
+            let entry_id = format!("{generation}-1");
+            guard.appends.push(CapturedAppend {
+                entry: entry_from_fields(command.marker_fields, generation)?,
+            });
+            Ok(super::RedisPromotionResult {
+                generation,
+                entry_id,
+            })
+        })
+    }
+
+    fn append_fenced<'a>(
+        &'a self,
+        command: super::RedisAppendCommand<'a>,
     ) -> futures::future::BoxFuture<'a, Result<String>> {
         Box::pin(async move {
             let delay = self.inner.lock().await.append_delay;
@@ -579,17 +862,57 @@ impl RedisStreamWriter for FakeRedisWriter {
             }
             let mut guard = self.inner.lock().await;
             guard.append_attempt_count = guard.append_attempt_count.saturating_add(1);
+            if guard.lease_expired
+                || (guard.active_token.is_some()
+                    && (guard.active_token.as_deref() != Some(command.writer_token)
+                        || guard.active_generation != command.generation))
+            {
+                return Err(anyhow!("stale Redis broadcaster writer token"));
+            }
             if guard.fail_next_appends > 0 {
                 guard.fail_next_appends -= 1;
                 return Err(anyhow!("planned append failure"));
             }
-            let entry_id = format!("1000-{}", guard.appends.len());
+            let entry_id = redis_entry_id(command.entry)?;
             guard.appends.push(CapturedAppend {
-                entry: entry.clone(),
+                entry: command.entry.clone(),
             });
             Ok(entry_id)
         })
     }
+
+    fn renew_writer<'a>(
+        &'a self,
+        command: super::RedisRenewCommand<'a>,
+    ) -> futures::future::BoxFuture<'a, Result<()>> {
+        Box::pin(async move {
+            let guard = self.inner.lock().await;
+            if guard.lease_expired
+                || (guard.active_token.is_some()
+                    && (guard.active_token.as_deref() != Some(command.writer_token)
+                        || guard.active_generation != command.generation))
+            {
+                return Err(anyhow!("stale Redis broadcaster writer token"));
+            }
+            Ok(())
+        })
+    }
+}
+
+fn entry_from_fields(
+    fields: &[(String, String)],
+    generation: u64,
+) -> Result<BroadcasterRedisStreamEntry> {
+    let mut value = serde_json::Map::new();
+    for (field, field_value) in fields {
+        value.insert(
+            field.clone(),
+            serde_json::Value::String(
+                field_value.replace(super::GENERATION_PLACEHOLDER, &generation.to_string()),
+            ),
+        );
+    }
+    serde_json::from_value(serde_json::Value::Object(value)).map_err(Into::into)
 }
 
 async fn ready_cache(

--- a/crates/runtime/src/broadcaster/redis_publisher/tests.rs
+++ b/crates/runtime/src/broadcaster/redis_publisher/tests.rs
@@ -19,8 +19,8 @@ use tycho_simulation::tycho_common::Bytes;
 
 use super::{
     redis_entry_fields, redis_entry_id, redis_stream_entry_matches_reply,
-    BroadcasterRedisPublisher, BroadcasterRedisPublisherConfig, BroadcasterRedisPublisherMode,
-    RedisStreamWriter,
+    writer_lease_ttl_for_heartbeat_interval, BroadcasterRedisPublisher,
+    BroadcasterRedisPublisherConfig, BroadcasterRedisPublisherMode, RedisStreamWriter,
 };
 use crate::broadcaster::state::BroadcasterSnapshotCache;
 use simulator_core::broadcaster::{
@@ -249,6 +249,37 @@ async fn lease_loss_retires_active_writer_without_appending() -> Result<()> {
 }
 
 #[tokio::test]
+async fn configured_writer_lease_ttl_is_used_for_all_fenced_writer_commands() -> Result<()> {
+    let raw_cache = ready_cache(BroadcasterBackend::Native, 10, "native-1").await?;
+    let writer = FakeRedisWriter::default();
+    let mut config = publisher_config();
+    config.writer_lease_ttl = Duration::from_secs(180);
+    let publisher = BroadcasterRedisPublisher::new(config, Arc::new(writer.clone()));
+
+    publisher
+        .promote(vec![BroadcasterBackend::Native], "active_writer_promoted")
+        .await?;
+
+    let update = raw_cache
+        .apply_update(&update(BroadcasterBackend::Native, 11, "native-2"))
+        .await?;
+    publisher
+        .publish_accepted_payload(BroadcasterPayload::Update(update))
+        .await?;
+    publisher.renew_lease().await?;
+
+    assert_eq!(
+        writer.lease_ttls().await,
+        vec![
+            Duration::from_secs(180),
+            Duration::from_secs(180),
+            Duration::from_secs(180)
+        ]
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn retired_publisher_does_not_run_generation_reset() -> Result<()> {
     let writer = FakeRedisWriter::default();
     let old = BroadcasterRedisPublisher::new(publisher_config(), Arc::new(writer.clone()));
@@ -360,6 +391,18 @@ fn publisher_modes_serialize_as_stable_lowercase_strings() {
     assert_eq!(
         BroadcasterRedisPublisherMode::Unhealthy.as_str(),
         "unhealthy"
+    );
+}
+
+#[test]
+fn writer_lease_ttl_keeps_a_margin_over_the_heartbeat_interval() {
+    assert_eq!(
+        writer_lease_ttl_for_heartbeat_interval(Duration::from_secs(5)),
+        Duration::from_secs(30)
+    );
+    assert_eq!(
+        writer_lease_ttl_for_heartbeat_interval(Duration::from_secs(60)),
+        Duration::from_secs(180)
     );
 }
 
@@ -784,6 +827,7 @@ struct FakeRedisWriterState {
     active_token: Option<String>,
     active_generation: u64,
     lease_expired: bool,
+    lease_ttls: Vec<Duration>,
     fail_next_appends: usize,
     append_delay: Option<Duration>,
     append_attempt_count: usize,
@@ -806,6 +850,10 @@ impl FakeRedisWriter {
         self.inner.lock().await.appends.clone()
     }
 
+    async fn lease_ttls(&self) -> Vec<Duration> {
+        self.inner.lock().await.lease_ttls.clone()
+    }
+
     async fn expire_active_writer(&self) {
         let mut guard = self.inner.lock().await;
         guard.active_token = None;
@@ -820,6 +868,7 @@ impl RedisStreamWriter for FakeRedisWriter {
     ) -> futures::future::BoxFuture<'a, Result<super::RedisPromotionResult>> {
         Box::pin(async move {
             let mut guard = self.inner.lock().await;
+            guard.lease_ttls.push(command.lease_ttl);
             if let Some(expected_token) = command.expected_writer_token {
                 if guard.lease_expired {
                     return Err(anyhow!("stale Redis broadcaster writer token"));
@@ -862,6 +911,7 @@ impl RedisStreamWriter for FakeRedisWriter {
             }
             let mut guard = self.inner.lock().await;
             guard.append_attempt_count = guard.append_attempt_count.saturating_add(1);
+            guard.lease_ttls.push(command.lease_ttl);
             if guard.lease_expired
                 || (guard.active_token.is_some()
                     && (guard.active_token.as_deref() != Some(command.writer_token)
@@ -886,7 +936,8 @@ impl RedisStreamWriter for FakeRedisWriter {
         command: super::RedisRenewCommand<'a>,
     ) -> futures::future::BoxFuture<'a, Result<()>> {
         Box::pin(async move {
-            let guard = self.inner.lock().await;
+            let mut guard = self.inner.lock().await;
+            guard.lease_ttls.push(command.lease_ttl);
             if guard.lease_expired
                 || (guard.active_token.is_some()
                     && (guard.active_token.as_deref() != Some(command.writer_token)
@@ -992,5 +1043,6 @@ fn publisher_config() -> BroadcasterRedisPublisherConfig {
         chain_id: Chain::Ethereum.id(),
         append_retry_window: Duration::from_millis(10),
         maxlen: None,
+        writer_lease_ttl: Duration::from_secs(30),
     }
 }

--- a/crates/runtime/src/broadcaster/service.rs
+++ b/crates/runtime/src/broadcaster/service.rs
@@ -1673,6 +1673,7 @@ mod tests {
             chain_id: Chain::Ethereum.id(),
             append_retry_window: Duration::from_millis(10),
             maxlen: None,
+            writer_lease_ttl: Duration::from_secs(30),
         }
     }
 

--- a/crates/runtime/src/broadcaster/service.rs
+++ b/crates/runtime/src/broadcaster/service.rs
@@ -12,7 +12,9 @@ use tycho_simulation::{
     tycho_client::feed::{BlockHeader, FeedMessage},
 };
 
-use crate::broadcaster::redis_publisher::BroadcasterRedisPublisher;
+use crate::broadcaster::redis_publisher::{
+    BroadcasterRedisPublisher, BroadcasterRedisPublisherMode,
+};
 use crate::broadcaster::state::{
     combine_snapshot_exports, BroadcasterReadiness, BroadcasterSnapshotCache,
     BroadcasterSnapshotExport, BroadcasterSnapshotSessionsSnapshot, BroadcasterStatusSnapshot,
@@ -269,6 +271,7 @@ impl BroadcasterServiceState {
         );
         let reason = reason.into();
         let _gate = services[0].lifecycle_gate.lock().await;
+        let publisher_mode = services[0].redis_publisher.mode().await;
         let mut reset_backends = Vec::new();
         for service in services {
             service
@@ -279,15 +282,82 @@ impl BroadcasterServiceState {
                 .snapshot_sessions
                 .disconnect_all(SessionCloseReason::GenerationReset)
                 .await;
-            reset_backends.extend(service.cache.configured_backends());
-            service.cache.reset_generation().await;
+            if publisher_mode != BroadcasterRedisPublisherMode::Retired {
+                reset_backends.extend(service.cache.configured_backends());
+            }
+        }
+        if publisher_mode == BroadcasterRedisPublisherMode::Retired {
+            return;
         }
         reset_backends.sort();
         reset_backends.dedup();
-        services[0]
+        let boundary = match services[0]
             .redis_publisher
-            .reset_generation(reason, reset_backends)
-            .await;
+            .reset_generation_boundary(reason, reset_backends)
+            .await
+        {
+            Ok(boundary) => boundary,
+            Err(error) => {
+                warn!(
+                    error = %error,
+                    "Skipping broadcaster cache reset because Redis generation reset failed"
+                );
+                return;
+            }
+        };
+        for service in services {
+            service.cache.reset_to_generation(boundary.generation).await;
+        }
+    }
+
+    pub async fn promote_when_ready(
+        services: &[Self],
+        reason: impl Into<String>,
+    ) -> Result<Option<BroadcasterRedisReplayBoundary>> {
+        anyhow::ensure!(
+            !services.is_empty(),
+            "broadcaster promotion requires at least one service"
+        );
+        ensure_shared_lifecycle(services, "broadcaster promotion")?;
+
+        let _gate = services[0].lifecycle_gate.lock().await;
+        match services[0].redis_publisher.mode().await {
+            BroadcasterRedisPublisherMode::Active => {
+                return services[0]
+                    .redis_publisher
+                    .replay_boundary()
+                    .await
+                    .map(Some);
+            }
+            BroadcasterRedisPublisherMode::Passive => {}
+            BroadcasterRedisPublisherMode::Retired | BroadcasterRedisPublisherMode::Unhealthy => {
+                return Ok(None);
+            }
+        }
+
+        for service in services {
+            let status = service.status_snapshot().await;
+            if status.readiness != BroadcasterReadiness::Ready {
+                return Ok(None);
+            }
+        }
+
+        // The process has warmed every configured cache. Promotion is the point
+        // where that local state becomes the active snapshot generation.
+        let mut backends = services
+            .iter()
+            .flat_map(|service| service.cache.configured_backends())
+            .collect::<Vec<_>>();
+        backends.sort();
+        backends.dedup();
+        let boundary = services[0]
+            .redis_publisher
+            .promote(backends, reason)
+            .await?;
+        for service in services {
+            service.cache.relabel_generation(boundary.generation).await;
+        }
+        Ok(Some(boundary))
     }
 
     pub async fn apply_update(&self, update: &TychoUpdate) -> Result<()> {
@@ -314,6 +384,8 @@ impl BroadcasterServiceState {
         let _gate = self.lifecycle_gate.lock().await;
         if let Some(heartbeat) = self.cache.heartbeat().await? {
             self.publish_to_redis(heartbeat).await?;
+        } else {
+            self.redis_publisher.renew_lease().await?;
         }
         self.snapshot_sessions
             .cleanup_expired_snapshot_sessions()
@@ -367,6 +439,8 @@ impl BroadcasterServiceState {
             anyhow::anyhow!("combined broadcaster snapshot session missing chain_id")
         })?;
         let snapshot = combine_snapshot_exports(chain_id, exports)?;
+        // Snapshot export and replay-boundary capture have to describe the same
+        // active writer. Passive or stale writers fail closed here.
         let redis_replay_boundary = match services[0].redis_publisher.replay_boundary().await {
             Ok(boundary) => boundary,
             Err(error) => {
@@ -390,6 +464,16 @@ impl BroadcasterServiceState {
         session_id: u64,
         index: u32,
     ) -> Result<BroadcasterEnvelope, SnapshotSessionError> {
+        if let Err(error) = self.redis_publisher.verify_active_writer().await {
+            warn!(
+                error = %error,
+                "Refusing broadcaster snapshot payload without active Redis writer fence"
+            );
+            self.snapshot_sessions
+                .disconnect_all(SessionCloseReason::GenerationReset)
+                .await;
+            return Err(SnapshotSessionError::NotFound);
+        }
         self.snapshot_sessions
             .snapshot_payload(session_id, index)
             .await
@@ -406,7 +490,8 @@ impl BroadcasterServiceState {
     }
 
     async fn publish_to_redis(&self, payload: BroadcasterPayload) -> Result<()> {
-        self.redis_publisher
+        let result = self
+            .redis_publisher
             .publish_accepted_payload(payload)
             .await
             .inspect_err(|error| {
@@ -415,8 +500,15 @@ impl BroadcasterServiceState {
                     error = %error,
                     "Redis broadcaster publication failed"
                 );
-            })
-            .context("failed to publish accepted broadcaster delta to Redis")
+            });
+        if result.is_err()
+            && self.redis_publisher.mode().await == BroadcasterRedisPublisherMode::Retired
+        {
+            self.snapshot_sessions
+                .disconnect_all(SessionCloseReason::GenerationReset)
+                .await;
+        }
+        result.context("failed to publish accepted broadcaster delta to Redis")
     }
 
     #[cfg(test)]
@@ -541,6 +633,291 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn passive_service_warms_cache_without_redis_appends_or_snapshot_sessions() -> Result<()>
+    {
+        let cache = BroadcasterSnapshotCache::new(1, vec![BroadcasterBackend::Native]);
+        let writer = ServiceFakeRedisWriter::default();
+        let publisher = Arc::new(BroadcasterRedisPublisher::new(
+            publisher_config(),
+            Arc::new(writer.clone()),
+        ));
+        let service = BroadcasterServiceState::with_lifecycle_gate(
+            8_388_608,
+            cache,
+            BroadcasterUpstreamState::default(),
+            publisher,
+            Arc::new(Mutex::new(())),
+        );
+        service.mark_upstream_connected().await;
+
+        service
+            .apply_update(&native_only_update(10, "native-1"))
+            .await?;
+
+        let status = service.status_snapshot().await;
+        assert!(status.snapshot.ready);
+        assert_eq!(status.snapshot.total_states, 1);
+        assert!(
+            writer.appends().await.is_empty(),
+            "passive warmup must update only the local cache"
+        );
+        assert!(
+            service
+                .create_snapshot_session(Duration::from_secs(300))
+                .await?
+                .is_none(),
+            "passive publishers must not serve snapshot sessions"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn promotion_preserves_warmed_cache_and_enables_snapshot_sessions() -> Result<()> {
+        let cache = BroadcasterSnapshotCache::new(1, vec![BroadcasterBackend::Native]);
+        let writer = ServiceFakeRedisWriter::default();
+        let publisher = Arc::new(BroadcasterRedisPublisher::new(
+            publisher_config(),
+            Arc::new(writer.clone()),
+        ));
+        let service = BroadcasterServiceState::with_lifecycle_gate(
+            8_388_608,
+            cache,
+            BroadcasterUpstreamState::default(),
+            Arc::clone(&publisher),
+            Arc::new(Mutex::new(())),
+        );
+        service.mark_upstream_connected().await;
+        service
+            .apply_update(&native_only_update(10, "native-1"))
+            .await?;
+
+        let boundary = BroadcasterServiceState::promote_when_ready(
+            std::slice::from_ref(&service),
+            "active_writer_promoted",
+        )
+        .await?
+        .ok_or_else(|| anyhow!("ready passive service should promote"))?;
+
+        assert_eq!(boundary.exclusive_message_seq, 1);
+        let status = service.status_snapshot().await;
+        assert!(status.snapshot.ready);
+        assert_eq!(status.snapshot.total_states, 1);
+        assert_eq!(status.snapshot.stream_id, boundary.stream_id);
+        assert_eq!(status.snapshot.snapshot_id, boundary.snapshot_id);
+        assert_eq!(publisher.status_snapshot().await.mode, "active");
+
+        let session = service
+            .create_snapshot_session(Duration::from_secs(300))
+            .await?
+            .ok_or_else(|| anyhow!("active promoted broadcaster should serve a session"))?;
+        assert_eq!(session.redis_replay_boundary, boundary);
+        assert_eq!(writer.appends().await.len(), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn active_publication_failure_keeps_update_out_of_cache() -> Result<()> {
+        let cache = BroadcasterSnapshotCache::new(1, vec![BroadcasterBackend::Native]);
+        let writer = ServiceFakeRedisWriter::default();
+        let publisher = Arc::new(BroadcasterRedisPublisher::new(
+            publisher_config(),
+            Arc::new(writer.clone()),
+        ));
+        publisher
+            .promote(vec![BroadcasterBackend::Native], "active_writer_promoted")
+            .await?;
+        let service = BroadcasterServiceState::with_lifecycle_gate(
+            8_388_608,
+            cache,
+            BroadcasterUpstreamState::default(),
+            publisher,
+            Arc::new(Mutex::new(())),
+        );
+        service.mark_upstream_connected().await;
+        writer.fail_next_appends(100).await;
+
+        let Err(error) = service
+            .apply_update(&native_only_update(10, "native-1"))
+            .await
+        else {
+            return Err(anyhow!("active service must fail when Redis append fails"));
+        };
+
+        assert!(format!("{error:#}").contains("failed to publish accepted broadcaster delta"));
+        let status = service.status_snapshot().await;
+        assert!(!status.snapshot.ready);
+        assert_eq!(status.snapshot.total_states, 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn retired_service_refuses_updates_without_cache_commit() -> Result<()> {
+        let cache = BroadcasterSnapshotCache::new(1, vec![BroadcasterBackend::Native]);
+        let writer = ServiceFakeRedisWriter::default();
+        let old = Arc::new(BroadcasterRedisPublisher::new(
+            publisher_config(),
+            Arc::new(writer.clone()),
+        ));
+        let new = BroadcasterRedisPublisher::new(publisher_config(), Arc::new(writer.clone()));
+        old.promote(vec![BroadcasterBackend::Native], "old_active")
+            .await?;
+        new.promote(vec![BroadcasterBackend::Native], "new_active")
+            .await?;
+        let service = BroadcasterServiceState::with_lifecycle_gate(
+            8_388_608,
+            cache,
+            BroadcasterUpstreamState::default(),
+            Arc::clone(&old),
+            Arc::new(Mutex::new(())),
+        );
+        service.mark_upstream_connected().await;
+
+        let Err(error) = service
+            .apply_update(&native_only_update(10, "native-1"))
+            .await
+        else {
+            return Err(anyhow!("retired service must refuse accepted updates"));
+        };
+
+        assert!(format!("{error:#}").contains("stale Redis broadcaster writer"));
+        assert_eq!(old.status_snapshot().await.mode, "retired");
+        let status = service.status_snapshot().await;
+        assert_eq!(status.snapshot.total_states, 0);
+        assert!(!status.snapshot.ready);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn retired_service_closes_existing_snapshot_sessions() -> Result<()> {
+        let cache = BroadcasterSnapshotCache::new(1, vec![BroadcasterBackend::Native]);
+        let writer = ServiceFakeRedisWriter::default();
+        let old = Arc::new(BroadcasterRedisPublisher::new(
+            publisher_config(),
+            Arc::new(writer.clone()),
+        ));
+        let new = BroadcasterRedisPublisher::new(publisher_config(), Arc::new(writer));
+        old.promote(vec![BroadcasterBackend::Native], "old_active")
+            .await?;
+        let service = BroadcasterServiceState::with_lifecycle_gate(
+            8_388_608,
+            cache,
+            BroadcasterUpstreamState::default(),
+            Arc::clone(&old),
+            Arc::new(Mutex::new(())),
+        );
+        service.mark_upstream_connected().await;
+        service
+            .apply_update(&native_only_update(10, "native-1"))
+            .await?;
+        let session = service
+            .create_snapshot_session(Duration::from_secs(300))
+            .await?
+            .ok_or_else(|| anyhow!("active service should create a snapshot session"))?;
+
+        new.promote(vec![BroadcasterBackend::Native], "new_active")
+            .await?;
+        let Err(_error) = service
+            .apply_update(&native_only_update(11, "native-2"))
+            .await
+        else {
+            return Err(anyhow!("fenced old service must fail the stale update"));
+        };
+
+        let Err(error) = service
+            .snapshot_session_payload(session.session_id, 0)
+            .await
+        else {
+            return Err(anyhow!(
+                "retired service must not serve old snapshot payloads"
+            ));
+        };
+        assert_eq!(error, SnapshotSessionError::NotFound);
+        assert_eq!(service.status_snapshot().await.snapshot_sessions.active, 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stale_active_service_refuses_new_snapshot_session_before_append_or_heartbeat(
+    ) -> Result<()> {
+        let cache = BroadcasterSnapshotCache::new(1, vec![BroadcasterBackend::Native]);
+        let writer = ServiceFakeRedisWriter::default();
+        let old = Arc::new(BroadcasterRedisPublisher::new(
+            publisher_config(),
+            Arc::new(writer.clone()),
+        ));
+        let new = BroadcasterRedisPublisher::new(publisher_config(), Arc::new(writer));
+        old.promote(vec![BroadcasterBackend::Native], "old_active")
+            .await?;
+        let service = BroadcasterServiceState::with_lifecycle_gate(
+            8_388_608,
+            cache,
+            BroadcasterUpstreamState::default(),
+            Arc::clone(&old),
+            Arc::new(Mutex::new(())),
+        );
+        service.mark_upstream_connected().await;
+        service
+            .apply_update(&native_only_update(10, "native-1"))
+            .await?;
+        new.promote(vec![BroadcasterBackend::Native], "new_active")
+            .await?;
+
+        assert!(
+            service
+                .create_snapshot_session(Duration::from_secs(300))
+                .await?
+                .is_none(),
+            "stale active services must not create snapshot sessions before append fencing"
+        );
+        assert_eq!(old.status_snapshot().await.mode, "retired");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stale_active_service_stops_serving_existing_snapshot_session_before_append_or_heartbeat(
+    ) -> Result<()> {
+        let cache = BroadcasterSnapshotCache::new(1, vec![BroadcasterBackend::Native]);
+        let writer = ServiceFakeRedisWriter::default();
+        let old = Arc::new(BroadcasterRedisPublisher::new(
+            publisher_config(),
+            Arc::new(writer.clone()),
+        ));
+        let new = BroadcasterRedisPublisher::new(publisher_config(), Arc::new(writer));
+        old.promote(vec![BroadcasterBackend::Native], "old_active")
+            .await?;
+        let service = BroadcasterServiceState::with_lifecycle_gate(
+            8_388_608,
+            cache,
+            BroadcasterUpstreamState::default(),
+            Arc::clone(&old),
+            Arc::new(Mutex::new(())),
+        );
+        service.mark_upstream_connected().await;
+        service
+            .apply_update(&native_only_update(10, "native-1"))
+            .await?;
+        let session = service
+            .create_snapshot_session(Duration::from_secs(300))
+            .await?
+            .ok_or_else(|| anyhow!("active service should create a snapshot session"))?;
+        new.promote(vec![BroadcasterBackend::Native], "new_active")
+            .await?;
+
+        let Err(error) = service
+            .snapshot_session_payload(session.session_id, 0)
+            .await
+        else {
+            return Err(anyhow!(
+                "stale active service must not serve old snapshot payloads"
+            ));
+        };
+        assert_eq!(error, SnapshotSessionError::NotFound);
+        assert_eq!(old.status_snapshot().await.mode, "retired");
+        assert_eq!(service.status_snapshot().await.snapshot_sessions.active, 0);
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn snapshot_session_boundary_is_registered_before_queued_update() -> Result<()> {
         let service = ready_service().await?;
         let gate = service.lock_lifecycle_gate_for_test().await;
@@ -591,8 +968,8 @@ mod tests {
             first_payload.payload,
             BroadcasterPayload::SnapshotStart(_)
         ));
-        assert_eq!(session.redis_replay_boundary.exclusive_message_seq, 1);
-        assert_eq!(publisher_boundary.exclusive_message_seq, 2);
+        assert_eq!(session.redis_replay_boundary.exclusive_message_seq, 2);
+        assert_eq!(publisher_boundary.exclusive_message_seq, 3);
         Ok(())
     }
 
@@ -600,11 +977,16 @@ mod tests {
     async fn shared_snapshot_session_boundary_is_registered_before_queued_rfq_update() -> Result<()>
     {
         let writer = ServiceFakeRedisWriter::default();
-        let publisher = Arc::new(BroadcasterRedisPublisher::new_with_initial_generation(
+        let publisher = Arc::new(BroadcasterRedisPublisher::new(
             publisher_config(),
             Arc::new(writer),
-            1,
         ));
+        publisher
+            .promote(
+                vec![BroadcasterBackend::Native, BroadcasterBackend::Rfq],
+                "active_writer_promoted",
+            )
+            .await?;
         let lifecycle_gate = Arc::new(Mutex::new(()));
         let raw_service = BroadcasterServiceState::with_lifecycle_gate(
             8_388_608,
@@ -675,18 +1057,17 @@ mod tests {
             first_payload.payload,
             BroadcasterPayload::SnapshotStart(_)
         ));
-        assert_eq!(session.redis_replay_boundary.exclusive_message_seq, 2);
-        assert_eq!(publisher_boundary.exclusive_message_seq, 3);
+        assert_eq!(session.redis_replay_boundary.exclusive_message_seq, 3);
+        assert_eq!(publisher_boundary.exclusive_message_seq, 4);
         Ok(())
     }
 
     #[tokio::test]
     async fn combined_snapshot_session_rejects_mismatched_lifecycle_gate() -> Result<()> {
         let writer = ServiceFakeRedisWriter::default();
-        let publisher = Arc::new(BroadcasterRedisPublisher::new_with_initial_generation(
+        let publisher = Arc::new(BroadcasterRedisPublisher::new(
             publisher_config(),
             Arc::new(writer),
-            1,
         ));
         let raw_service = BroadcasterServiceState::with_lifecycle_gate(
             8_388_608,
@@ -777,11 +1158,13 @@ mod tests {
     async fn generation_reset_requires_new_redis_stream_generation() -> Result<()> {
         let cache = BroadcasterSnapshotCache::new(1, vec![BroadcasterBackend::Native]);
         let writer = ServiceFakeRedisWriter::default();
-        let publisher = Arc::new(BroadcasterRedisPublisher::new_with_initial_generation(
+        let publisher = Arc::new(BroadcasterRedisPublisher::new(
             publisher_config(),
             Arc::new(writer.clone()),
-            1,
         ));
+        publisher
+            .promote(vec![BroadcasterBackend::Native], "active_writer_promoted")
+            .await?;
         let service = BroadcasterServiceState::with_lifecycle_gate(
             8_388_608,
             cache,
@@ -838,11 +1221,13 @@ mod tests {
         let cache = BroadcasterSnapshotCache::new(1, vec![BroadcasterBackend::Native]);
         let writer = ServiceFakeRedisWriter::default();
         writer.fail_next_appends(100).await;
-        let publisher = Arc::new(BroadcasterRedisPublisher::new_with_initial_generation(
+        let publisher = Arc::new(BroadcasterRedisPublisher::new(
             publisher_config(),
             Arc::new(writer.clone()),
-            1,
         ));
+        publisher
+            .promote(vec![BroadcasterBackend::Native], "active_writer_promoted")
+            .await?;
         let service = BroadcasterServiceState::with_lifecycle_gate(
             8_388_608,
             cache,
@@ -874,11 +1259,13 @@ mod tests {
     async fn heartbeat_fails_when_redis_publication_fails() -> Result<()> {
         let cache = BroadcasterSnapshotCache::new(1, vec![BroadcasterBackend::Native]);
         let writer = ServiceFakeRedisWriter::default();
-        let publisher = Arc::new(BroadcasterRedisPublisher::new_with_initial_generation(
+        let publisher = Arc::new(BroadcasterRedisPublisher::new(
             publisher_config(),
             Arc::new(writer.clone()),
-            1,
         ));
+        publisher
+            .promote(vec![BroadcasterBackend::Native], "active_writer_promoted")
+            .await?;
         let service = BroadcasterServiceState::with_lifecycle_gate(
             8_388_608,
             cache,
@@ -905,11 +1292,16 @@ mod tests {
     async fn shared_generation_reset_keeps_backend_caches_and_redis_publisher_aligned() -> Result<()>
     {
         let writer = ServiceFakeRedisWriter::default();
-        let publisher = Arc::new(BroadcasterRedisPublisher::new_with_initial_generation(
+        let publisher = Arc::new(BroadcasterRedisPublisher::new(
             publisher_config(),
             Arc::new(writer),
-            1,
         ));
+        publisher
+            .promote(
+                vec![BroadcasterBackend::Native, BroadcasterBackend::Rfq],
+                "active_writer_promoted",
+            )
+            .await?;
         let lifecycle_gate = Arc::new(Mutex::new(()));
         let raw_service = BroadcasterServiceState::with_lifecycle_gate(
             8_388_608,
@@ -952,11 +1344,13 @@ mod tests {
     async fn snapshot_session_response_includes_redis_replay_boundary() -> Result<()> {
         let cache = BroadcasterSnapshotCache::new(1, vec![BroadcasterBackend::Native]);
         let writer = ServiceFakeRedisWriter::default();
-        let publisher = Arc::new(BroadcasterRedisPublisher::new_with_initial_generation(
+        let publisher = Arc::new(BroadcasterRedisPublisher::new(
             publisher_config(),
             Arc::new(writer.clone()),
-            1,
         ));
+        publisher
+            .promote(vec![BroadcasterBackend::Native], "active_writer_promoted")
+            .await?;
         let service = BroadcasterServiceState::with_lifecycle_gate(
             8_388_608,
             cache,
@@ -988,8 +1382,8 @@ mod tests {
             session.redis_replay_boundary.snapshot_id,
             session.snapshot_id
         );
-        assert_eq!(session.redis_replay_boundary.exclusive_entry_id(), "1-1");
-        assert_eq!(session.redis_replay_boundary.exclusive_message_seq, 1);
+        assert_eq!(session.redis_replay_boundary.exclusive_entry_id(), "1-2");
+        assert_eq!(session.redis_replay_boundary.exclusive_message_seq, 2);
         assert!(
             writer.appends().await.iter().all(|entry| {
                 !matches!(
@@ -1106,11 +1500,13 @@ mod tests {
     async fn ready_service() -> Result<BroadcasterServiceState> {
         let cache = BroadcasterSnapshotCache::new(1, vec![BroadcasterBackend::Native]);
         let writer = ServiceFakeRedisWriter::default();
-        let publisher = Arc::new(BroadcasterRedisPublisher::new_with_initial_generation(
+        let publisher = Arc::new(BroadcasterRedisPublisher::new(
             publisher_config(),
             Arc::new(writer),
-            1,
         ));
+        publisher
+            .promote(vec![BroadcasterBackend::Native], "active_writer_promoted")
+            .await?;
         let upstream = BroadcasterUpstreamState::default();
         let service = BroadcasterServiceState::with_lifecycle_gate(
             8_388_608,
@@ -1134,6 +1530,8 @@ mod tests {
     #[derive(Debug, Default)]
     struct ServiceFakeRedisWriterState {
         appends: Vec<BroadcasterRedisStreamEntry>,
+        active_token: Option<String>,
+        active_generation: u64,
         fail_next_appends: usize,
     }
 
@@ -1148,23 +1546,99 @@ mod tests {
     }
 
     impl RedisStreamWriter for ServiceFakeRedisWriter {
-        fn append<'a>(
+        fn promote<'a>(
             &'a self,
-            _stream_key: &'a str,
-            _maxlen: Option<u64>,
-            entry: &'a BroadcasterRedisStreamEntry,
+            command: crate::broadcaster::redis_publisher::RedisPromotionCommand<'a>,
+        ) -> futures::future::BoxFuture<
+            'a,
+            Result<crate::broadcaster::redis_publisher::RedisPromotionResult>,
+        > {
+            Box::pin(async move {
+                let mut guard = self.inner.lock().await;
+                if let Some(expected_token) = command.expected_writer_token {
+                    if guard.active_token.is_some()
+                        && (guard.active_token.as_deref() != Some(expected_token)
+                            || Some(guard.active_generation) != command.expected_generation)
+                    {
+                        return Err(anyhow!("stale Redis broadcaster writer token"));
+                    }
+                    if guard.active_token.is_none() {
+                        guard.active_generation = guard
+                            .active_generation
+                            .max(command.expected_generation.unwrap_or_default());
+                    }
+                }
+                guard.active_generation = guard.active_generation.saturating_add(1);
+                guard.active_token = Some(command.writer_token.to_string());
+                let generation = guard.active_generation;
+                let entry_id = format!("{generation}-1");
+                guard
+                    .appends
+                    .push(entry_from_fields(command.marker_fields, generation)?);
+                Ok(crate::broadcaster::redis_publisher::RedisPromotionResult {
+                    generation,
+                    entry_id,
+                })
+            })
+        }
+
+        fn append_fenced<'a>(
+            &'a self,
+            command: crate::broadcaster::redis_publisher::RedisAppendCommand<'a>,
         ) -> futures::future::BoxFuture<'a, Result<String>> {
             Box::pin(async move {
                 let mut guard = self.inner.lock().await;
+                if guard.active_token.is_some()
+                    && (guard.active_token.as_deref() != Some(command.writer_token)
+                        || guard.active_generation != command.generation)
+                {
+                    return Err(anyhow!("stale Redis broadcaster writer token"));
+                }
+                if guard.active_token.is_none() {
+                    guard.active_generation = guard.active_generation.max(command.generation);
+                }
                 if guard.fail_next_appends > 0 {
                     guard.fail_next_appends -= 1;
                     return Err(anyhow!("planned append failure"));
                 }
-                let entry_id = format!("1000-{}", guard.appends.len());
-                guard.appends.push(entry.clone());
+                let entry_id = crate::broadcaster::redis_publisher::redis_entry_id(command.entry)?;
+                guard.appends.push(command.entry.clone());
                 Ok(entry_id)
             })
         }
+
+        fn renew_writer<'a>(
+            &'a self,
+            command: crate::broadcaster::redis_publisher::RedisRenewCommand<'a>,
+        ) -> futures::future::BoxFuture<'a, Result<()>> {
+            Box::pin(async move {
+                let guard = self.inner.lock().await;
+                if guard.active_token.is_some()
+                    && (guard.active_token.as_deref() != Some(command.writer_token)
+                        || guard.active_generation != command.generation)
+                {
+                    return Err(anyhow!("stale Redis broadcaster writer token"));
+                }
+                Ok(())
+            })
+        }
+    }
+
+    fn entry_from_fields(
+        fields: &[(String, String)],
+        generation: u64,
+    ) -> Result<BroadcasterRedisStreamEntry> {
+        let mut value = serde_json::Map::new();
+        for (field, field_value) in fields {
+            value.insert(
+                field.clone(),
+                serde_json::Value::String(field_value.replace(
+                    crate::broadcaster::redis_publisher::GENERATION_PLACEHOLDER,
+                    &generation.to_string(),
+                )),
+            );
+        }
+        serde_json::from_value(serde_json::Value::Object(value)).map_err(Into::into)
     }
 
     fn snapshot_export() -> BroadcasterSnapshotExport {

--- a/crates/runtime/src/broadcaster/state.rs
+++ b/crates/runtime/src/broadcaster/state.rs
@@ -25,6 +25,8 @@ use super::redis_publisher::BroadcasterRedisPublisherStatus;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum BroadcasterReadiness {
     Ready,
+    RedisPublisherPassive,
+    RedisPublisherRetired,
     RedisPublisherUnhealthy,
     SnapshotWarmingUp,
     UpstreamDisconnected,
@@ -35,6 +37,8 @@ impl BroadcasterReadiness {
         match self {
             Self::UpstreamDisconnected => "upstream_disconnected",
             Self::SnapshotWarmingUp => "snapshot_warming_up",
+            Self::RedisPublisherPassive => "redis_publisher_passive",
+            Self::RedisPublisherRetired => "redis_publisher_retired",
             Self::RedisPublisherUnhealthy => "redis_publisher_unhealthy",
             Self::Ready => "ready",
         }
@@ -220,13 +224,16 @@ impl BroadcasterSnapshotCache {
         }
     }
 
-    pub async fn reset_generation(&self) {
+    pub async fn reset_to_generation(&self, generation: u64) {
         let mut guard = self.inner.write().await;
-        guard.generation = guard.generation.saturating_add(1);
-        guard.stream_id = format_stream_id(self.chain_id, guard.generation);
-        guard.snapshot_id = format_snapshot_id(self.chain_id, guard.generation);
+        Self::relabel_generation_locked(self.chain_id, &mut guard, generation);
         guard.partitions.clear();
         guard.known_backends.clear();
+    }
+
+    pub async fn relabel_generation(&self, generation: u64) {
+        let mut guard = self.inner.write().await;
+        Self::relabel_generation_locked(self.chain_id, &mut guard, generation);
     }
 
     pub async fn apply_update(&self, update: &TychoUpdate) -> Result<BroadcasterUpdateMessage> {
@@ -422,6 +429,17 @@ impl BroadcasterSnapshotCache {
                 .and_then(|partition| partition.block_number)
                 .is_some()
         })
+    }
+
+    fn relabel_generation_locked(
+        chain_id: u64,
+        guard: &mut BroadcasterSnapshotCacheData,
+        generation: u64,
+    ) {
+        let generation = generation.max(1);
+        guard.generation = generation;
+        guard.stream_id = format_stream_id(chain_id, generation);
+        guard.snapshot_id = format_snapshot_id(chain_id, generation);
     }
 }
 
@@ -2068,13 +2086,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cache_resets_generation_on_reset() -> Result<()> {
+    async fn cache_resets_to_redis_owned_generation() -> Result<()> {
         let cache = BroadcasterSnapshotCache::new(1, vec![BroadcasterBackend::Native]);
         cache.apply_update(&native_only_update()).await?;
         let snapshot_before = cache.export_snapshot(8_388_608).await?;
         assert_eq!(snapshot_before.snapshot_id, "chain-1-snapshot-1");
 
-        cache.reset_generation().await;
+        cache.reset_to_generation(2).await;
         let snapshot_after = cache.export_snapshot(8_388_608).await?;
         assert_eq!(snapshot_after.stream_id, "chain-1-stream-2");
         assert_eq!(snapshot_after.snapshot_id, "chain-1-snapshot-2");

--- a/crates/runtime/src/stream.rs
+++ b/crates/runtime/src/stream.rs
@@ -1188,6 +1188,7 @@ mod tests {
                 chain_id,
                 append_retry_window: Duration::from_millis(10),
                 maxlen: None,
+                writer_lease_ttl: Duration::from_secs(30),
             },
             Arc::new(StreamTestRedisWriter),
         ))

--- a/crates/runtime/src/stream.rs
+++ b/crates/runtime/src/stream.rs
@@ -1117,7 +1117,7 @@ mod tests {
     use crate::models::state::{StateStore, VmStreamStatus};
     use crate::models::stream_health::StreamHealth;
     use crate::models::tokens::TokenStore;
-    use simulator_core::broadcaster::{BroadcasterBackend, BroadcasterRedisStreamEntry};
+    use simulator_core::broadcaster::BroadcasterBackend;
     use tycho_simulation::tycho_common::models::Chain;
 
     #[test]
@@ -1179,19 +1179,10 @@ mod tests {
     #[derive(Debug)]
     struct StreamTestRedisWriter;
 
-    impl RedisStreamWriter for StreamTestRedisWriter {
-        fn append<'a>(
-            &'a self,
-            _stream_key: &'a str,
-            _maxlen: Option<u64>,
-            entry: &'a BroadcasterRedisStreamEntry,
-        ) -> futures::future::BoxFuture<'a, anyhow::Result<String>> {
-            Box::pin(async move { Ok(format!("1-{}", entry.message_seq)) })
-        }
-    }
+    impl RedisStreamWriter for StreamTestRedisWriter {}
 
     fn test_redis_publisher(chain_id: u64) -> Arc<BroadcasterRedisPublisher> {
-        Arc::new(BroadcasterRedisPublisher::new_with_initial_generation(
+        Arc::new(BroadcasterRedisPublisher::new(
             BroadcasterRedisPublisherConfig {
                 stream_key: "stream:test".to_string(),
                 chain_id,
@@ -1199,7 +1190,6 @@ mod tests {
                 maxlen: None,
             },
             Arc::new(StreamTestRedisWriter),
-            1,
         ))
     }
 

--- a/scripts/test_verify_broadcaster_redis.sh
+++ b/scripts/test_verify_broadcaster_redis.sh
@@ -13,9 +13,14 @@ TYCHO_BROADCASTER_URL=https://broadcaster.example/prod/base
 [[ "$(derive_status_url)" == "https://broadcaster.example/prod/base/status" ]]
 unset TYCHO_BROADCASTER_URL
 
-status_body='{"status":"ready","chain_id":8453,"redis_publisher":{"healthy":true,"stream_key":"dsolver:broadcaster:local:8453:events","stream_id":"chain-8453-stream-2","snapshot_id":"chain-8453-snapshot-2","replay_boundary":{"streamKey":"dsolver:broadcaster:local:8453:events","streamId":"chain-8453-stream-2","snapshotId":"chain-8453-snapshot-2","generation":2,"exclusiveMessageSeq":14}}}'
+status_body='{"status":"ready","chain_id":8453,"redis_publisher":{"healthy":true,"mode":"active","stream_key":"dsolver:broadcaster:local:8453:events","stream_id":"chain-8453-stream-2","snapshot_id":"chain-8453-snapshot-2","replay_boundary":{"streamKey":"dsolver:broadcaster:local:8453:events","streamId":"chain-8453-stream-2","snapshotId":"chain-8453-snapshot-2","generation":2,"exclusiveMessageSeq":14}}}'
 boundary_json="$(extract_replay_boundary "$status_body")"
 [[ "$(boundary_entry_id "$boundary_json")" == "2-14" ]]
+
+if extract_replay_boundary "${status_body/\"mode\":\"active\"/\"mode\":\"passive\"}" >/dev/null 2>&1; then
+  echo "expected passive redis_publisher mode to fail replay boundary parsing" >&2
+  exit 1
+fi
 
 if extract_replay_boundary "${status_body/exclusiveMessageSeq/missingMessageSeq}" >/dev/null 2>&1; then
   echo "expected missing exclusiveMessageSeq to fail replay boundary parsing" >&2

--- a/scripts/verify_broadcaster_redis.sh
+++ b/scripts/verify_broadcaster_redis.sh
@@ -128,6 +128,8 @@ if not isinstance(publisher, dict):
     raise SystemExit("broadcaster /status did not include redis_publisher")
 if publisher.get("healthy") is not True:
     raise SystemExit("broadcaster redis_publisher is not healthy")
+if publisher.get("mode") != "active":
+    raise SystemExit("broadcaster redis_publisher is not active")
 boundary = publisher.get("replay_boundary")
 if not isinstance(boundary, dict):
     raise SystemExit("broadcaster redis_publisher has no replay_boundary")


### PR DESCRIPTION
Adds active writer ownership for the broadcaster Redis stream so a new broadcaster can warm passively before taking over.