### PR TITLE
ci: make prod deploys dispatch-only and add base-production target

### DIFF
--- a/.github/workflows/deploy-broadcaster.yml
+++ b/.github/workflows/deploy-broadcaster.yml
@@ -10,6 +10,7 @@ on:
         options:
           - staging-solve-base
           - quoter-base
+          - base-production
 
 permissions:
   id-token: write
@@ -22,7 +23,7 @@ jobs:
   build-and-deploy:
     name: Build & Deploy Broadcaster (${{ inputs.target }})
     runs-on: ubuntu-latest
-    environment: ${{ inputs.target == 'quoter-base' && 'production' || 'staging' }}
+    environment: ${{ (inputs.target == 'quoter-base' || inputs.target == 'base-production') && 'production' || 'staging' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,6 @@ name: Build & Push Simulator Image
 on:
   push:
     branches:
-      - master
       - staging
       - shadow
   workflow_dispatch:
@@ -51,9 +50,6 @@ jobs:
           elif [ "$REF_NAME" = "staging" ]; then
             TARGETS='["staging-solve-base"]'
             ENV="staging"
-          else
-            TARGETS='["quoter-base","solve-base"]'
-            ENV="production"
           fi
           echo "targets=$TARGETS" >> "$GITHUB_OUTPUT"
           echo "environment=$ENV" >> "$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -219,6 +219,10 @@ For ops, `/encode` timeout and failure logs include stable `encode_error_kind` a
 
 If you are integrating against `/simulate`, inspect `meta` on every successful HTTP response. If you are integrating against `/encode`, normal HTTP success and error handling is still the right control flow.
 
+## Deployments
+
+Production simulator and broadcaster images are built and pushed to ECR only through manual dispatch of `deploy.yml` or `deploy-broadcaster.yml` for the target environment. Pushing an image does not change what runs in production on its own. Activation is a separate step in the infrastructure repository, while pushes to the `staging` branch continue to build and deploy staging automatically.
+
 ## Verification
 
 CI-equivalent commands:


### PR DESCRIPTION
Makes pushes to master fully inert so prod simulator images only build and deploy through an explicit workflow dispatch. The old push path force-deployed tycho-simulator on both prod clusters, which would have rolled incompatible code the moment we merge staging into master.

Also adds base-production as a deploy-broadcaster target for the upcoming shared broadcaster stack. It maps to the production environment and reuses the target-derived ECR and cluster naming, keeping the guarded force-deploy so it degrades gracefully until the infra lands.