### PR TITLE
ci: add broadcaster-only dispatch deploy workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           test -n "$PRIVATE_DEWIZ_GITHUB_TOKEN"
           git config --global url."https://x-access-token:${PRIVATE_DEWIZ_GITHUB_TOKEN}@github.com/pedrobergamini/".insteadOf "ssh://git@github.com/pedrobergamini/"
-          git config --global url."https://x-access-token:${PRIVATE_DEWIZ_GITHUB_TOKEN}@github.com/pedrobergamini/".insteadOf "git@github.com:pedrobergamini/"
+          git config --global --add url."https://x-access-token:${PRIVATE_DEWIZ_GITHUB_TOKEN}@github.com/pedrobergamini/".insteadOf "git@github.com:pedrobergamini/"
       - name: Check formatting
         run: cargo fmt --all -- --check
 
@@ -51,7 +51,7 @@ jobs:
         run: |
           test -n "$PRIVATE_DEWIZ_GITHUB_TOKEN"
           git config --global url."https://x-access-token:${PRIVATE_DEWIZ_GITHUB_TOKEN}@github.com/pedrobergamini/".insteadOf "ssh://git@github.com/pedrobergamini/"
-          git config --global url."https://x-access-token:${PRIVATE_DEWIZ_GITHUB_TOKEN}@github.com/pedrobergamini/".insteadOf "git@github.com:pedrobergamini/"
+          git config --global --add url."https://x-access-token:${PRIVATE_DEWIZ_GITHUB_TOKEN}@github.com/pedrobergamini/".insteadOf "git@github.com:pedrobergamini/"
       - name: Run clippy
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
@@ -68,7 +68,7 @@ jobs:
         run: |
           test -n "$PRIVATE_DEWIZ_GITHUB_TOKEN"
           git config --global url."https://x-access-token:${PRIVATE_DEWIZ_GITHUB_TOKEN}@github.com/pedrobergamini/".insteadOf "ssh://git@github.com/pedrobergamini/"
-          git config --global url."https://x-access-token:${PRIVATE_DEWIZ_GITHUB_TOKEN}@github.com/pedrobergamini/".insteadOf "git@github.com:pedrobergamini/"
+          git config --global --add url."https://x-access-token:${PRIVATE_DEWIZ_GITHUB_TOKEN}@github.com/pedrobergamini/".insteadOf "git@github.com:pedrobergamini/"
       - uses: taiki-e/install-action@nextest
       - name: Run tests
         run: cargo nextest run --workspace
@@ -86,7 +86,7 @@ jobs:
         run: |
           test -n "$PRIVATE_DEWIZ_GITHUB_TOKEN"
           git config --global url."https://x-access-token:${PRIVATE_DEWIZ_GITHUB_TOKEN}@github.com/pedrobergamini/".insteadOf "ssh://git@github.com/pedrobergamini/"
-          git config --global url."https://x-access-token:${PRIVATE_DEWIZ_GITHUB_TOKEN}@github.com/pedrobergamini/".insteadOf "git@github.com:pedrobergamini/"
+          git config --global --add url."https://x-access-token:${PRIVATE_DEWIZ_GITHUB_TOKEN}@github.com/pedrobergamini/".insteadOf "git@github.com:pedrobergamini/"
       - name: Build simulator release binary
         run: cargo build -p apps --bin dsolver-simulator-service --release
       - name: Build broadcaster release binary

--- a/.github/workflows/deploy-broadcaster.yml
+++ b/.github/workflows/deploy-broadcaster.yml
@@ -1,0 +1,63 @@
+name: Deploy Broadcaster
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Target stack
+        required: true
+        type: choice
+        options:
+          - staging-solve-base
+          - quoter-base
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: eu-central-1
+
+jobs:
+  build-and-deploy:
+    name: Build & Deploy Broadcaster (${{ inputs.target }})
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.target == 'quoter-base' && 'production' || 'staging' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - uses: aws-actions/amazon-ecr-login@v2
+        id: ecr-login
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.broadcaster-service
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ steps.ecr-login.outputs.registry }}/tycho-broadcaster-${{ inputs.target }}:${{ github.sha }}
+            ${{ steps.ecr-login.outputs.registry }}/tycho-broadcaster-${{ inputs.target }}:latest
+          cache-from: type=gha,scope=broadcaster-service-${{ inputs.target }}
+          cache-to: type=gha,mode=max,scope=broadcaster-service-${{ inputs.target }}
+          secrets: |
+            github_token=${{ secrets.PRIVATE_DEWIZ_GITHUB_TOKEN }}
+
+      - name: Force deploy broadcaster ECS service
+        env:
+          CLUSTER: ${{ inputs.target }}
+        run: |
+          # The broadcaster service may not exist yet because its infra lands separately, so skip instead of failing.
+          STATUS=$(aws ecs describe-services --cluster "$CLUSTER" --services broadcaster --region ${{ env.AWS_REGION }} --query 'services[0].status' --output text 2>/dev/null || echo "MISSING")
+          if [ "$STATUS" = "ACTIVE" ]; then
+            aws ecs update-service --cluster "$CLUSTER" --service broadcaster --force-new-deployment --region ${{ env.AWS_REGION }} --query 'service.serviceName' --output text
+          else
+            echo "broadcaster service not ACTIVE in $CLUSTER (status: $STATUS), skipping force deploy"
+          fi


### PR DESCRIPTION
Adds a dispatch only workflow to build and deploy just the broadcaster image to a chosen environment (staging-solve-base or quoter-base).

The push triggered deploy always builds both images and force deploys the simulator together with the broadcaster, so there was no way to ship the broadcaster on its own. This mirrors the broadcaster path from deploy.yml (same ECR repo, cache scopes, build secret, and the guarded force deploy that skips when the service is not ACTIVE yet), minus the simulator steps and with no push trigger. Needed for the staging Redis streams rollout so we can bring the broadcaster up from dev before cutting the simulator over.