### PR TITLE
feat: add native progress latency telemetry

### DIFF
--- a/crates/runtime/src/broadcaster/redis_subscription/processor.rs
+++ b/crates/runtime/src/broadcaster/redis_subscription/processor.rs
@@ -1,10 +1,11 @@
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{anyhow, Result};
 use tokio::sync::OwnedRwLockWriteGuard;
 use tokio::time::Instant;
-use tracing::warn;
+use tracing::{info, warn};
 use tycho_simulation::{
     evm::decoder::TychoStreamDecoder,
     evm::engine_db::SHARED_TYCHO_DB,
@@ -210,12 +211,45 @@ impl BroadcasterSubscriptionProcessor {
         envelope: &BroadcasterEnvelope,
     ) -> Result<()> {
         if redis_entry_scope_contains(entry, self.controls.backend()) {
+            let native_progress_block = if self.controls.backend() == BroadcasterBackend::Native {
+                match &envelope.payload {
+                    BroadcasterPayload::Update(update) => update.complete_native_block(),
+                    _ => None,
+                }
+            } else {
+                None
+            };
+            let consumer_started_at = Instant::now();
+            let consumer_started_at_ms = unix_time_ms();
             self.observe_with_state_version(envelope.clone(), Some(entry.state_version))
                 .await?;
             self.controls
                 .broadcaster_subscription()
                 .record_publisher_to_consumer_delay(entry.published_at_ms)
                 .await;
+            if let Some(block_number) = native_progress_block {
+                let consumer_processing_ms = consumer_started_at.elapsed().as_millis() as u64;
+                let publisher_to_consumer_start_ms =
+                    consumer_started_at_ms.saturating_sub(entry.published_at_ms);
+                let publisher_to_consumer_complete_ms =
+                    publisher_to_consumer_start_ms.saturating_add(consumer_processing_ms);
+                let consumer_applied_at_ms =
+                    consumer_started_at_ms.saturating_add(consumer_processing_ms);
+                info!(
+                    event = "broadcaster_native_update_applied",
+                    block = block_number,
+                    stream_id = entry.stream_id.as_str(),
+                    message_seq = entry.message_seq,
+                    state_version = entry.state_version,
+                    published_at_ms = entry.published_at_ms,
+                    consumer_started_at_ms,
+                    consumer_applied_at_ms,
+                    publisher_to_consumer_start_ms,
+                    consumer_processing_ms,
+                    publisher_to_consumer_complete_ms,
+                    "Broadcaster native update applied"
+                );
+            }
             return Ok(());
         }
 
@@ -437,6 +471,12 @@ impl BroadcasterSubscriptionProcessor {
         }
         Ok(())
     }
+}
+
+fn unix_time_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_millis() as u64)
 }
 
 #[cfg(test)]

--- a/crates/runtime/src/config/mod.rs
+++ b/crates/runtime/src/config/mod.rs
@@ -1077,7 +1077,7 @@ mod tests {
         };
 
         assert_eq!(chain.chain_profile.chain, Chain::Base);
-        assert_eq!(chain.chain_profile.native_progress_lease_secs, 5);
+        assert_eq!(chain.chain_profile.native_progress_lease_secs, 10);
         assert_eq!(chain.chain_profile.recovery_max_buffered_native_blocks, 64);
         assert_eq!(chain.tycho_url, "tycho-base-beta.propellerheads.xyz");
         assert!(chain

--- a/crates/runtime/src/stream.rs
+++ b/crates/runtime/src/stream.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use futures::StreamExt;
 use rand::Rng;
@@ -416,6 +416,8 @@ async fn handle_broadcaster_raw_update(
     cfg: &StreamSupervisorConfig,
     ready_logged: &mut bool,
 ) -> Option<StreamExit> {
+    let received_at = Instant::now();
+    let received_at_ms = unix_time_ms();
     let now = Instant::now();
     let has_advanced = update
         .sync_states
@@ -466,6 +468,18 @@ async fn handle_broadcaster_raw_update(
     if let Some(native_block) = applied.native_progress {
         health.record_progress(native_block).await;
     }
+    let native_progress_block = applied.native_progress.unwrap_or_default();
+    let block_timestamp_ms = applied
+        .native_progress
+        .and_then(|block| broadcaster_raw_block_timestamp_ms(&update, block));
+    let broadcaster_processing_ms = received_at.elapsed().as_millis() as u64;
+    let broadcaster_completed_at_ms = received_at_ms.saturating_add(broadcaster_processing_ms);
+    let base_to_broadcaster_receive_ms = block_timestamp_ms
+        .map(|timestamp| received_at_ms.saturating_sub(timestamp))
+        .unwrap_or_default();
+    let base_to_broadcaster_complete_ms = block_timestamp_ms
+        .map(|timestamp| broadcaster_completed_at_ms.saturating_sub(timestamp))
+        .unwrap_or_default();
     maybe_log_memory_snapshot(
         "broadcaster",
         "stream_update",
@@ -478,6 +492,15 @@ async fn handle_broadcaster_raw_update(
         stream = StreamKind::Broadcaster.as_str(),
         block = block_number,
         new_pairs,
+        native_progress_advanced = applied.native_progress.is_some(),
+        native_progress_block,
+        native_timing_available = block_timestamp_ms.is_some(),
+        block_timestamp_ms = block_timestamp_ms.unwrap_or_default(),
+        broadcaster_received_at_ms = received_at_ms,
+        broadcaster_completed_at_ms,
+        base_to_broadcaster_receive_ms,
+        broadcaster_processing_ms,
+        base_to_broadcaster_complete_ms,
         "Raw broadcaster update processed"
     );
 
@@ -504,6 +527,23 @@ fn broadcaster_raw_block_number(update: &FeedMessage<BlockHeader>) -> u64 {
         .map(|message| message.header.clone().block_number_or_timestamp())
         .max()
         .unwrap_or_default()
+}
+
+fn broadcaster_raw_block_timestamp_ms(
+    update: &FeedMessage<BlockHeader>,
+    block_number: u64,
+) -> Option<u64> {
+    update
+        .state_msgs
+        .values()
+        .find(|message| message.header.number == block_number)
+        .map(|message| message.header.timestamp.saturating_mul(1_000))
+}
+
+fn unix_time_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_millis() as u64)
 }
 
 async fn handle_stream_error(

--- a/simulator-manifest.toml
+++ b/simulator-manifest.toml
@@ -133,7 +133,7 @@ route_policy = "ethereum"
 
 [[chains]]
 chain_id = 8453
-native_progress_lease_secs = 5
+native_progress_lease_secs = 10
 recovery_max_buffered_native_blocks = 64
 tycho_url = "tycho-base-beta.propellerheads.xyz"
 bebop_url = "https://api.bebop.xyz/pmm/base/v3/tokens"


### PR DESCRIPTION
## Summary

- Increase the Base native progress lease from 5 seconds to 10 seconds.
- Add structured timing fields that separate upstream delivery, broadcaster processing, Redis propagation, and simulator application latency.
