### PR TITLE
ci: add broadcaster-production deploy target

### DIFF
--- a/.github/workflows/deploy-broadcaster.yml
+++ b/.github/workflows/deploy-broadcaster.yml
@@ -10,7 +10,7 @@ on:
         options:
           - staging-solve-base
           - quoter-base
-          - base-production
+          - broadcaster-production
 
 permissions:
   id-token: write
@@ -23,7 +23,7 @@ jobs:
   build-and-deploy:
     name: Build & Deploy Broadcaster (${{ inputs.target }})
     runs-on: ubuntu-latest
-    environment: ${{ (inputs.target == 'quoter-base' || inputs.target == 'base-production') && 'production' || 'staging' }}
+    environment: ${{ (inputs.target == 'quoter-base' || inputs.target == 'broadcaster-production') && 'production' || 'staging' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -37,6 +37,18 @@ jobs:
 
       - uses: docker/setup-buildx-action@v3
 
+      - name: Resolve ECR repository
+        id: ecr-repository
+        env:
+          TARGET: ${{ inputs.target }}
+        run: |
+          if [ "$TARGET" = "broadcaster-production" ]; then
+            REPOSITORY="tycho-broadcaster-production"
+          else
+            REPOSITORY="tycho-broadcaster-$TARGET"
+          fi
+          echo "repository=$REPOSITORY" >> "$GITHUB_OUTPUT"
+
       - uses: docker/build-push-action@v5
         with:
           context: .
@@ -44,8 +56,8 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ${{ steps.ecr-login.outputs.registry }}/tycho-broadcaster-${{ inputs.target }}:${{ github.sha }}
-            ${{ steps.ecr-login.outputs.registry }}/tycho-broadcaster-${{ inputs.target }}:latest
+            ${{ steps.ecr-login.outputs.registry }}/${{ steps.ecr-repository.outputs.repository }}:${{ github.sha }}
+            ${{ steps.ecr-login.outputs.registry }}/${{ steps.ecr-repository.outputs.repository }}:latest
           cache-from: type=gha,scope=broadcaster-service-${{ inputs.target }}
           cache-to: type=gha,mode=max,scope=broadcaster-service-${{ inputs.target }}
           secrets: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,6 +107,7 @@ jobs:
             github_token=${{ secrets.PRIVATE_DEWIZ_GITHUB_TOKEN }}
 
       - name: Force deploy ECS service
+        if: matrix.target == 'shadow' || matrix.target == 'staging-solve-base'
         env:
           CLUSTER: ${{ matrix.target }}
         run: |


### PR DESCRIPTION
Renames the deploy-broadcaster dispatch target to broadcaster-production, matching the new infra stack name, and maps its ECR repo to tycho-broadcaster-production so the name doesn't stutter. Also drops the simulator force-deploy for quoter-base and solve-base dispatches since prod task definitions are pinned to immutable SHAs now, so restarting on the old image only costs a warm-up. Staging and shadow keep their existing behavior.