### PR TITLE
feat: fence encode staleness by pool identity and retry once

### DIFF
--- a/crates/apps/tests/integration/encode_route.rs
+++ b/crates/apps/tests/integration/encode_route.rs
@@ -92,20 +92,25 @@ impl TychoEncoder for MockTychoEncoder {
 struct PublishingEncoderState {
     state_store: Arc<StateStore>,
     router: Bytes,
+    update_pool_id: String,
     calls: AtomicUsize,
 }
 
 impl PublishingEncoderState {
-    fn new(state_store: Arc<StateStore>, router: Bytes) -> Self {
+    fn new(state_store: Arc<StateStore>, router: Bytes, update_pool_id: String) -> Self {
         Self {
             state_store,
             router,
+            update_pool_id,
             calls: AtomicUsize::new(0),
         }
     }
 
     fn publish_update(&self) {
-        let states: HashMap<String, Box<dyn ProtocolSim>> = HashMap::new();
+        let states = HashMap::from([(
+            self.update_pool_id.clone(),
+            Box::new(EchoAmountSim) as Box<dyn ProtocolSim>,
+        )]);
         let new_pairs: HashMap<String, ProtocolComponent> = HashMap::new();
         let update = Update::new(43, states, new_pairs);
         tokio::task::block_in_place(|| {
@@ -123,9 +128,9 @@ struct PublishUpdateOnFirstCallEncoder {
 }
 
 impl PublishUpdateOnFirstCallEncoder {
-    fn new(state_store: Arc<StateStore>, router: Bytes) -> Self {
+    fn new(state_store: Arc<StateStore>, router: Bytes, update_pool_id: String) -> Self {
         Self {
-            state: PublishingEncoderState::new(state_store, router),
+            state: PublishingEncoderState::new(state_store, router, update_pool_id),
         }
     }
 
@@ -164,9 +169,9 @@ struct PublishUpdateOnEveryCallEncoder {
 }
 
 impl PublishUpdateOnEveryCallEncoder {
-    fn new(state_store: Arc<StateStore>, router: Bytes) -> Self {
+    fn new(state_store: Arc<StateStore>, router: Bytes, update_pool_id: String) -> Self {
         Self {
-            state: PublishingEncoderState::new(state_store, router),
+            state: PublishingEncoderState::new(state_store, router, update_pool_id),
         }
     }
 
@@ -205,9 +210,14 @@ struct PublishUpdateWithWrongRouterEncoder {
 }
 
 impl PublishUpdateWithWrongRouterEncoder {
-    fn new(state_store: Arc<StateStore>, router: Bytes, wrong_router: Bytes) -> Self {
+    fn new(
+        state_store: Arc<StateStore>,
+        router: Bytes,
+        wrong_router: Bytes,
+        update_pool_id: String,
+    ) -> Self {
         Self {
-            state: PublishingEncoderState::new(state_store, router),
+            state: PublishingEncoderState::new(state_store, router, update_pool_id),
             wrong_router,
         }
     }
@@ -867,6 +877,41 @@ async fn setup_app_state_and_request(
     Ok((create_router(runtime), request))
 }
 
+async fn add_native_echo_pool(
+    state: &AppState,
+    request: &RouteEncodeRequest,
+    pool_id: &str,
+) -> Result<()> {
+    let token_in = parse_bytes(&request.token_in)?;
+    let token_out = parse_bytes(&request.token_out)?;
+    let component = ProtocolComponent::new(
+        parse_bytes("0x00000000000000000000000000000000000000bb")?,
+        "uniswap_v2".to_string(),
+        "uniswap_v2".to_string(),
+        state.chain,
+        vec![
+            make_token(&token_in, "TK1", state.chain),
+            make_token(&token_out, "TK2", state.chain),
+        ],
+        Vec::new(),
+        HashMap::new(),
+        Bytes::default(),
+        NaiveDateTime::default(),
+    );
+    state
+        .native_state_store
+        .apply_update(Update::new(
+            43,
+            HashMap::from([(
+                pool_id.to_string(),
+                Box::new(EchoAmountSim) as Box<dyn ProtocolSim>,
+            )]),
+            HashMap::from([(pool_id.to_string(), component)]),
+        ))
+        .await;
+    Ok(())
+}
+
 async fn post_encode(
     app: axum::Router,
     request: &RouteEncodeRequest,
@@ -1062,6 +1107,10 @@ async fn encode_route_retries_after_first_attempt_publication() -> Result<()> {
     let encoder = Arc::new(PublishUpdateOnFirstCallEncoder::new(
         Arc::clone(&state.native_state_store),
         parse_bytes(&request.tycho_router_address)?,
+        request.segments[0].hops[0].swaps[0]
+            .pool
+            .component_id
+            .clone(),
     ));
     let runtime_encoder: Arc<dyn TychoEncoder> = encoder.clone();
     let app = create_router(SimulatorRuntime::new_with_encoder(state, runtime_encoder));
@@ -1080,6 +1129,35 @@ async fn encode_route_retries_after_first_attempt_publication() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn encode_route_does_not_retry_after_unrelated_pool_publication() -> Result<()> {
+    let config = EncodeFixtureConfig {
+        request_id: "req-unrelated-publication",
+        ..EncodeFixtureConfig::default()
+    };
+    let (state, request) = build_app_state_and_request(config).await?;
+    add_native_echo_pool(&state, &request, "pool-unrelated").await?;
+    let encoder = Arc::new(PublishUpdateOnFirstCallEncoder::new(
+        Arc::clone(&state.native_state_store),
+        parse_bytes(&request.tycho_router_address)?,
+        "pool-unrelated".to_string(),
+    ));
+    let runtime_encoder: Arc<dyn TychoEncoder> = encoder.clone();
+    let app = create_router(SimulatorRuntime::new_with_encoder(state, runtime_encoder));
+
+    let (status, body) = post_encode(app, &request).await?;
+
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "unexpected status {}: {}",
+        status,
+        String::from_utf8_lossy(&body)
+    );
+    assert_eq!(encoder.call_count(), 1);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn encode_route_returns_service_unavailable_after_second_publication() -> Result<()> {
     let config = EncodeFixtureConfig {
         request_id: "req-retry-second-trip",
@@ -1089,6 +1167,10 @@ async fn encode_route_returns_service_unavailable_after_second_publication() -> 
     let encoder = Arc::new(PublishUpdateOnEveryCallEncoder::new(
         Arc::clone(&state.native_state_store),
         parse_bytes(&request.tycho_router_address)?,
+        request.segments[0].hops[0].swaps[0]
+            .pool
+            .component_id
+            .clone(),
     ));
     let runtime_encoder: Arc<dyn TychoEncoder> = encoder.clone();
     let app = create_router(SimulatorRuntime::new_with_encoder(state, runtime_encoder));
@@ -1116,6 +1198,10 @@ async fn encode_route_returns_deterministic_error_without_retry_after_publicatio
         Arc::clone(&state.native_state_store),
         parse_bytes(&request.tycho_router_address)?,
         parse_bytes("0x0000000000000000000000000000000000000005")?,
+        request.segments[0].hops[0].swaps[0]
+            .pool
+            .component_id
+            .clone(),
     ));
     let runtime_encoder: Arc<dyn TychoEncoder> = encoder.clone();
     let app = create_router(SimulatorRuntime::new_with_encoder(state, runtime_encoder));

--- a/crates/apps/tests/integration/encode_route.rs
+++ b/crates/apps/tests/integration/encode_route.rs
@@ -2,6 +2,7 @@ use std::any::Any;
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
 use std::str::FromStr;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
@@ -56,18 +57,174 @@ struct MockTychoEncoder {
     router: Bytes,
 }
 
+fn mock_encoded_solution(router: Bytes) -> EncodedSolution {
+    EncodedSolution {
+        swaps: vec![0x01, 0x02],
+        interacting_with: router,
+        function_signature: "singleSwap()".to_string(),
+        n_tokens: 0,
+        permit: None,
+    }
+}
+
 impl TychoEncoder for MockTychoEncoder {
     fn encode_solutions(
         &self,
         _solutions: Vec<Solution>,
     ) -> Result<Vec<EncodedSolution>, EncodingError> {
-        Ok(vec![EncodedSolution {
-            swaps: vec![0x01, 0x02],
-            interacting_with: self.router.clone(),
-            function_signature: "singleSwap()".to_string(),
-            n_tokens: 0,
-            permit: None,
-        }])
+        Ok(vec![mock_encoded_solution(self.router.clone())])
+    }
+
+    fn encode_full_calldata(
+        &self,
+        _solutions: Vec<Solution>,
+    ) -> Result<Vec<Transaction>, EncodingError> {
+        Err(EncodingError::FatalError(
+            "encode_full_calldata not supported in tests".to_string(),
+        ))
+    }
+
+    fn validate_solution(&self, _solution: &Solution) -> Result<(), EncodingError> {
+        Ok(())
+    }
+}
+
+struct PublishingEncoderState {
+    state_store: Arc<StateStore>,
+    router: Bytes,
+    calls: AtomicUsize,
+}
+
+impl PublishingEncoderState {
+    fn new(state_store: Arc<StateStore>, router: Bytes) -> Self {
+        Self {
+            state_store,
+            router,
+            calls: AtomicUsize::new(0),
+        }
+    }
+
+    fn publish_update(&self) {
+        let states: HashMap<String, Box<dyn ProtocolSim>> = HashMap::new();
+        let new_pairs: HashMap<String, ProtocolComponent> = HashMap::new();
+        let update = Update::new(43, states, new_pairs);
+        tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(self.state_store.apply_update(update));
+        });
+    }
+
+    fn call_count(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+struct PublishUpdateOnFirstCallEncoder {
+    state: PublishingEncoderState,
+}
+
+impl PublishUpdateOnFirstCallEncoder {
+    fn new(state_store: Arc<StateStore>, router: Bytes) -> Self {
+        Self {
+            state: PublishingEncoderState::new(state_store, router),
+        }
+    }
+
+    fn call_count(&self) -> usize {
+        self.state.call_count()
+    }
+}
+
+impl TychoEncoder for PublishUpdateOnFirstCallEncoder {
+    fn encode_solutions(
+        &self,
+        _solutions: Vec<Solution>,
+    ) -> Result<Vec<EncodedSolution>, EncodingError> {
+        if self.state.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+            self.state.publish_update();
+        }
+        Ok(vec![mock_encoded_solution(self.state.router.clone())])
+    }
+
+    fn encode_full_calldata(
+        &self,
+        _solutions: Vec<Solution>,
+    ) -> Result<Vec<Transaction>, EncodingError> {
+        Err(EncodingError::FatalError(
+            "encode_full_calldata not supported in tests".to_string(),
+        ))
+    }
+
+    fn validate_solution(&self, _solution: &Solution) -> Result<(), EncodingError> {
+        Ok(())
+    }
+}
+
+struct PublishUpdateOnEveryCallEncoder {
+    state: PublishingEncoderState,
+}
+
+impl PublishUpdateOnEveryCallEncoder {
+    fn new(state_store: Arc<StateStore>, router: Bytes) -> Self {
+        Self {
+            state: PublishingEncoderState::new(state_store, router),
+        }
+    }
+
+    fn call_count(&self) -> usize {
+        self.state.call_count()
+    }
+}
+
+impl TychoEncoder for PublishUpdateOnEveryCallEncoder {
+    fn encode_solutions(
+        &self,
+        _solutions: Vec<Solution>,
+    ) -> Result<Vec<EncodedSolution>, EncodingError> {
+        self.state.calls.fetch_add(1, Ordering::SeqCst);
+        self.state.publish_update();
+        Ok(vec![mock_encoded_solution(self.state.router.clone())])
+    }
+
+    fn encode_full_calldata(
+        &self,
+        _solutions: Vec<Solution>,
+    ) -> Result<Vec<Transaction>, EncodingError> {
+        Err(EncodingError::FatalError(
+            "encode_full_calldata not supported in tests".to_string(),
+        ))
+    }
+
+    fn validate_solution(&self, _solution: &Solution) -> Result<(), EncodingError> {
+        Ok(())
+    }
+}
+
+struct PublishUpdateWithWrongRouterEncoder {
+    state: PublishingEncoderState,
+    wrong_router: Bytes,
+}
+
+impl PublishUpdateWithWrongRouterEncoder {
+    fn new(state_store: Arc<StateStore>, router: Bytes, wrong_router: Bytes) -> Self {
+        Self {
+            state: PublishingEncoderState::new(state_store, router),
+            wrong_router,
+        }
+    }
+
+    fn call_count(&self) -> usize {
+        self.state.call_count()
+    }
+}
+
+impl TychoEncoder for PublishUpdateWithWrongRouterEncoder {
+    fn encode_solutions(
+        &self,
+        _solutions: Vec<Solution>,
+    ) -> Result<Vec<EncodedSolution>, EncodingError> {
+        self.state.calls.fetch_add(1, Ordering::SeqCst);
+        self.state.publish_update();
+        Ok(vec![mock_encoded_solution(self.wrong_router.clone())])
     }
 
     fn encode_full_calldata(
@@ -892,6 +1049,86 @@ async fn encode_route_end_to_end_returns_interactions_and_debug() -> Result<()> 
             .and_then(|resim| resim.block_number),
         Some(42)
     );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn encode_route_retries_after_first_attempt_publication() -> Result<()> {
+    let config = EncodeFixtureConfig {
+        request_id: "req-retry-success",
+        ..EncodeFixtureConfig::default()
+    };
+    let (state, request) = build_app_state_and_request(config).await?;
+    let encoder = Arc::new(PublishUpdateOnFirstCallEncoder::new(
+        Arc::clone(&state.native_state_store),
+        parse_bytes(&request.tycho_router_address)?,
+    ));
+    let runtime_encoder: Arc<dyn TychoEncoder> = encoder.clone();
+    let app = create_router(SimulatorRuntime::new_with_encoder(state, runtime_encoder));
+
+    let (status, body) = post_encode(app, &request).await?;
+
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "unexpected status {}: {}",
+        status,
+        String::from_utf8_lossy(&body)
+    );
+    assert_eq!(encoder.call_count(), 2);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn encode_route_returns_service_unavailable_after_second_publication() -> Result<()> {
+    let config = EncodeFixtureConfig {
+        request_id: "req-retry-second-trip",
+        ..EncodeFixtureConfig::default()
+    };
+    let (state, request) = build_app_state_and_request(config).await?;
+    let encoder = Arc::new(PublishUpdateOnEveryCallEncoder::new(
+        Arc::clone(&state.native_state_store),
+        parse_bytes(&request.tycho_router_address)?,
+    ));
+    let runtime_encoder: Arc<dyn TychoEncoder> = encoder.clone();
+    let app = create_router(SimulatorRuntime::new_with_encoder(state, runtime_encoder));
+
+    let (status, body) = post_encode(app, &request).await?;
+
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    let response: EncodeErrorResponse = serde_json::from_slice(&body)?;
+    assert_eq!(
+        response.error,
+        "Native state changed while the route was being encoded; retry against the current version"
+    );
+    assert_eq!(encoder.call_count(), 2);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn encode_route_returns_deterministic_error_without_retry_after_publication() -> Result<()> {
+    let config = EncodeFixtureConfig {
+        request_id: "req-deterministic-no-retry",
+        ..EncodeFixtureConfig::default()
+    };
+    let (state, request) = build_app_state_and_request(config).await?;
+    let encoder = Arc::new(PublishUpdateWithWrongRouterEncoder::new(
+        Arc::clone(&state.native_state_store),
+        parse_bytes(&request.tycho_router_address)?,
+        parse_bytes("0x0000000000000000000000000000000000000005")?,
+    ));
+    let runtime_encoder: Arc<dyn TychoEncoder> = encoder.clone();
+    let app = create_router(SimulatorRuntime::new_with_encoder(state, runtime_encoder));
+
+    let (status, body) = post_encode(app, &request).await?;
+
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    let response: EncodeErrorResponse = serde_json::from_slice(&body)?;
+    assert_eq!(
+        response.error,
+        "Encoded router address does not match request tychoRouterAddress"
+    );
+    assert_eq!(encoder.call_count(), 1);
     Ok(())
 }
 

--- a/crates/runtime/src/models/state.rs
+++ b/crates/runtime/src/models/state.rs
@@ -801,30 +801,6 @@ impl AppState {
         }
     }
 
-    pub(crate) async fn native_request_fence_status(
-        &self,
-        pinned_generation: u64,
-    ) -> NativeFenceStatus {
-        if !self.native_broadcaster_bootstrap_ready().await {
-            return NativeFenceStatus::Unavailable;
-        }
-        if is_update_stale(
-            self.native_update_age_ms().await,
-            self.native_progress_lease_ms(),
-        ) {
-            return NativeFenceStatus::Unavailable;
-        }
-        let (state_ready, requests_allowed, current_generation) =
-            self.native_state_store.request_snapshot().await;
-        if !state_ready || !requests_allowed {
-            return NativeFenceStatus::Unavailable;
-        }
-        if current_generation != pinned_generation {
-            return NativeFenceStatus::Changed;
-        }
-        NativeFenceStatus::Current
-    }
-
     pub(crate) async fn native_route_fence_status(
         &self,
         pinned: &PublishedStatePin,
@@ -861,13 +837,6 @@ impl AppState {
         // Route identity replaces only the generation test after the availability preamble.
         let current = self.native_state_store.pin().await;
         NativePoolFenceStatus::Available(pinned.changed_pool_ids(&current, pool_ids))
-    }
-
-    pub(crate) async fn native_request_is_current(&self, pinned_generation: u64) -> bool {
-        matches!(
-            self.native_request_fence_status(pinned_generation).await,
-            NativeFenceStatus::Current
-        )
     }
 
     pub async fn vm_readiness(&self) -> VmReadiness {
@@ -2365,59 +2334,6 @@ mod tests {
             .await;
         assert!(state.is_ready().await);
         assert_eq!(state.native_readiness().await, NativeReadiness::Ready);
-    }
-
-    #[tokio::test]
-    async fn native_request_generation_survives_wire_version_realignment() {
-        let state = build_readiness_test_state(false, false).await;
-        state.native_stream_health.record_update(1).await;
-        let pinned = state.native_state_store.pin().await;
-        let wire_version = pinned.version();
-
-        assert!(
-            state
-                .native_request_is_current(pinned.request_generation())
-                .await
-        );
-        assert_eq!(
-            state
-                .native_request_fence_status(pinned.request_generation())
-                .await,
-            NativeFenceStatus::Current
-        );
-
-        state.native_state_store.fence_requests().await;
-        assert!(!state.is_ready().await);
-        assert!(
-            !state
-                .native_request_is_current(pinned.request_generation())
-                .await
-        );
-        assert_eq!(
-            state
-                .native_request_fence_status(pinned.request_generation())
-                .await,
-            NativeFenceStatus::Unavailable
-        );
-
-        state
-            .native_state_store
-            .align_bootstrap_state_version(wire_version)
-            .await;
-        assert_eq!(state.native_state_store.state_version().await, wire_version);
-        assert!(state.is_ready().await);
-        assert!(
-            !state
-                .native_request_is_current(pinned.request_generation())
-                .await,
-            "realigning to the same wire version must not recreate an old request fence"
-        );
-        assert_eq!(
-            state
-                .native_request_fence_status(pinned.request_generation())
-                .await,
-            NativeFenceStatus::Changed
-        );
     }
 
     #[tokio::test]

--- a/crates/runtime/src/models/state.rs
+++ b/crates/runtime/src/models/state.rs
@@ -1220,6 +1220,10 @@ impl PublishedStatePin {
         pool_by_id_from_published(&self.state, id)
     }
 
+    /// Pointer identity is a valid fence because updates replace state and component Arcs instead
+    /// of mutating them. `get_amount_out` borrows state and returns a separate state after the
+    /// swap, while delta application requires `&mut self` upstream. Native protocol states do not
+    /// use interior mutability, which the invariant test below enforces with a real implementation.
     pub(crate) fn changed_pool_ids(
         &self,
         current: &Self,
@@ -1816,7 +1820,12 @@ mod tests {
 
     use num_bigint::BigUint;
     use tycho_simulation::{
-        protocol::models::ProtocolComponent,
+        evm::protocol::uniswap_v2::state::UniswapV2State,
+        protocol::models::{DecoderContext, ProtocolComponent, TryFromWithBlock},
+        tycho_client::feed::{
+            dto::ComponentWithState as DtoComponentWithState, synchronizer::ComponentWithState,
+            BlockHeader,
+        },
         tycho_common::{
             dto::ProtocolStateDelta,
             models::{token::Token, Chain},
@@ -3464,6 +3473,109 @@ mod tests {
                 .await,
             NativePoolFenceStatus::Available(HashSet::from(["pool-native".to_string()]))
         );
+    }
+
+    #[tokio::test]
+    async fn get_amount_out_preserves_published_pool_identity_and_result() {
+        const SNAPSHOTS_JSON: &str =
+            include_str!("../../tests/fixtures/simulation_baseline_snapshots.json");
+        const POOL_ID: &str = "uniswap-v2-baseline";
+
+        let mut snapshots: HashMap<String, DtoComponentWithState> =
+            serde_json::from_str(SNAPSHOTS_JSON)
+                .unwrap_or_else(|error| unreachable!("valid simulation snapshots: {error}"));
+        let snapshot: ComponentWithState = snapshots
+            .remove("uniswap_v2")
+            .unwrap_or_else(|| unreachable!("Uniswap V2 snapshot exists"))
+            .into();
+        let tokens = snapshot
+            .component
+            .tokens
+            .iter()
+            .enumerate()
+            .map(|(index, address)| {
+                Token::new(
+                    address,
+                    &format!("TOKEN{index}"),
+                    18,
+                    0,
+                    &[Some(10_000)],
+                    Chain::Base,
+                    100,
+                )
+            })
+            .collect::<Vec<_>>();
+        let token_in = tokens[0].clone();
+        let token_out = tokens[1].clone();
+        let all_tokens = tokens
+            .iter()
+            .cloned()
+            .map(|token| (token.address.clone(), token))
+            .collect::<HashMap<_, _>>();
+        let component = ProtocolComponent::new(
+            address(42),
+            snapshot.component.protocol_system.clone(),
+            snapshot.component.protocol_type_name.clone(),
+            snapshot.component.chain,
+            tokens.clone(),
+            snapshot.component.contract_addresses.clone(),
+            snapshot.component.static_attributes.clone(),
+            snapshot.component.creation_tx.clone(),
+            snapshot.component.created_at,
+        );
+        let pool_state = UniswapV2State::try_from_with_header(
+            snapshot,
+            BlockHeader {
+                number: 20_000_000,
+                timestamp: 1_700_000_000,
+                ..Default::default()
+            },
+            &HashMap::new(),
+            &all_tokens,
+            &DecoderContext::new(),
+        )
+        .await
+        .unwrap_or_else(|error| unreachable!("valid Uniswap V2 snapshot: {error}"));
+
+        let token_store = Arc::new(TokenStore::new(
+            HashMap::new(),
+            "http://localhost".to_string(),
+            "test".to_string(),
+            Chain::Base,
+            Duration::from_secs(1),
+        ));
+        let store = StateStore::new(token_store);
+        store
+            .apply_update(Update::new(
+                20_000_000,
+                HashMap::from([(
+                    POOL_ID.to_string(),
+                    Box::new(pool_state) as Box<dyn ProtocolSim>,
+                )]),
+                HashMap::from([(POOL_ID.to_string(), component)]),
+            ))
+            .await;
+
+        let pinned = store.pin().await;
+        let (pinned_state, _) = pinned
+            .pool_by_id(POOL_ID)
+            .unwrap_or_else(|| unreachable!("fixture pool exists"));
+        let amount_in = BigUint::from(1_000_000_000_000u64);
+        let first = pinned_state
+            .get_amount_out(amount_in.clone(), &token_in, &token_out)
+            .unwrap_or_else(|error| unreachable!("fixture swap succeeds: {error}"));
+
+        let published = store.pin().await;
+        let (published_state, _) = published
+            .pool_by_id(POOL_ID)
+            .unwrap_or_else(|| unreachable!("fixture pool exists"));
+        assert!(Arc::ptr_eq(&pinned_state, &published_state));
+
+        let repeated = pinned_state
+            .get_amount_out(amount_in, &token_in, &token_out)
+            .unwrap_or_else(|error| unreachable!("repeated fixture swap succeeds: {error}"));
+        assert_eq!(first.amount, repeated.amount);
+        assert_eq!(first.gas, repeated.gas);
     }
 
     #[tokio::test]

--- a/crates/runtime/src/models/state.rs
+++ b/crates/runtime/src/models/state.rs
@@ -528,6 +528,12 @@ pub(crate) enum NativeFenceStatus {
     Unavailable,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum NativePoolFenceStatus {
+    Available(HashSet<String>),
+    Unavailable,
+}
+
 impl EncodeAvailability {
     pub const fn availability_message(self) -> Option<&'static str> {
         match self {
@@ -817,6 +823,44 @@ impl AppState {
             return NativeFenceStatus::Changed;
         }
         NativeFenceStatus::Current
+    }
+
+    pub(crate) async fn native_route_fence_status(
+        &self,
+        pinned: &PublishedStatePin,
+        pool_ids: &HashSet<String>,
+    ) -> NativeFenceStatus {
+        match self.native_pool_fence_status(pinned, pool_ids).await {
+            NativePoolFenceStatus::Available(changed_pool_ids) if changed_pool_ids.is_empty() => {
+                NativeFenceStatus::Current
+            }
+            NativePoolFenceStatus::Available(_) => NativeFenceStatus::Changed,
+            NativePoolFenceStatus::Unavailable => NativeFenceStatus::Unavailable,
+        }
+    }
+
+    pub(crate) async fn native_pool_fence_status(
+        &self,
+        pinned: &PublishedStatePin,
+        pool_ids: &HashSet<String>,
+    ) -> NativePoolFenceStatus {
+        if !self.native_broadcaster_bootstrap_ready().await {
+            return NativePoolFenceStatus::Unavailable;
+        }
+        if is_update_stale(
+            self.native_update_age_ms().await,
+            self.native_progress_lease_ms(),
+        ) {
+            return NativePoolFenceStatus::Unavailable;
+        }
+        let (state_ready, requests_allowed, _) = self.native_state_store.request_snapshot().await;
+        if !state_ready || !requests_allowed {
+            return NativePoolFenceStatus::Unavailable;
+        }
+
+        // Route identity replaces only the generation test after the availability preamble.
+        let current = self.native_state_store.pin().await;
+        NativePoolFenceStatus::Available(pinned.changed_pool_ids(&current, pool_ids))
     }
 
     pub(crate) async fn native_request_is_current(&self, pinned_generation: u64) -> bool {
@@ -1205,6 +1249,36 @@ impl PublishedStatePin {
 
     pub(crate) fn pool_by_id(&self, id: &str) -> Option<PoolEntry> {
         pool_by_id_from_published(&self.state, id)
+    }
+
+    pub(crate) fn changed_pool_ids(
+        &self,
+        current: &Self,
+        pool_ids: &HashSet<String>,
+    ) -> HashSet<String> {
+        pool_ids
+            .iter()
+            .filter(|pool_id| {
+                let pinned_entry = self.pool_by_id(pool_id);
+                let current_entry = current.pool_by_id(pool_id);
+                match (pinned_entry, current_entry) {
+                    (None, None) => {
+                        // Neither pin has an identity that could have moved during encode.
+                        false
+                    }
+                    (None, Some(_)) | (Some(_), None) => true,
+                    (
+                        Some((pinned_state, pinned_component)),
+                        Some((current_state, current_component)),
+                    ) => {
+                        // Component identity catches pools removed and re-added between pins.
+                        !Arc::ptr_eq(&pinned_state, &current_state)
+                            || !Arc::ptr_eq(&pinned_component, &current_component)
+                    }
+                }
+            })
+            .cloned()
+            .collect()
     }
 }
 
@@ -3400,6 +3474,249 @@ mod tests {
         let ids: HashSet<String> = matches.into_iter().map(|(id, _)| id).collect();
 
         assert_eq!(ids, HashSet::from(["pool-native".to_string()]));
+    }
+
+    async fn build_native_identity_fence_state() -> AppState {
+        let state = build_readiness_test_state(false, false).await;
+        state
+            .native_state_store
+            .apply_update(mk_update(vec![(
+                "pool-b".to_string(),
+                mk_component(
+                    31,
+                    "uniswap_v2",
+                    "uniswap_v2_pool",
+                    vec![mk_token(32, "TKNC"), mk_token(33, "TKND")],
+                ),
+                Box::new(DummySim),
+            )]))
+            .await;
+        state
+    }
+
+    #[tokio::test]
+    async fn native_route_fence_tracks_touched_pool_identity_only() {
+        let state = build_native_identity_fence_state().await;
+        let pinned = state.native_state_store.pin().await;
+        let (pinned_a_state, pinned_a_component) = pinned
+            .pool_by_id("pool-native")
+            .unwrap_or_else(|| unreachable!("fixture pool exists"));
+        let (pinned_b_state, pinned_b_component) = pinned
+            .pool_by_id("pool-b")
+            .unwrap_or_else(|| unreachable!("fixture pool exists"));
+
+        state
+            .native_state_store
+            .apply_update(Update::new(
+                2,
+                HashMap::from([(
+                    "pool-native".to_string(),
+                    Box::new(DummySim) as Box<dyn ProtocolSim>,
+                )]),
+                HashMap::new(),
+            ))
+            .await;
+
+        let current = state.native_state_store.pin().await;
+        let (current_a_state, current_a_component) = current
+            .pool_by_id("pool-native")
+            .unwrap_or_else(|| unreachable!("fixture pool exists"));
+        let (current_b_state, current_b_component) = current
+            .pool_by_id("pool-b")
+            .unwrap_or_else(|| unreachable!("fixture pool exists"));
+        assert!(!Arc::ptr_eq(&pinned_a_state, &current_a_state));
+        assert!(Arc::ptr_eq(&pinned_a_component, &current_a_component));
+        assert!(Arc::ptr_eq(&pinned_b_state, &current_b_state));
+        assert!(Arc::ptr_eq(&pinned_b_component, &current_b_component));
+
+        let pool_a = HashSet::from(["pool-native".to_string()]);
+        let pool_b = HashSet::from(["pool-b".to_string()]);
+        assert_eq!(
+            state.native_route_fence_status(&pinned, &pool_a).await,
+            NativeFenceStatus::Changed
+        );
+        assert_eq!(
+            state.native_route_fence_status(&pinned, &pool_b).await,
+            NativeFenceStatus::Current
+        );
+        assert_eq!(
+            state
+                .native_pool_fence_status(
+                    &pinned,
+                    &HashSet::from(["pool-native".to_string(), "pool-b".to_string()])
+                )
+                .await,
+            NativePoolFenceStatus::Available(HashSet::from(["pool-native".to_string()]))
+        );
+    }
+
+    #[tokio::test]
+    async fn native_route_fence_marks_removed_pool_changed() {
+        let state = build_native_identity_fence_state().await;
+        let pinned = state.native_state_store.pin().await;
+        let component = pinned
+            .pool_by_id("pool-native")
+            .map(|(_, component)| component.as_ref().clone())
+            .unwrap_or_else(|| unreachable!("fixture pool exists"));
+
+        state
+            .native_state_store
+            .apply_update(
+                Update::new(2, HashMap::new(), HashMap::new())
+                    .set_removed_pairs(HashMap::from([("pool-native".to_string(), component)])),
+            )
+            .await;
+
+        assert_eq!(
+            state
+                .native_route_fence_status(&pinned, &HashSet::from(["pool-native".to_string()]))
+                .await,
+            NativeFenceStatus::Changed
+        );
+    }
+
+    #[tokio::test]
+    async fn native_route_fence_distinguishes_missing_removed_and_added_pools() {
+        let state = build_native_identity_fence_state().await;
+        let pinned = state.native_state_store.pin().await;
+        let removed_component = pinned
+            .pool_by_id("pool-native")
+            .map(|(_, component)| component.as_ref().clone())
+            .unwrap_or_else(|| unreachable!("fixture pool exists"));
+        let added_component = mk_component(
+            34,
+            "uniswap_v2",
+            "uniswap_v2_pool",
+            vec![mk_token(35, "TKNE"), mk_token(36, "TKNF")],
+        );
+
+        state
+            .native_state_store
+            .apply_update(
+                mk_update(vec![(
+                    "pool-added".to_string(),
+                    added_component,
+                    Box::new(DummySim),
+                )])
+                .set_removed_pairs(HashMap::from([(
+                    "pool-native".to_string(),
+                    removed_component,
+                )])),
+            )
+            .await;
+
+        let missing_pool = HashSet::from(["pool-missing".to_string()]);
+        assert_eq!(
+            state
+                .native_route_fence_status(&pinned, &missing_pool)
+                .await,
+            NativeFenceStatus::Current
+        );
+        assert_eq!(
+            state.native_pool_fence_status(&pinned, &missing_pool).await,
+            NativePoolFenceStatus::Available(HashSet::new())
+        );
+        assert_eq!(
+            state
+                .native_route_fence_status(&pinned, &HashSet::from(["pool-native".to_string()]))
+                .await,
+            NativeFenceStatus::Changed
+        );
+        assert_eq!(
+            state
+                .native_route_fence_status(&pinned, &HashSet::from(["pool-added".to_string()]))
+                .await,
+            NativeFenceStatus::Changed
+        );
+    }
+
+    #[tokio::test]
+    async fn native_pool_identity_marks_full_reset_changed() {
+        let state = build_native_identity_fence_state().await;
+        let pinned = state.native_state_store.pin().await;
+
+        state.native_state_store.reset().await;
+        let current = state.native_state_store.pin().await;
+
+        assert_eq!(
+            pinned.changed_pool_ids(
+                &current,
+                &HashSet::from(["pool-native".to_string(), "pool-b".to_string()])
+            ),
+            HashSet::from(["pool-native".to_string(), "pool-b".to_string()])
+        );
+    }
+
+    #[tokio::test]
+    async fn native_route_fence_ignores_bootstrap_version_alignment() {
+        let state = build_native_identity_fence_state().await;
+        let pinned = state.native_state_store.pin().await;
+
+        state
+            .native_state_store
+            .align_bootstrap_state_version(pinned.version())
+            .await;
+
+        let current = state.native_state_store.pin().await;
+        assert_ne!(
+            pinned.request_generation(),
+            current.request_generation(),
+            "alignment should still advance the request generation"
+        );
+        assert_eq!(
+            state
+                .native_route_fence_status(&pinned, &HashSet::from(["pool-native".to_string()]))
+                .await,
+            NativeFenceStatus::Current
+        );
+    }
+
+    #[tokio::test]
+    async fn native_route_fence_marks_recovery_candidate_changed() {
+        let state = build_native_identity_fence_state().await;
+        let pinned = state.native_state_store.pin().await;
+        let candidate_store = StateStore::new_private(Arc::clone(&state.tokens));
+        candidate_store
+            .apply_update(mk_update(vec![(
+                "pool-native".to_string(),
+                mk_component(
+                    28,
+                    "uniswap_v2",
+                    "uniswap_v2_pool",
+                    vec![mk_token(29, "TKNA"), mk_token(30, "TKNB")],
+                ),
+                Box::new(DummySim),
+            )]))
+            .await;
+        let candidate = candidate_store.pin().await;
+
+        state
+            .native_state_store
+            .publish_candidate(candidate, pinned.version().saturating_add(1))
+            .await
+            .unwrap_or_else(|error| unreachable!("newer candidate publishes: {error}"));
+
+        assert_eq!(
+            state
+                .native_route_fence_status(&pinned, &HashSet::from(["pool-native".to_string()]))
+                .await,
+            NativeFenceStatus::Changed
+        );
+    }
+
+    #[tokio::test]
+    async fn native_route_fence_reports_fenced_requests_unavailable() {
+        let state = build_native_identity_fence_state().await;
+        let pinned = state.native_state_store.pin().await;
+
+        state.native_state_store.fence_requests().await;
+
+        assert_eq!(
+            state
+                .native_route_fence_status(&pinned, &HashSet::from(["pool-native".to_string()]))
+                .await,
+            NativeFenceStatus::Unavailable
+        );
     }
 
     #[tokio::test]

--- a/crates/runtime/src/models/state.rs
+++ b/crates/runtime/src/models/state.rs
@@ -815,22 +815,27 @@ impl AppState {
         }
     }
 
+    pub(crate) async fn native_request_availability(&self) -> (bool, u64) {
+        let bootstrap_ready = self.native_broadcaster_bootstrap_ready().await;
+        let update_is_stale = is_update_stale(
+            self.native_update_age_ms().await,
+            self.native_progress_lease_ms(),
+        );
+        let (state_ready, requests_allowed, current_generation) =
+            self.native_state_store.request_snapshot().await;
+        (
+            bootstrap_ready && !update_is_stale && state_ready && requests_allowed,
+            current_generation,
+        )
+    }
+
     pub(crate) async fn native_pool_fence_status(
         &self,
         pinned: &PublishedStatePin,
         pool_ids: &HashSet<String>,
     ) -> NativePoolFenceStatus {
-        if !self.native_broadcaster_bootstrap_ready().await {
-            return NativePoolFenceStatus::Unavailable;
-        }
-        if is_update_stale(
-            self.native_update_age_ms().await,
-            self.native_progress_lease_ms(),
-        ) {
-            return NativePoolFenceStatus::Unavailable;
-        }
-        let (state_ready, requests_allowed, _) = self.native_state_store.request_snapshot().await;
-        if !state_ready || !requests_allowed {
+        let (available, _) = self.native_request_availability().await;
+        if !available {
             return NativePoolFenceStatus::Unavailable;
         }
 

--- a/crates/runtime/src/models/state.rs
+++ b/crates/runtime/src/models/state.rs
@@ -521,6 +521,13 @@ pub enum EncodeAvailability {
     RfqStale,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NativeFenceStatus {
+    Current,
+    Changed,
+    Unavailable,
+}
+
 impl EncodeAvailability {
     pub const fn availability_message(self) -> Option<&'static str> {
         match self {
@@ -788,19 +795,35 @@ impl AppState {
         }
     }
 
-    pub(crate) async fn native_request_is_current(&self, pinned_generation: u64) -> bool {
+    pub(crate) async fn native_request_fence_status(
+        &self,
+        pinned_generation: u64,
+    ) -> NativeFenceStatus {
         if !self.native_broadcaster_bootstrap_ready().await {
-            return false;
+            return NativeFenceStatus::Unavailable;
         }
         if is_update_stale(
             self.native_update_age_ms().await,
             self.native_progress_lease_ms(),
         ) {
-            return false;
+            return NativeFenceStatus::Unavailable;
         }
         let (state_ready, requests_allowed, current_generation) =
             self.native_state_store.request_snapshot().await;
-        state_ready && requests_allowed && current_generation == pinned_generation
+        if !state_ready || !requests_allowed {
+            return NativeFenceStatus::Unavailable;
+        }
+        if current_generation != pinned_generation {
+            return NativeFenceStatus::Changed;
+        }
+        NativeFenceStatus::Current
+    }
+
+    pub(crate) async fn native_request_is_current(&self, pinned_generation: u64) -> bool {
+        matches!(
+            self.native_request_fence_status(pinned_generation).await,
+            NativeFenceStatus::Current
+        )
     }
 
     pub async fn vm_readiness(&self) -> VmReadiness {
@@ -2282,6 +2305,12 @@ mod tests {
                 .native_request_is_current(pinned.request_generation())
                 .await
         );
+        assert_eq!(
+            state
+                .native_request_fence_status(pinned.request_generation())
+                .await,
+            NativeFenceStatus::Current
+        );
 
         state.native_state_store.fence_requests().await;
         assert!(!state.is_ready().await);
@@ -2289,6 +2318,12 @@ mod tests {
             !state
                 .native_request_is_current(pinned.request_generation())
                 .await
+        );
+        assert_eq!(
+            state
+                .native_request_fence_status(pinned.request_generation())
+                .await,
+            NativeFenceStatus::Unavailable
         );
 
         state
@@ -2302,6 +2337,12 @@ mod tests {
                 .native_request_is_current(pinned.request_generation())
                 .await,
             "realigning to the same wire version must not recreate an old request fence"
+        );
+        assert_eq!(
+            state
+                .native_request_fence_status(pinned.request_generation())
+                .await,
+            NativeFenceStatus::Changed
         );
     }
 

--- a/crates/runtime/src/models/state.rs
+++ b/crates/runtime/src/models/state.rs
@@ -529,6 +529,12 @@ pub(crate) enum NativeFenceStatus {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NativeRouteFenceCheck {
+    pub(crate) status: NativeFenceStatus,
+    pub(crate) current_generation: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum NativePoolFenceStatus {
     Available(HashSet<String>),
     Unavailable,
@@ -805,13 +811,21 @@ impl AppState {
         &self,
         pinned: &PublishedStatePin,
         pool_ids: &HashSet<String>,
-    ) -> NativeFenceStatus {
-        match self.native_pool_fence_status(pinned, pool_ids).await {
+    ) -> NativeRouteFenceCheck {
+        let current = self.native_state_store.pin().await;
+        let status = match self
+            .native_pool_fence_status(pinned, &current, pool_ids)
+            .await
+        {
             NativePoolFenceStatus::Available(changed_pool_ids) if changed_pool_ids.is_empty() => {
                 NativeFenceStatus::Current
             }
             NativePoolFenceStatus::Available(_) => NativeFenceStatus::Changed,
             NativePoolFenceStatus::Unavailable => NativeFenceStatus::Unavailable,
+        };
+        NativeRouteFenceCheck {
+            status,
+            current_generation: current.request_generation(),
         }
     }
 
@@ -832,16 +846,25 @@ impl AppState {
     pub(crate) async fn native_pool_fence_status(
         &self,
         pinned: &PublishedStatePin,
+        current: &PublishedStatePin,
         pool_ids: &HashSet<String>,
     ) -> NativePoolFenceStatus {
-        let (available, _) = self.native_request_availability().await;
-        if !available {
+        if !self.native_broadcaster_bootstrap_ready().await {
             return NativePoolFenceStatus::Unavailable;
         }
-
-        // Route identity replaces only the generation test after the availability preamble.
-        let current = self.native_state_store.pin().await;
-        NativePoolFenceStatus::Available(pinned.changed_pool_ids(&current, pool_ids))
+        if is_update_stale(
+            self.native_update_age_ms().await,
+            self.native_progress_lease_ms(),
+        ) {
+            return NativePoolFenceStatus::Unavailable;
+        }
+        // The request flags must come from the same publication as the identity compare.
+        // fence_requests only flips requests_allowed and keeps every pool Arc, so a fence
+        // landing between a separate availability read and the pin would pass as Current.
+        if !current.state.ready || !current.state.requests_allowed {
+            return NativePoolFenceStatus::Unavailable;
+        }
+        NativePoolFenceStatus::Available(pinned.changed_pool_ids(current, pool_ids))
     }
 
     pub async fn vm_readiness(&self) -> VmReadiness {
@@ -3462,17 +3485,24 @@ mod tests {
         let pool_a = HashSet::from(["pool-native".to_string()]);
         let pool_b = HashSet::from(["pool-b".to_string()]);
         assert_eq!(
-            state.native_route_fence_status(&pinned, &pool_a).await,
+            state
+                .native_route_fence_status(&pinned, &pool_a)
+                .await
+                .status,
             NativeFenceStatus::Changed
         );
         assert_eq!(
-            state.native_route_fence_status(&pinned, &pool_b).await,
+            state
+                .native_route_fence_status(&pinned, &pool_b)
+                .await
+                .status,
             NativeFenceStatus::Current
         );
         assert_eq!(
             state
                 .native_pool_fence_status(
                     &pinned,
+                    &current,
                     &HashSet::from(["pool-native".to_string(), "pool-b".to_string()])
                 )
                 .await,
@@ -3603,7 +3633,8 @@ mod tests {
         assert_eq!(
             state
                 .native_route_fence_status(&pinned, &HashSet::from(["pool-native".to_string()]))
-                .await,
+                .await
+                .status,
             NativeFenceStatus::Changed
         );
     }
@@ -3642,23 +3673,29 @@ mod tests {
         assert_eq!(
             state
                 .native_route_fence_status(&pinned, &missing_pool)
-                .await,
+                .await
+                .status,
             NativeFenceStatus::Current
         );
+        let current = state.native_state_store.pin().await;
         assert_eq!(
-            state.native_pool_fence_status(&pinned, &missing_pool).await,
+            state
+                .native_pool_fence_status(&pinned, &current, &missing_pool)
+                .await,
             NativePoolFenceStatus::Available(HashSet::new())
         );
         assert_eq!(
             state
                 .native_route_fence_status(&pinned, &HashSet::from(["pool-native".to_string()]))
-                .await,
+                .await
+                .status,
             NativeFenceStatus::Changed
         );
         assert_eq!(
             state
                 .native_route_fence_status(&pinned, &HashSet::from(["pool-added".to_string()]))
-                .await,
+                .await
+                .status,
             NativeFenceStatus::Changed
         );
     }
@@ -3699,7 +3736,8 @@ mod tests {
         assert_eq!(
             state
                 .native_route_fence_status(&pinned, &HashSet::from(["pool-native".to_string()]))
-                .await,
+                .await
+                .status,
             NativeFenceStatus::Current
         );
     }
@@ -3732,7 +3770,8 @@ mod tests {
         assert_eq!(
             state
                 .native_route_fence_status(&pinned, &HashSet::from(["pool-native".to_string()]))
-                .await,
+                .await
+                .status,
             NativeFenceStatus::Changed
         );
     }
@@ -3747,7 +3786,8 @@ mod tests {
         assert_eq!(
             state
                 .native_route_fence_status(&pinned, &HashSet::from(["pool-native".to_string()]))
-                .await,
+                .await
+                .status,
             NativeFenceStatus::Unavailable
         );
     }

--- a/crates/runtime/src/services/encode.rs
+++ b/crates/runtime/src/services/encode.rs
@@ -18,6 +18,7 @@ mod mocks;
 pub use error::{EncodeError, EncodeErrorKind};
 pub use response::{log_failure, log_handler_timeout, log_received, log_success};
 
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -151,14 +152,18 @@ async fn encode_route(
     for attempt_number in [AttemptNumber::First, AttemptNumber::Second] {
         let attempt = encode_attempt(&state, &prepared, attempt_number).await;
         let outcome_class = attempt.outcome.class();
-        let fence_status = if outcome_class == AttemptOutcomeClass::Deterministic {
-            NativeFenceStatus::Current
+        let fence_evaluation = if outcome_class == AttemptOutcomeClass::Deterministic {
+            None
         } else {
-            attempt.native_fence.status(&state).await
+            attempt.native_fence.evaluate(&state).await
         };
+        let fence_status = fence_evaluation
+            .as_ref()
+            .map_or(NativeFenceStatus::Current, |evaluation| evaluation.status);
 
         match resolve_attempt(outcome_class, fence_status, attempt_number) {
             AttemptResolution::ReturnOutcome => {
+                log_fence(&fence_evaluation, &prepared, attempt_number, "pass");
                 return attempt.outcome.into_result().map(|mut computation| {
                     computation.attempts = attempt_number.value();
                     computation.first_attempt_expected_amount_out =
@@ -181,6 +186,12 @@ async fn encode_route(
                     prepared.backend_usage.rfq,
                 );
                 if !budget.can_start {
+                    log_fence(
+                        &fence_evaluation,
+                        &prepared,
+                        attempt_number,
+                        "retry_skipped_budget",
+                    );
                     response::log_retry_skipped_budget(
                         prepared.request.request_id.as_deref(),
                         budget.remaining,
@@ -190,6 +201,7 @@ async fn encode_route(
                     return Err(native_state_changed_error());
                 }
 
+                log_fence(&fence_evaluation, &prepared, attempt_number, "retry");
                 let trigger = if outcome_class == AttemptOutcomeClass::Success {
                     RetryTrigger::Fence
                 } else {
@@ -207,6 +219,12 @@ async fn encode_route(
                 first_attempt_expected_amount_out = first_expected_amount_out;
             }
             AttemptResolution::ReturnNativeStateChanged => {
+                log_fence(
+                    &fence_evaluation,
+                    &prepared,
+                    attempt_number,
+                    "second_trip_abort",
+                );
                 response::log_second_trip_abort(
                     prepared.request.request_id.as_deref(),
                     outcome_class.label(),
@@ -217,6 +235,7 @@ async fn encode_route(
                 return Err(native_state_changed_error());
             }
             AttemptResolution::ReturnNativeUnavailable => {
+                log_fence(&fence_evaluation, &prepared, attempt_number, "unavailable");
                 return Err(native_state_changed_error());
             }
         }
@@ -304,13 +323,22 @@ async fn encode_attempt(
     } else {
         None
     };
-    let native_fence = NativeAttemptFence::from_pin(native_pin.as_ref());
-    let outcome = encode_attempt_with_pin(state, prepared, attempt_number, native_pin).await;
+    let execution =
+        encode_attempt_with_pin(state, prepared, attempt_number, native_pin.clone()).await;
+    let native_pool_ids = execution
+        .native_pool_ids
+        .unwrap_or_else(|| normalized_native_pool_ids(&prepared.normalized));
+    let native_fence = NativeAttemptFence::new(native_pin, native_pool_ids);
 
     EncodeAttempt {
-        outcome: AttemptOutcome::from_result(outcome),
+        outcome: AttemptOutcome::from_result(execution.outcome),
         native_fence,
     }
+}
+
+struct EncodeAttemptExecution {
+    outcome: Result<EncodeComputation, AttemptError>,
+    native_pool_ids: Option<HashSet<String>>,
 }
 
 async fn encode_attempt_with_pin(
@@ -318,7 +346,7 @@ async fn encode_attempt_with_pin(
     prepared: &PreparedEncodeRoute,
     attempt_number: AttemptNumber,
     native_pin: Option<PublishedStatePin>,
-) -> Result<EncodeComputation, AttemptError> {
+) -> EncodeAttemptExecution {
     let rebuild_guard = state
         .acquire_simulation_rebuild_guard(prepared.backend_usage.vm, prepared.backend_usage.rfq)
         .await;
@@ -330,11 +358,14 @@ async fn encode_attempt_with_pin(
         )
         .await;
     if let Some(message) = availability.availability_message() {
-        return Err(AttemptError::deterministic(EncodeError::unavailable(
-            message,
-        )));
+        return EncodeAttemptExecution {
+            outcome: Err(AttemptError::deterministic(EncodeError::unavailable(
+                message,
+            ))),
+            native_pool_ids: None,
+        };
     }
-    let resimulated = resimulate::resimulate_route_with_native_pin(
+    let resimulated = match resimulate::resimulate_route_with_native_pin(
         state,
         &prepared.normalized,
         prepared.chain,
@@ -344,7 +375,31 @@ async fn encode_attempt_with_pin(
         rebuild_guard,
         native_pin,
     )
-    .await?;
+    .await
+    {
+        Ok(resimulated) => resimulated,
+        Err(error) => {
+            return EncodeAttemptExecution {
+                outcome: Err(error),
+                native_pool_ids: None,
+            };
+        }
+    };
+    let native_pool_ids = resimulated_native_pool_ids(&resimulated);
+    let outcome = complete_encode_attempt(state, prepared, attempt_number, resimulated).await;
+
+    EncodeAttemptExecution {
+        outcome,
+        native_pool_ids: Some(native_pool_ids),
+    }
+}
+
+async fn complete_encode_attempt(
+    state: &AppState,
+    prepared: &PreparedEncodeRoute,
+    attempt_number: AttemptNumber,
+    resimulated: model::ResimulatedRouteInternal,
+) -> Result<EncodeComputation, AttemptError> {
     response::log_resimulation_amounts(
         prepared.request.request_id.as_deref(),
         attempt_number.value(),
@@ -393,23 +448,82 @@ async fn encode_attempt_with_pin(
     })
 }
 
+fn normalized_native_pool_ids(normalized: &NormalizedRouteInternal) -> HashSet<String> {
+    normalized
+        .segments
+        .iter()
+        .flat_map(|segment| segment.hops.iter())
+        .flat_map(|hop| hop.swaps.iter())
+        .filter(|swap| backend::PoolBackend::from_protocol_hint(&swap.pool.protocol).is_native())
+        .map(|swap| swap.pool.component_id.clone())
+        .collect()
+}
+
+fn resimulated_native_pool_ids(resimulated: &model::ResimulatedRouteInternal) -> HashSet<String> {
+    // Reused pools can carry route-local state Arcs. Compare the published entries by ID.
+    // Store fallback can find a native pool absent from the pin. One retry converges.
+    resimulated
+        .segments
+        .iter()
+        .flat_map(|segment| segment.hops.iter())
+        .flat_map(|hop| hop.swaps.iter())
+        .filter(|swap| swap.backend.is_native())
+        .map(|swap| swap.pool.component_id.clone())
+        .collect()
+}
+
 struct NativeAttemptFence {
-    request_generation: Option<u64>,
+    pin: Option<PublishedStatePin>,
+    native_pool_ids: HashSet<String>,
 }
 
 impl NativeAttemptFence {
-    fn from_pin(pin: Option<&PublishedStatePin>) -> Self {
+    fn new(pin: Option<PublishedStatePin>, native_pool_ids: HashSet<String>) -> Self {
         Self {
-            request_generation: pin.map(PublishedStatePin::request_generation),
+            pin,
+            native_pool_ids,
         }
     }
 
-    async fn status(&self, state: &AppState) -> NativeFenceStatus {
-        let Some(request_generation) = self.request_generation else {
-            return NativeFenceStatus::Current;
-        };
-        state.native_request_fence_status(request_generation).await
+    async fn evaluate(&self, state: &AppState) -> Option<NativeFenceEvaluation> {
+        let pinned = self.pin.as_ref()?;
+        let status = state
+            .native_route_fence_status(pinned, &self.native_pool_ids)
+            .await;
+        let current_generation = state.native_state_store.pin().await.request_generation();
+        Some(NativeFenceEvaluation {
+            status,
+            generation_moved: current_generation != pinned.request_generation(),
+            identity_changed: status == NativeFenceStatus::Changed,
+            native_pool_count: self.native_pool_ids.len(),
+        })
     }
+}
+
+struct NativeFenceEvaluation {
+    status: NativeFenceStatus,
+    generation_moved: bool,
+    identity_changed: bool,
+    native_pool_count: usize,
+}
+
+fn log_fence(
+    evaluation: &Option<NativeFenceEvaluation>,
+    prepared: &PreparedEncodeRoute,
+    attempt_number: AttemptNumber,
+    outcome: &str,
+) {
+    let Some(evaluation) = evaluation.as_ref() else {
+        return;
+    };
+    response::log_fence_evaluation(
+        prepared.request.request_id.as_deref(),
+        attempt_number.value(),
+        evaluation.generation_moved,
+        evaluation.identity_changed,
+        evaluation.native_pool_count,
+        outcome,
+    );
 }
 
 enum AttemptOutcome {

--- a/crates/runtime/src/services/encode.rs
+++ b/crates/runtime/src/services/encode.rs
@@ -19,16 +19,26 @@ pub use error::{EncodeError, EncodeErrorKind};
 pub use response::{log_failure, log_handler_timeout, log_received, log_success};
 
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crate::models::messages::{RouteEncodeRequest, RouteEncodeResponse};
-use crate::models::state::{AppState, PublishedStatePin};
+use crate::models::state::{AppState, NativeFenceStatus, PublishedStatePin};
 use error::AttemptError;
+use model::NormalizedRouteInternal;
+use num_bigint::BigUint;
 use tycho_execution::encoding::tycho_encoder::TychoEncoder;
 use tycho_simulation::tycho_common::{models::Chain, Bytes};
 
+use super::stream_builder::ENCODE_RFQ_QUOTE_TIMEOUT;
+
 type EncoderFactory =
     Arc<dyn Fn(Chain, Bytes) -> Result<Arc<dyn TychoEncoder>, AttemptError> + Send + Sync>;
+
+const MAX_ENCODE_ATTEMPTS: u8 = 2;
+const RETRY_RFQ_BUDGET_MARGIN: Duration = Duration::from_millis(500);
+const RETRY_NATIVE_BUDGET_FLOOR: Duration = Duration::from_millis(300);
+const NATIVE_STATE_CHANGED_MESSAGE: &str =
+    "Native state changed while the route was being encoded; retry against the current version";
 
 /// Transport-free runtime wrapper for `/encode` route encoding.
 #[derive(Clone)]
@@ -75,6 +85,8 @@ impl EncodeService {
             self.state.clone(),
             request,
             Arc::clone(&self.encoder_factory),
+            started_at,
+            request_timeout,
         );
 
         let Ok(computation) = tokio::time::timeout(request_timeout, computation_future).await
@@ -100,17 +112,124 @@ pub struct EncodeComputation {
     pub expected_amount_out: String,
     pub amount_out_delta: String,
     pub reset_approval: bool,
+    pub attempts: u8,
+    pub first_attempt_expected_amount_out: Option<String>,
 }
 
-#[expect(
-    clippy::too_many_lines,
-    reason = "request validation, pinning, resimulation, and final fencing stay visible in one request flow"
-)]
+struct PreparedEncodeRoute {
+    request: RouteEncodeRequest,
+    chain: Chain,
+    token_in: Bytes,
+    token_out: Bytes,
+    amount_in: BigUint,
+    min_amount_out: BigUint,
+    router_address: Bytes,
+    is_native_input: bool,
+    normalized: NormalizedRouteInternal,
+    backend_usage: RouteBackendUsage,
+    reset_approval: bool,
+    encoder: Arc<dyn TychoEncoder>,
+}
+
+#[derive(Clone, Copy)]
+struct RouteBackendUsage {
+    native: bool,
+    vm: bool,
+    rfq: bool,
+}
+
 async fn encode_route(
     state: AppState,
     request: RouteEncodeRequest,
     encoder_factory: EncoderFactory,
+    started_at: Instant,
+    request_timeout: Duration,
 ) -> Result<EncodeComputation, EncodeError> {
+    let prepared = prepare_encode_route(&state, request, encoder_factory).await?;
+    let mut first_attempt_expected_amount_out = None;
+
+    for attempt_number in [AttemptNumber::First, AttemptNumber::Second] {
+        let attempt = encode_attempt(&state, &prepared, attempt_number).await;
+        let outcome_class = attempt.outcome.class();
+        let fence_status = if outcome_class == AttemptOutcomeClass::Deterministic {
+            NativeFenceStatus::Current
+        } else {
+            attempt.native_fence.status(&state).await
+        };
+
+        match resolve_attempt(outcome_class, fence_status, attempt_number) {
+            AttemptResolution::ReturnOutcome => {
+                return attempt.outcome.into_result().map(|mut computation| {
+                    computation.attempts = attempt_number.value();
+                    computation.first_attempt_expected_amount_out =
+                        first_attempt_expected_amount_out.clone();
+                    computation
+                });
+            }
+            AttemptResolution::Retry => {
+                let first_error_kind = attempt.outcome.error().map(EncodeError::kind);
+                let first_error_message = attempt
+                    .outcome
+                    .error()
+                    .map(EncodeError::message)
+                    .map(str::to_string);
+                let first_expected_amount_out =
+                    attempt.outcome.expected_amount_out().map(str::to_string);
+                let budget = retry_budget(
+                    request_timeout,
+                    started_at.elapsed(),
+                    prepared.backend_usage.rfq,
+                );
+                if !budget.can_start {
+                    response::log_retry_skipped_budget(
+                        prepared.request.request_id.as_deref(),
+                        budget.remaining,
+                        started_at.elapsed(),
+                        prepared.backend_usage.rfq,
+                    );
+                    return Err(native_state_changed_error());
+                }
+
+                let trigger = if outcome_class == AttemptOutcomeClass::Success {
+                    RetryTrigger::Fence
+                } else {
+                    RetryTrigger::StateDependentError
+                };
+                response::log_retry_fired(
+                    prepared.request.request_id.as_deref(),
+                    trigger.label(),
+                    first_error_kind,
+                    first_error_message.as_deref(),
+                    first_expected_amount_out.as_deref(),
+                    started_at.elapsed(),
+                    prepared.backend_usage.rfq,
+                );
+                first_attempt_expected_amount_out = first_expected_amount_out;
+            }
+            AttemptResolution::ReturnNativeStateChanged => {
+                response::log_second_trip_abort(
+                    prepared.request.request_id.as_deref(),
+                    outcome_class.label(),
+                    attempt.outcome.error().map(EncodeError::message),
+                    attempt.outcome.expected_amount_out(),
+                    started_at.elapsed(),
+                );
+                return Err(native_state_changed_error());
+            }
+            AttemptResolution::ReturnNativeUnavailable => {
+                return Err(native_state_changed_error());
+            }
+        }
+    }
+
+    unreachable!("encode attempt loop always returns after attempt two")
+}
+
+async fn prepare_encode_route(
+    state: &AppState,
+    request: RouteEncodeRequest,
+    encoder_factory: EncoderFactory,
+) -> Result<PreparedEncodeRoute, EncodeError> {
     let chain = request::validate_chain(request.chain_id, state.chain)?;
     request::validate_swap_kinds(&request)?;
 
@@ -137,84 +256,129 @@ async fn encode_route(
         allowlist,
     )?;
     let (uses_native, uses_vm, uses_rfq) = normalize::route_backend_usage(&normalized);
+    let backend_usage = RouteBackendUsage {
+        native: uses_native,
+        vm: uses_vm,
+        rfq: uses_rfq,
+    };
     let availability = state
         .encode_availability(uses_native, uses_vm, uses_rfq)
         .await;
     if let Some(message) = availability.availability_message() {
         return Err(EncodeError::unavailable(message));
     }
-    let native_pin = if uses_native {
+
+    // Build the encoder once so retries repeat only state-dependent work.
+    let encoder = encoder_factory(chain, router_address.clone()).map_err(EncodeError::from)?;
+    let reset_approval =
+        request::should_reset_allowance(&state.reset_allowance_tokens, request.chain_id, &token_in);
+
+    Ok(PreparedEncodeRoute {
+        request,
+        chain,
+        token_in,
+        token_out,
+        amount_in,
+        min_amount_out,
+        router_address,
+        is_native_input,
+        normalized,
+        backend_usage,
+        reset_approval,
+        encoder,
+    })
+}
+
+struct EncodeAttempt {
+    outcome: AttemptOutcome,
+    native_fence: NativeAttemptFence,
+}
+
+async fn encode_attempt(
+    state: &AppState,
+    prepared: &PreparedEncodeRoute,
+    attempt_number: AttemptNumber,
+) -> EncodeAttempt {
+    let native_pin = if prepared.backend_usage.native {
         Some(state.native_state_store.pin().await)
     } else {
         None
     };
-    let native_request_generation = native_pin
-        .as_ref()
-        .map(PublishedStatePin::request_generation);
+    let native_fence = NativeAttemptFence::from_pin(native_pin.as_ref());
+    let outcome = encode_attempt_with_pin(state, prepared, attempt_number, native_pin).await;
+
+    EncodeAttempt {
+        outcome: AttemptOutcome::from_result(outcome),
+        native_fence,
+    }
+}
+
+async fn encode_attempt_with_pin(
+    state: &AppState,
+    prepared: &PreparedEncodeRoute,
+    attempt_number: AttemptNumber,
+    native_pin: Option<PublishedStatePin>,
+) -> Result<EncodeComputation, AttemptError> {
     let rebuild_guard = state
-        .acquire_simulation_rebuild_guard(uses_vm, uses_rfq)
+        .acquire_simulation_rebuild_guard(prepared.backend_usage.vm, prepared.backend_usage.rfq)
         .await;
     let availability = state
-        .encode_availability(uses_native, uses_vm, uses_rfq)
+        .encode_availability(
+            prepared.backend_usage.native,
+            prepared.backend_usage.vm,
+            prepared.backend_usage.rfq,
+        )
         .await;
     if let Some(message) = availability.availability_message() {
-        return Err(EncodeError::unavailable(message));
+        return Err(AttemptError::deterministic(EncodeError::unavailable(
+            message,
+        )));
     }
     let resimulated = resimulate::resimulate_route_with_native_pin(
-        &state,
-        &normalized,
-        chain,
-        &token_in,
-        &token_out,
-        allowlist,
+        state,
+        &prepared.normalized,
+        prepared.chain,
+        &prepared.token_in,
+        &prepared.token_out,
+        &state.native_token_protocol_allowlist,
         rebuild_guard,
         native_pin,
     )
-    .await
-    .map_err(EncodeError::from)?;
-    response::log_resimulation_amounts(request.request_id.as_deref(), &resimulated);
+    .await?;
+    response::log_resimulation_amounts(
+        prepared.request.request_id.as_deref(),
+        attempt_number.value(),
+        &resimulated,
+    );
     let expected_total = response::compute_expected_total(&resimulated);
-    if expected_total < min_amount_out {
-        return Err(EncodeError::simulation(
+    if expected_total < prepared.min_amount_out {
+        return Err(AttemptError::state_dependent(EncodeError::simulation(
             "Route expectedAmountOut below minAmountOut",
-        ));
+        )));
     }
-    let amount_out_delta = (&expected_total - &min_amount_out).to_string();
-    let encoder = encoder_factory(chain, router_address.clone()).map_err(EncodeError::from)?;
+    let amount_out_delta = (&expected_total - &prepared.min_amount_out).to_string();
     let route_context = calldata::RouteContext {
-        request: &request,
-        token_in: &token_in,
-        token_out: &token_out,
-        amount_in: &amount_in,
-        router_address: &router_address,
-        is_native_input,
+        request: &prepared.request,
+        token_in: &prepared.token_in,
+        token_out: &prepared.token_out,
+        amount_in: &prepared.amount_in,
+        router_address: &prepared.router_address,
+        is_native_input: prepared.is_native_input,
     };
     let router_call = calldata::build_route_calldata_tx(
         &route_context,
         &resimulated,
-        encoder.as_ref(),
-        &min_amount_out,
-    )
-    .map_err(EncodeError::from)?;
-    let reset_approval =
-        request::should_reset_allowance(&state.reset_allowance_tokens, request.chain_id, &token_in);
+        prepared.encoder.as_ref(),
+        &prepared.min_amount_out,
+    )?;
     let interactions = calldata::build_settlement_interactions(
-        &token_in,
-        &amount_in,
+        &prepared.token_in,
+        &prepared.amount_in,
         router_call,
-        reset_approval,
-        is_native_input,
-    )
-    .map_err(EncodeError::from)?;
-
-    let debug = response::build_debug(&state, &request).await;
-    if let Some(native_request_generation) = native_request_generation {
-        ensure_native_encode_current(
-            state
-                .native_request_is_current(native_request_generation)
-                .await,
-        )?;
-    }
+        prepared.reset_approval,
+        prepared.is_native_input,
+    )?;
+    let debug = response::build_debug(state, &prepared.request).await;
 
     Ok(EncodeComputation {
         response: RouteEncodeResponse {
@@ -223,26 +387,249 @@ async fn encode_route(
         },
         expected_amount_out: expected_total.to_string(),
         amount_out_delta,
-        reset_approval,
+        reset_approval: prepared.reset_approval,
+        attempts: attempt_number.value(),
+        first_attempt_expected_amount_out: None,
     })
 }
 
-fn ensure_native_encode_current(native_is_current: bool) -> Result<(), EncodeError> {
-    if native_is_current {
-        return Ok(());
+struct NativeAttemptFence {
+    request_generation: Option<u64>,
+}
+
+impl NativeAttemptFence {
+    fn from_pin(pin: Option<&PublishedStatePin>) -> Self {
+        Self {
+            request_generation: pin.map(PublishedStatePin::request_generation),
+        }
     }
-    Err(EncodeError::unavailable(
-        "Native state changed while the route was being encoded; retry against the current version",
-    ))
+
+    async fn status(&self, state: &AppState) -> NativeFenceStatus {
+        let Some(request_generation) = self.request_generation else {
+            return NativeFenceStatus::Current;
+        };
+        state.native_request_fence_status(request_generation).await
+    }
+}
+
+enum AttemptOutcome {
+    Success(EncodeComputation),
+    StateDependent(EncodeError),
+    Deterministic(EncodeError),
+}
+
+impl AttemptOutcome {
+    fn from_result(result: Result<EncodeComputation, AttemptError>) -> Self {
+        match result {
+            Ok(computation) => Self::Success(computation),
+            Err(AttemptError::StateDependent(error)) => Self::StateDependent(error),
+            Err(AttemptError::Deterministic(error)) => Self::Deterministic(error),
+        }
+    }
+
+    const fn class(&self) -> AttemptOutcomeClass {
+        match self {
+            Self::Success(_) => AttemptOutcomeClass::Success,
+            Self::StateDependent(_) => AttemptOutcomeClass::StateDependent,
+            Self::Deterministic(_) => AttemptOutcomeClass::Deterministic,
+        }
+    }
+
+    fn error(&self) -> Option<&EncodeError> {
+        match self {
+            Self::Success(_) => None,
+            Self::StateDependent(error) | Self::Deterministic(error) => Some(error),
+        }
+    }
+
+    fn expected_amount_out(&self) -> Option<&str> {
+        match self {
+            Self::Success(computation) => Some(computation.expected_amount_out.as_str()),
+            Self::StateDependent(_) | Self::Deterministic(_) => None,
+        }
+    }
+
+    fn into_result(self) -> Result<EncodeComputation, EncodeError> {
+        match self {
+            Self::Success(computation) => Ok(computation),
+            Self::StateDependent(error) | Self::Deterministic(error) => Err(error),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AttemptOutcomeClass {
+    Success,
+    StateDependent,
+    Deterministic,
+}
+
+impl AttemptOutcomeClass {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::StateDependent => "state_dependent_error",
+            Self::Deterministic => "deterministic_error",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AttemptNumber {
+    First,
+    Second,
+}
+
+impl AttemptNumber {
+    const fn value(self) -> u8 {
+        match self {
+            Self::First => 1,
+            Self::Second => MAX_ENCODE_ATTEMPTS,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AttemptResolution {
+    ReturnOutcome,
+    Retry,
+    ReturnNativeStateChanged,
+    ReturnNativeUnavailable,
+}
+
+const fn resolve_attempt(
+    outcome_class: AttemptOutcomeClass,
+    fence_status: NativeFenceStatus,
+    attempt_number: AttemptNumber,
+) -> AttemptResolution {
+    match (outcome_class, fence_status, attempt_number) {
+        (AttemptOutcomeClass::Deterministic, _, _)
+        | (
+            AttemptOutcomeClass::Success | AttemptOutcomeClass::StateDependent,
+            NativeFenceStatus::Current,
+            _,
+        ) => AttemptResolution::ReturnOutcome,
+        (_, NativeFenceStatus::Unavailable, _) => AttemptResolution::ReturnNativeUnavailable,
+        (
+            AttemptOutcomeClass::Success | AttemptOutcomeClass::StateDependent,
+            NativeFenceStatus::Changed,
+            AttemptNumber::First,
+        ) => AttemptResolution::Retry,
+        (
+            AttemptOutcomeClass::Success | AttemptOutcomeClass::StateDependent,
+            NativeFenceStatus::Changed,
+            AttemptNumber::Second,
+        ) => {
+            // A second generation change invalidates success and state-dependent errors alike.
+            AttemptResolution::ReturnNativeStateChanged
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RetryBudget {
+    remaining: Duration,
+    can_start: bool,
+}
+
+fn retry_budget(request_timeout: Duration, elapsed: Duration, route_uses_rfq: bool) -> RetryBudget {
+    let remaining = request_timeout.saturating_sub(elapsed);
+    // RFQ quotes block the task, so attempt two needs enough time to cover the quote and finish.
+    let required = if route_uses_rfq {
+        ENCODE_RFQ_QUOTE_TIMEOUT.saturating_add(RETRY_RFQ_BUDGET_MARGIN)
+    } else {
+        RETRY_NATIVE_BUDGET_FLOOR
+    };
+    RetryBudget {
+        remaining,
+        can_start: remaining >= required,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RetryTrigger {
+    Fence,
+    StateDependentError,
+}
+
+impl RetryTrigger {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Fence => "fence",
+            Self::StateDependentError => "state_dependent_error",
+        }
+    }
+}
+
+fn native_state_changed_error() -> EncodeError {
+    EncodeError::unavailable(NATIVE_STATE_CHANGED_MESSAGE)
 }
 
 #[cfg(test)]
-mod version_fence_tests {
-    use super::ensure_native_encode_current;
+mod retry_tests {
+    use super::{
+        resolve_attempt, retry_budget, AttemptNumber, AttemptOutcomeClass, AttemptResolution,
+        NativeFenceStatus,
+    };
+    use std::time::Duration;
 
     #[test]
-    fn native_encode_fence_rejects_stale_requests() {
-        assert!(ensure_native_encode_current(true).is_ok());
-        assert!(ensure_native_encode_current(false).is_err());
+    fn resolve_attempt_covers_every_outcome_fence_and_attempt_combination() {
+        use AttemptNumber::{First, Second};
+        use AttemptOutcomeClass::{Deterministic, StateDependent, Success};
+        use AttemptResolution::{
+            Retry, ReturnNativeStateChanged, ReturnNativeUnavailable, ReturnOutcome,
+        };
+        use NativeFenceStatus::{Changed, Current, Unavailable};
+
+        let cases = [
+            (Success, Current, First, ReturnOutcome),
+            (Success, Current, Second, ReturnOutcome),
+            (Success, Changed, First, Retry),
+            (Success, Changed, Second, ReturnNativeStateChanged),
+            (Success, Unavailable, First, ReturnNativeUnavailable),
+            (Success, Unavailable, Second, ReturnNativeUnavailable),
+            (StateDependent, Current, First, ReturnOutcome),
+            (StateDependent, Current, Second, ReturnOutcome),
+            (StateDependent, Changed, First, Retry),
+            (StateDependent, Changed, Second, ReturnNativeStateChanged),
+            (StateDependent, Unavailable, First, ReturnNativeUnavailable),
+            (StateDependent, Unavailable, Second, ReturnNativeUnavailable),
+            (Deterministic, Current, First, ReturnOutcome),
+            (Deterministic, Current, Second, ReturnOutcome),
+            (Deterministic, Changed, First, ReturnOutcome),
+            (Deterministic, Changed, Second, ReturnOutcome),
+            (Deterministic, Unavailable, First, ReturnOutcome),
+            (Deterministic, Unavailable, Second, ReturnOutcome),
+        ];
+
+        assert_eq!(cases.len(), 18);
+        for (outcome, fence, attempt, expected) in cases {
+            assert_eq!(
+                resolve_attempt(outcome, fence, attempt),
+                expected,
+                "{outcome:?} with {fence:?} on {attempt:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn retry_budget_requires_quote_timeout_and_margin_for_rfq_routes() {
+        let timeout = Duration::from_millis(4_500);
+
+        assert!(retry_budget(timeout, Duration::from_millis(1_000), true).can_start);
+        let insufficient = retry_budget(timeout, Duration::from_millis(1_001), true);
+        assert!(!insufficient.can_start);
+        assert_eq!(insufficient.remaining, Duration::from_millis(3_499));
+    }
+
+    #[test]
+    fn retry_budget_uses_native_floor_without_rfq_hops() {
+        let timeout = Duration::from_millis(4_500);
+
+        assert!(retry_budget(timeout, Duration::from_millis(4_200), false).can_start);
+        let insufficient = retry_budget(timeout, Duration::from_millis(4_201), false);
+        assert!(!insufficient.can_start);
+        assert_eq!(insufficient.remaining, Duration::from_millis(299));
     }
 }

--- a/crates/runtime/src/services/encode.rs
+++ b/crates/runtime/src/services/encode.rs
@@ -487,14 +487,13 @@ impl NativeAttemptFence {
 
     async fn evaluate(&self, state: &AppState) -> Option<NativeFenceEvaluation> {
         let pinned = self.pin.as_ref()?;
-        let status = state
+        let check = state
             .native_route_fence_status(pinned, &self.native_pool_ids)
             .await;
-        let current_generation = state.native_state_store.pin().await.request_generation();
         Some(NativeFenceEvaluation {
-            status,
-            generation_moved: current_generation != pinned.request_generation(),
-            identity_changed: status == NativeFenceStatus::Changed,
+            status: check.status,
+            generation_moved: check.current_generation != pinned.request_generation(),
+            identity_changed: check.status == NativeFenceStatus::Changed,
             native_pool_count: self.native_pool_ids.len(),
         })
     }

--- a/crates/runtime/src/services/encode.rs
+++ b/crates/runtime/src/services/encode.rs
@@ -23,11 +23,12 @@ use std::time::Instant;
 
 use crate::models::messages::{RouteEncodeRequest, RouteEncodeResponse};
 use crate::models::state::{AppState, PublishedStatePin};
+use error::AttemptError;
 use tycho_execution::encoding::tycho_encoder::TychoEncoder;
 use tycho_simulation::tycho_common::{models::Chain, Bytes};
 
 type EncoderFactory =
-    Arc<dyn Fn(Chain, Bytes) -> Result<Arc<dyn TychoEncoder>, EncodeError> + Send + Sync>;
+    Arc<dyn Fn(Chain, Bytes) -> Result<Arc<dyn TychoEncoder>, AttemptError> + Send + Sync>;
 
 /// Transport-free runtime wrapper for `/encode` route encoding.
 #[derive(Clone)]
@@ -169,7 +170,8 @@ async fn encode_route(
         rebuild_guard,
         native_pin,
     )
-    .await?;
+    .await
+    .map_err(EncodeError::from)?;
     response::log_resimulation_amounts(request.request_id.as_deref(), &resimulated);
     let expected_total = response::compute_expected_total(&resimulated);
     if expected_total < min_amount_out {
@@ -178,7 +180,7 @@ async fn encode_route(
         ));
     }
     let amount_out_delta = (&expected_total - &min_amount_out).to_string();
-    let encoder = encoder_factory(chain, router_address.clone())?;
+    let encoder = encoder_factory(chain, router_address.clone()).map_err(EncodeError::from)?;
     let route_context = calldata::RouteContext {
         request: &request,
         token_in: &token_in,
@@ -192,7 +194,8 @@ async fn encode_route(
         &resimulated,
         encoder.as_ref(),
         &min_amount_out,
-    )?;
+    )
+    .map_err(EncodeError::from)?;
     let reset_approval =
         request::should_reset_allowance(&state.reset_allowance_tokens, request.chain_id, &token_in);
     let interactions = calldata::build_settlement_interactions(
@@ -201,7 +204,8 @@ async fn encode_route(
         router_call,
         reset_approval,
         is_native_input,
-    )?;
+    )
+    .map_err(EncodeError::from)?;
 
     let debug = response::build_debug(&state, &request).await;
     if let Some(native_request_generation) = native_request_generation {

--- a/crates/runtime/src/services/encode.rs
+++ b/crates/runtime/src/services/encode.rs
@@ -40,6 +40,8 @@ const RETRY_RFQ_BUDGET_MARGIN: Duration = Duration::from_millis(500);
 const RETRY_NATIVE_BUDGET_FLOOR: Duration = Duration::from_millis(300);
 const NATIVE_STATE_CHANGED_MESSAGE: &str =
     "Native state changed while the route was being encoded; retry against the current version";
+const NATIVE_STATE_UNAVAILABLE_MESSAGE: &str =
+    "Native state is unavailable for encoding; retry once the simulator is ready";
 
 /// Transport-free runtime wrapper for `/encode` route encoding.
 #[derive(Clone)]
@@ -183,7 +185,7 @@ async fn encode_route(
                 let budget = retry_budget(
                     request_timeout,
                     started_at.elapsed(),
-                    prepared.backend_usage.rfq,
+                    attempt.route_uses_rfq,
                 );
                 if !budget.can_start {
                     log_fence(
@@ -196,7 +198,7 @@ async fn encode_route(
                         prepared.request.request_id.as_deref(),
                         budget.remaining,
                         started_at.elapsed(),
-                        prepared.backend_usage.rfq,
+                        attempt.route_uses_rfq,
                     );
                     return Err(native_state_changed_error());
                 }
@@ -214,7 +216,7 @@ async fn encode_route(
                     first_error_message.as_deref(),
                     first_expected_amount_out.as_deref(),
                     started_at.elapsed(),
-                    prepared.backend_usage.rfq,
+                    attempt.route_uses_rfq,
                 );
                 first_attempt_expected_amount_out = first_expected_amount_out;
             }
@@ -236,7 +238,7 @@ async fn encode_route(
             }
             AttemptResolution::ReturnNativeUnavailable => {
                 log_fence(&fence_evaluation, &prepared, attempt_number, "unavailable");
-                return Err(native_state_changed_error());
+                return Err(EncodeError::unavailable(NATIVE_STATE_UNAVAILABLE_MESSAGE));
             }
         }
     }
@@ -311,6 +313,7 @@ async fn prepare_encode_route(
 struct EncodeAttempt {
     outcome: AttemptOutcome,
     native_fence: NativeAttemptFence,
+    route_uses_rfq: bool,
 }
 
 async fn encode_attempt(
@@ -329,16 +332,25 @@ async fn encode_attempt(
         .native_pool_ids
         .unwrap_or_else(|| normalized_native_pool_ids(&prepared.normalized));
     let native_fence = NativeAttemptFence::new(native_pin, native_pool_ids);
+    // Protocol hints can misclassify a pool's backend; the resimulated route carries the
+    // component-resolved truth. The retry budget must know about a real RFQ hop, or a
+    // retry approved under the native floor would run a firm quote inside block_in_place
+    // that the request timeout cannot interrupt.
+    let route_uses_rfq = execution
+        .route_uses_rfq
+        .unwrap_or(prepared.backend_usage.rfq);
 
     EncodeAttempt {
         outcome: AttemptOutcome::from_result(execution.outcome),
         native_fence,
+        route_uses_rfq,
     }
 }
 
 struct EncodeAttemptExecution {
     outcome: Result<EncodeComputation, AttemptError>,
     native_pool_ids: Option<HashSet<String>>,
+    route_uses_rfq: Option<bool>,
 }
 
 async fn encode_attempt_with_pin(
@@ -363,6 +375,7 @@ async fn encode_attempt_with_pin(
                 message,
             ))),
             native_pool_ids: None,
+            route_uses_rfq: None,
         };
     }
     let resimulated = match resimulate::resimulate_route_with_native_pin(
@@ -382,15 +395,18 @@ async fn encode_attempt_with_pin(
             return EncodeAttemptExecution {
                 outcome: Err(error),
                 native_pool_ids: None,
+                route_uses_rfq: None,
             };
         }
     };
     let native_pool_ids = resimulated_native_pool_ids(&resimulated);
+    let route_uses_rfq = resimulated_route_uses_rfq(&resimulated);
     let outcome = complete_encode_attempt(state, prepared, attempt_number, resimulated).await;
 
     EncodeAttemptExecution {
         outcome,
         native_pool_ids: Some(native_pool_ids),
+        route_uses_rfq: Some(route_uses_rfq),
     }
 }
 
@@ -457,6 +473,15 @@ fn normalized_native_pool_ids(normalized: &NormalizedRouteInternal) -> HashSet<S
         .filter(|swap| backend::PoolBackend::from_protocol_hint(&swap.pool.protocol).is_native())
         .map(|swap| swap.pool.component_id.clone())
         .collect()
+}
+
+fn resimulated_route_uses_rfq(resimulated: &model::ResimulatedRouteInternal) -> bool {
+    resimulated
+        .segments
+        .iter()
+        .flat_map(|segment| segment.hops.iter())
+        .flat_map(|hop| hop.swaps.iter())
+        .any(|swap| swap.backend.is_rfq())
 }
 
 fn resimulated_native_pool_ids(resimulated: &model::ResimulatedRouteInternal) -> HashSet<String> {

--- a/crates/runtime/src/services/encode/allocation.rs
+++ b/crates/runtime/src/services/encode/allocation.rs
@@ -4,6 +4,7 @@ use tycho_simulation::tycho_common::Bytes;
 
 use crate::models::messages::PoolRef;
 
+use super::error::AttemptError;
 use super::model::NormalizedSwapDraftInternal;
 use super::EncodeError;
 
@@ -100,12 +101,16 @@ pub(super) fn allocate_swaps_by_bps(
     swaps: &[NormalizedSwapDraftInternal],
     segment_index: usize,
     hop_index: usize,
-) -> Result<Vec<AllocatedSwap>, EncodeError> {
+) -> Result<Vec<AllocatedSwap>, AttemptError> {
     if swaps.is_empty() {
-        return Err(EncodeError::invalid("hop.swaps must not be empty"));
+        return Err(AttemptError::deterministic(EncodeError::invalid(
+            "hop.swaps must not be empty",
+        )));
     }
     if hop_amount_in.is_zero() {
-        return Err(EncodeError::invalid("hop amountIn must be > 0"));
+        return Err(AttemptError::deterministic(EncodeError::invalid(
+            "hop amountIn must be > 0",
+        )));
     }
 
     let mut allocations = Vec::with_capacity(swaps.len());
@@ -115,14 +120,14 @@ pub(super) fn allocate_swaps_by_bps(
         &split_bps,
         &format!("segment[{}].hop[{}].swap", segment_index, hop_index),
         "splitBps",
-    )?;
+    )
+    .map_err(AttemptError::deterministic)?;
 
     for (index, swap) in swaps.iter().enumerate() {
         let split = swap.split_bps;
-        let amount_in = amounts
-            .get(index)
-            .cloned()
-            .ok_or_else(|| EncodeError::internal("Missing swap amount allocation"))?;
+        let amount_in = amounts.get(index).cloned().ok_or_else(|| {
+            AttemptError::deterministic(EncodeError::internal("Missing swap amount allocation"))
+        })?;
         allocations.push(AllocatedSwap {
             pool: swap.pool.clone(),
             token_in: swap.token_in.clone(),

--- a/crates/runtime/src/services/encode/calldata.rs
+++ b/crates/runtime/src/services/encode/calldata.rs
@@ -15,7 +15,7 @@ use tycho_simulation::tycho_common::{models::Chain, Bytes};
 
 use crate::models::messages::{Interaction, InteractionKind, RouteEncodeRequest};
 
-use super::error::map_encoding_error;
+use super::error::{map_encoding_error, AttemptError};
 use super::model::ResimulatedRouteInternal;
 use super::tycho_swaps::build_route_swaps;
 use super::wire::{biguint_to_u256_checked, format_address, format_calldata};
@@ -39,15 +39,15 @@ pub(super) struct RouteContext<'a> {
 pub(super) fn build_encoder(
     chain: Chain,
     router_address: Bytes,
-) -> Result<Arc<dyn TychoEncoder>, EncodeError> {
+) -> Result<Arc<dyn TychoEncoder>, AttemptError> {
     // TODO: we can probably optimize this in the feature to initialize the encoder registry + add default encoders during the server's startup.
     let swap_encoder_registry = SwapEncoderRegistry::new(chain)
         .add_default_encoders(None)
         .map_err(|err| {
-            EncodeError::encoding(format!(
+            AttemptError::deterministic(EncodeError::encoding(format!(
                 "Failed to build swap encoder registry for {}: {}",
                 chain, err
-            ))
+            )))
         })?;
 
     TychoRouterEncoderBuilder::new()
@@ -57,7 +57,12 @@ pub(super) fn build_encoder(
         .router_address(router_address)
         .build()
         .map(Arc::from)
-        .map_err(|err| EncodeError::encoding(format!("Failed to build Tycho encoder: {}", err)))
+        .map_err(|err| {
+            AttemptError::deterministic(EncodeError::encoding(format!(
+                "Failed to build Tycho encoder: {}",
+                err
+            )))
+        })
 }
 
 pub(super) fn build_route_calldata_tx(
@@ -65,9 +70,10 @@ pub(super) fn build_route_calldata_tx(
     resimulated: &ResimulatedRouteInternal,
     encoder: &dyn TychoEncoder,
     min_amount_out: &BigUint,
-) -> Result<CallDataPayload, EncodeError> {
+) -> Result<CallDataPayload, AttemptError> {
     let swaps = build_route_swaps(resimulated)?;
-    let sender = super::wire::parse_address(&context.request.settlement_address)?;
+    let sender = super::wire::parse_address(&context.request.settlement_address)
+        .map_err(AttemptError::deterministic)?;
     let receiver = sender.clone();
 
     let solution = Solution {
@@ -82,31 +88,21 @@ pub(super) fn build_route_calldata_tx(
         native_action: None,
     };
 
-    let encoded_solution = encoder
-        .encode_solutions(vec![solution.clone()])
-        .map_err(|err| match err {
-            EncodingError::InvalidInput(_) => {
-                EncodeError::invalid(format!("Route encoding failed: {}", err))
-            }
-            _ => EncodeError::encoding(format!("Route encoding failed: {}", err)),
-        })?
-        .into_iter()
-        .next()
-        .ok_or_else(|| EncodeError::encoding("Route encoding returned no solutions"))?;
+    let encoded_solution = take_encoded_solution(encoder.encode_solutions(vec![solution.clone()]))?;
 
     if encoded_solution.permit.is_some()
         || encoded_solution.function_signature.contains("Permit2")
         || encoded_solution.function_signature.contains("permit2")
     {
-        return Err(EncodeError::encoding(
+        return Err(AttemptError::deterministic(EncodeError::encoding(
             "Permit2 encodings are not supported for route calldata",
-        ));
+        )));
     }
 
     if &encoded_solution.interacting_with != context.router_address {
-        return Err(EncodeError::encoding(
+        return Err(AttemptError::deterministic(EncodeError::encoding(
             "Encoded router address does not match request tychoRouterAddress",
-        ));
+        )));
     }
 
     let is_transfer_from_allowed = !context.is_native_input;
@@ -129,13 +125,35 @@ pub(super) fn build_route_calldata_tx(
     })
 }
 
+fn take_encoded_solution(
+    result: Result<Vec<EncodedSolution>, EncodingError>,
+) -> Result<EncodedSolution, AttemptError> {
+    result
+        .map_err(|err| match err {
+            EncodingError::InvalidInput(_) => AttemptError::state_dependent(EncodeError::invalid(
+                format!("Route encoding failed: {}", err),
+            )),
+            _ => AttemptError::state_dependent(EncodeError::encoding(format!(
+                "Route encoding failed: {}",
+                err
+            ))),
+        })?
+        .into_iter()
+        .next()
+        .ok_or_else(|| {
+            AttemptError::state_dependent(EncodeError::encoding(
+                "Route encoding returned no solutions",
+            ))
+        })
+}
+
 pub(super) fn build_settlement_interactions(
     token_in: &Bytes,
     amount_in: &BigUint,
     router_call: CallDataPayload,
     reset_approval: bool,
     is_native_input: bool,
-) -> Result<Vec<Interaction>, EncodeError> {
+) -> Result<Vec<Interaction>, AttemptError> {
     let mut interactions = Vec::with_capacity(if is_native_input {
         1
     } else if reset_approval {
@@ -172,7 +190,7 @@ fn build_erc20_approve_interaction(
     token: &Bytes,
     spender: &Bytes,
     amount: &BigUint,
-) -> Result<Interaction, EncodeError> {
+) -> Result<Interaction, AttemptError> {
     let calldata = encode_erc20_approve_calldata(spender, amount)?;
     Ok(Interaction {
         kind: InteractionKind::Erc20Approve,
@@ -185,9 +203,12 @@ fn build_erc20_approve_interaction(
 fn encode_erc20_approve_calldata(
     spender: &Bytes,
     amount: &BigUint,
-) -> Result<Vec<u8>, EncodeError> {
-    let spender = bytes_to_address(spender).map_err(map_encoding_error)?;
-    let amount = biguint_to_u256_checked(amount, "approve amount")?;
+) -> Result<Vec<u8>, AttemptError> {
+    let spender = bytes_to_address(spender)
+        .map_err(map_encoding_error)
+        .map_err(AttemptError::deterministic)?;
+    let amount =
+        biguint_to_u256_checked(amount, "approve amount").map_err(AttemptError::deterministic)?;
     let calldata_args = (spender, amount).abi_encode();
     encode_function_call(ERC20_APPROVE_SIGNATURE, calldata_args)
 }
@@ -197,26 +218,34 @@ fn encode_route_calldata(
     solution: &Solution,
     receiver: &Bytes,
     is_transfer_from_allowed: bool,
-) -> Result<Vec<u8>, EncodeError> {
+) -> Result<Vec<u8>, AttemptError> {
     let signature = encoded_solution.function_signature.as_str();
     // `/encode` preserves route token semantics and does not inject wrap/unwrap steps.
     // Routes must already be protocol-compatible, and native-input routes must disable router
     // `transferFrom`.
     let is_wrap = false;
     let is_unwrap = false;
-    let given_amount = biguint_to_u256_checked(&solution.given_amount, "amountIn")?;
-    let checked_amount = biguint_to_u256_checked(&solution.checked_amount, "minAmountOut")?;
+    let given_amount = biguint_to_u256_checked(&solution.given_amount, "amountIn")
+        .map_err(AttemptError::deterministic)?;
+    let checked_amount = biguint_to_u256_checked(&solution.checked_amount, "minAmountOut")
+        .map_err(AttemptError::deterministic)?;
 
     let calldata_args = if signature.contains("splitSwap") {
         (
             given_amount,
-            bytes_to_address(&solution.given_token).map_err(map_encoding_error)?,
-            bytes_to_address(&solution.checked_token).map_err(map_encoding_error)?,
+            bytes_to_address(&solution.given_token)
+                .map_err(map_encoding_error)
+                .map_err(AttemptError::deterministic)?,
+            bytes_to_address(&solution.checked_token)
+                .map_err(map_encoding_error)
+                .map_err(AttemptError::deterministic)?,
             checked_amount,
             is_wrap,
             is_unwrap,
             alloy_primitives::U256::from(encoded_solution.n_tokens),
-            bytes_to_address(receiver).map_err(map_encoding_error)?,
+            bytes_to_address(receiver)
+                .map_err(map_encoding_error)
+                .map_err(AttemptError::deterministic)?,
             is_transfer_from_allowed,
             encoded_solution.swaps.clone(),
         )
@@ -224,27 +253,33 @@ fn encode_route_calldata(
     } else if signature.contains("singleSwap") || signature.contains("sequentialSwap") {
         (
             given_amount,
-            bytes_to_address(&solution.given_token).map_err(map_encoding_error)?,
-            bytes_to_address(&solution.checked_token).map_err(map_encoding_error)?,
+            bytes_to_address(&solution.given_token)
+                .map_err(map_encoding_error)
+                .map_err(AttemptError::deterministic)?,
+            bytes_to_address(&solution.checked_token)
+                .map_err(map_encoding_error)
+                .map_err(AttemptError::deterministic)?,
             checked_amount,
             is_wrap,
             is_unwrap,
-            bytes_to_address(receiver).map_err(map_encoding_error)?,
+            bytes_to_address(receiver)
+                .map_err(map_encoding_error)
+                .map_err(AttemptError::deterministic)?,
             is_transfer_from_allowed,
             encoded_solution.swaps.clone(),
         )
             .abi_encode_params()
     } else {
-        return Err(EncodeError::encoding(format!(
+        return Err(AttemptError::deterministic(EncodeError::encoding(format!(
             "Unsupported Tycho function signature: {}",
             signature
-        )));
+        ))));
     };
 
     encode_function_call(signature, calldata_args)
 }
 
-fn encode_function_call(signature: &str, encoded_args: Vec<u8>) -> Result<Vec<u8>, EncodeError> {
+fn encode_function_call(signature: &str, encoded_args: Vec<u8>) -> Result<Vec<u8>, AttemptError> {
     let selector = function_selector(signature)?;
     let mut call_data = Vec::with_capacity(4 + encoded_args.len());
     call_data.extend_from_slice(&selector);
@@ -252,13 +287,13 @@ fn encode_function_call(signature: &str, encoded_args: Vec<u8>) -> Result<Vec<u8
     Ok(call_data)
 }
 
-fn function_selector(signature: &str) -> Result<[u8; 4], EncodeError> {
+fn function_selector(signature: &str) -> Result<[u8; 4], AttemptError> {
     let normalized = signature.trim();
     if !normalized.contains('(') {
-        return Err(EncodeError::encoding(format!(
+        return Err(AttemptError::deterministic(EncodeError::encoding(format!(
             "Invalid function signature: {}",
             signature
-        )));
+        ))));
     }
     let mut hasher = Keccak256::new();
     hasher.update(normalized.as_bytes());
@@ -306,6 +341,19 @@ mod tests {
             .copied()
             .expect("single-swap calldata should include transferFrom flag")
             == 1
+    }
+
+    #[test]
+    fn tycho_solution_failures_are_state_dependent() {
+        let encode_error = take_encoded_solution(Err(EncodingError::FatalError(
+            "pool state rejected".to_string(),
+        )))
+        .expect_err("Tycho encoding should fail");
+        assert!(encode_error.is_state_dependent());
+
+        let empty_error =
+            take_encoded_solution(Ok(Vec::new())).expect_err("empty solutions should fail");
+        assert!(empty_error.is_state_dependent());
     }
 
     #[test]
@@ -611,6 +659,7 @@ mod tests {
             err.kind(),
             crate::services::encode::EncodeErrorKind::Encoding
         );
+        assert!(!err.is_state_dependent());
         assert!(
             err.message().contains("Permit2"),
             "unexpected error: {}",
@@ -702,6 +751,7 @@ mod tests {
             err.kind(),
             crate::services::encode::EncodeErrorKind::InvalidRequest
         );
+        assert!(!err.is_state_dependent());
         assert!(
             err.message().contains("uint256"),
             "unexpected error message: {:?}",

--- a/crates/runtime/src/services/encode/error.rs
+++ b/crates/runtime/src/services/encode/error.rs
@@ -16,6 +16,49 @@ pub struct EncodeError {
     message: String,
 }
 
+#[derive(Debug)]
+pub(super) enum AttemptError {
+    StateDependent(EncodeError),
+    Deterministic(EncodeError),
+}
+
+impl AttemptError {
+    pub(super) fn state_dependent(error: EncodeError) -> Self {
+        Self::StateDependent(error)
+    }
+
+    pub(super) fn deterministic(error: EncodeError) -> Self {
+        Self::Deterministic(error)
+    }
+
+    #[cfg(test)]
+    pub(super) fn is_state_dependent(&self) -> bool {
+        matches!(self, Self::StateDependent(_))
+    }
+
+    #[cfg(test)]
+    pub(super) fn kind(&self) -> EncodeErrorKind {
+        match self {
+            Self::StateDependent(error) | Self::Deterministic(error) => error.kind(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn message(&self) -> &str {
+        match self {
+            Self::StateDependent(error) | Self::Deterministic(error) => error.message(),
+        }
+    }
+}
+
+impl From<AttemptError> for EncodeError {
+    fn from(error: AttemptError) -> Self {
+        match error {
+            AttemptError::StateDependent(error) | AttemptError::Deterministic(error) => error,
+        }
+    }
+}
+
 impl EncodeError {
     pub fn invalid<T: Into<String>>(message: T) -> Self {
         Self {
@@ -79,7 +122,7 @@ pub(super) fn map_encoding_error(err: EncodingError) -> EncodeError {
 
 #[cfg(test)]
 mod tests {
-    use super::{EncodeError, EncodeErrorKind};
+    use super::{AttemptError, EncodeError, EncodeErrorKind};
 
     #[test]
     fn unavailable_errors_keep_kind_and_message() {
@@ -90,5 +133,23 @@ mod tests {
             error.message(),
             "Encode unavailable: native state warming up"
         );
+    }
+
+    #[test]
+    fn attempt_error_buckets_preserve_the_public_error() {
+        let state_dependent =
+            AttemptError::state_dependent(EncodeError::simulation("pool state changed"));
+        assert!(state_dependent.is_state_dependent());
+        let state_dependent = EncodeError::from(state_dependent);
+        assert_eq!(state_dependent.kind(), EncodeErrorKind::Simulation);
+        assert_eq!(state_dependent.message(), "pool state changed");
+
+        // Unavailable state must fail immediately instead of entering the future retry loop.
+        let deterministic =
+            AttemptError::deterministic(EncodeError::unavailable("state unavailable"));
+        assert!(!deterministic.is_state_dependent());
+        let deterministic = EncodeError::from(deterministic);
+        assert_eq!(deterministic.kind(), EncodeErrorKind::Unavailable);
+        assert_eq!(deterministic.message(), "state unavailable");
     }
 }

--- a/crates/runtime/src/services/encode/resimulate.rs
+++ b/crates/runtime/src/services/encode/resimulate.rs
@@ -30,6 +30,7 @@ use crate::services::stream_builder::{
 
 use super::allocation::allocate_swaps_by_bps;
 use super::backend::PoolBackend;
+use super::error::AttemptError;
 use super::model::{
     NormalizedRouteInternal, ResimulatedHopInternal, ResimulatedRouteInternal,
     ResimulatedSegmentInternal, ResimulatedSwapInternal,
@@ -78,7 +79,7 @@ async fn resimulate_route(
     request_token_out: &Bytes,
     native_token_protocol_allowlist: &[String],
     rebuild_guard: Arc<SimulationRebuildGuard>,
-) -> Result<ResimulatedRouteInternal, EncodeError> {
+) -> Result<ResimulatedRouteInternal, AttemptError> {
     let native_pin = Some(state.native_state_store.pin().await);
     resimulate_route_with_native_pin(
         state,
@@ -106,7 +107,7 @@ pub(super) async fn resimulate_route_with_native_pin(
     native_token_protocol_allowlist: &[String],
     rebuild_guard: Arc<SimulationRebuildGuard>,
     native_pin: Option<PublishedStatePin>,
-) -> Result<ResimulatedRouteInternal, EncodeError> {
+) -> Result<ResimulatedRouteInternal, AttemptError> {
     let mut resimulator =
         RouteResimulator::new(state, normalized, chain, rebuild_guard, native_pin);
 
@@ -158,7 +159,7 @@ impl<'a> RouteResimulator<'a> {
         &mut self,
         segment_index: usize,
         hop_index: usize,
-    ) -> Result<(), EncodeError> {
+    ) -> Result<(), AttemptError> {
         let Some(hop) = self
             .normalized
             .segments
@@ -168,22 +169,25 @@ impl<'a> RouteResimulator<'a> {
             return Ok(());
         };
         let hop_amount_in = {
-            let segment_state = self
-                .segment_states
-                .get_mut(segment_index)
-                .ok_or_else(|| EncodeError::internal("Segment state missing after resimulation"))?;
+            let segment_state = self.segment_states.get_mut(segment_index).ok_or_else(|| {
+                AttemptError::deterministic(EncodeError::internal(
+                    "Segment state missing after resimulation",
+                ))
+            })?;
             require_hop_amount_in(segment_state, segment_index, hop_index)?
         };
         let allocated_swaps =
-            allocate_swaps_by_bps(hop_amount_in.clone(), &hop.swaps, segment_index, hop_index)?;
+            allocate_swaps_by_bps(hop_amount_in.clone(), &hop.swaps, segment_index, hop_index)
+                .map_err(|error| classify_allocation_error(error, hop_index))?;
         let (swap_results, hop_expected) = self
             .simulate_allocated_swaps(allocated_swaps, &hop_amount_in)
             .await?;
         // We come back for the segment state here because the pool work above awaits.
-        let segment_state = self
-            .segment_states
-            .get_mut(segment_index)
-            .ok_or_else(|| EncodeError::internal("Segment state missing after resimulation"))?;
+        let segment_state = self.segment_states.get_mut(segment_index).ok_or_else(|| {
+            AttemptError::deterministic(EncodeError::internal(
+                "Segment state missing after resimulation",
+            ))
+        })?;
         segment_state.hops[hop_index] = Some(ResimulatedHopInternal {
             token_in: hop.token_in.clone(),
             token_out: hop.token_out.clone(),
@@ -199,7 +203,7 @@ impl<'a> RouteResimulator<'a> {
         &mut self,
         allocated_swaps: Vec<super::allocation::AllocatedSwap>,
         hop_amount_in: &BigUint,
-    ) -> Result<(Vec<ResimulatedSwapInternal>, BigUint), EncodeError> {
+    ) -> Result<(Vec<ResimulatedSwapInternal>, BigUint), AttemptError> {
         let mut swap_results = Vec::with_capacity(allocated_swaps.len());
         let mut hop_expected = BigUint::zero();
 
@@ -210,9 +214,8 @@ impl<'a> RouteResimulator<'a> {
         }
 
         if hop_expected.is_zero() {
-            return Err(EncodeError::simulation(format!(
-                "hop amountIn {} produced zero amountOut",
-                hop_amount_in
+            return Err(AttemptError::state_dependent(EncodeError::simulation(
+                format!("hop amountIn {} produced zero amountOut", hop_amount_in),
             )));
         }
 
@@ -222,7 +225,7 @@ impl<'a> RouteResimulator<'a> {
     async fn simulate_allocated_swap(
         &mut self,
         allocated: super::allocation::AllocatedSwap,
-    ) -> Result<ResimulatedSwapInternal, EncodeError> {
+    ) -> Result<ResimulatedSwapInternal, AttemptError> {
         let pool_entry = self.load_pool_entry(&allocated.pool.component_id).await?;
         ensure_erc4626_swap_supported(
             self.state,
@@ -285,7 +288,7 @@ impl<'a> RouteResimulator<'a> {
         })
     }
 
-    async fn load_pool_entry(&mut self, pool_id: &str) -> Result<CachedPoolEntry, EncodeError> {
+    async fn load_pool_entry(&mut self, pool_id: &str) -> Result<CachedPoolEntry, AttemptError> {
         if let Some(entry) = self.pool_cache.get(pool_id) {
             return Ok(entry.clone());
         }
@@ -327,7 +330,12 @@ impl<'a> RouteResimulator<'a> {
             .pool_by_id(pool_id)
             .await
             .map_err(availability_error)?
-            .ok_or_else(|| EncodeError::not_found(format!("Pool {} not found", pool_id)))?;
+            .ok_or_else(|| {
+                AttemptError::state_dependent(EncodeError::not_found(format!(
+                    "Pool {} not found",
+                    pool_id
+                )))
+            })?;
         let backend = PoolBackend::from_component(component.as_ref());
         let pool_state = if backend.is_rfq() {
             hydrate_rfq_pool_state(
@@ -352,7 +360,7 @@ impl<'a> RouteResimulator<'a> {
 
     fn build_resimulated_segments(
         &mut self,
-    ) -> Result<Vec<ResimulatedSegmentInternal>, EncodeError> {
+    ) -> Result<Vec<ResimulatedSegmentInternal>, AttemptError> {
         build_resimulated_segments(self.normalized, &mut self.segment_states)
     }
 }
@@ -373,7 +381,7 @@ fn hydrate_rfq_pool_state(
     chain: Chain,
     config: &RfqClientConfig,
     quote_timeout: Duration,
-) -> Result<Arc<dyn ProtocolSim>, EncodeError> {
+) -> Result<Arc<dyn ProtocolSim>, AttemptError> {
     // Broadcaster serialization strips credentials, so rebuild only the request-scoped client.
     // Firm quotes do not use the stream token filters carried by these clients.
     if let Some(state) = pool_state.as_any().downcast_ref::<BebopState>() {
@@ -423,27 +431,28 @@ fn hydrate_rfq_pool_state(
         return Ok(Arc::new(hydrated));
     }
 
-    Err(EncodeError::internal(format!(
+    Err(AttemptError::deterministic(EncodeError::internal(format!(
         "RFQ pool {pool_id} has unsupported state type"
-    )))
+    ))))
 }
 
 fn rfq_hydration_error(
     pool_id: &str,
     provider: &str,
     error: impl std::fmt::Display,
-) -> EncodeError {
-    EncodeError::internal(format!(
+) -> AttemptError {
+    AttemptError::deterministic(EncodeError::internal(format!(
         "Failed to hydrate {provider} client for RFQ pool {pool_id}: {error}"
-    ))
+    )))
 }
 
-fn availability_error(availability: crate::models::state::EncodeAvailability) -> EncodeError {
-    EncodeError::unavailable(
+fn availability_error(availability: crate::models::state::EncodeAvailability) -> AttemptError {
+    // Unavailable state must fail immediately instead of entering the future retry loop.
+    AttemptError::deterministic(EncodeError::unavailable(
         availability.availability_message().unwrap_or_else(|| {
             unreachable!("unready pool lookup must have an availability message")
         }),
-    )
+    ))
 }
 
 fn initialize_segment_states(normalized: &NormalizedRouteInternal) -> Vec<SegmentSimState> {
@@ -457,17 +466,26 @@ fn initialize_segment_states(normalized: &NormalizedRouteInternal) -> Vec<Segmen
         .collect()
 }
 
+fn classify_allocation_error(error: AttemptError, hop_index: usize) -> AttemptError {
+    // First-hop amounts come from the request. Later hop amounts come from simulated state.
+    if hop_index == 0 {
+        error
+    } else {
+        AttemptError::state_dependent(EncodeError::from(error))
+    }
+}
+
 fn require_hop_amount_in(
     segment_state: &SegmentSimState,
     segment_index: usize,
     hop_index: usize,
-) -> Result<BigUint, EncodeError> {
+) -> Result<BigUint, AttemptError> {
     let hop_amount_in = segment_state.next_amount_in.clone();
     if hop_amount_in.is_zero() {
-        return Err(EncodeError::invalid(format!(
+        return Err(AttemptError::deterministic(EncodeError::invalid(format!(
             "segment[{}].hop[{}] amountIn is zero",
             segment_index, hop_index
-        )));
+        ))));
     }
 
     Ok(hop_amount_in)
@@ -480,7 +498,7 @@ async fn simulate_swap(
         Arc<dyn ProtocolSim>,
         tycho_simulation::tycho_common::simulation::protocol_sim::GetAmountOutResult,
     ),
-    EncodeError,
+    AttemptError,
 > {
     let SwapSimulationRequest {
         pool_state,
@@ -502,30 +520,32 @@ async fn simulate_swap(
         .map_err(|err| execution_error(&failure_pool_id, err))?;
 
     let result = result.map_err(|err| {
-        EncodeError::simulation(format!("Pool {} simulation failed: {}", pool_id, err))
+        AttemptError::state_dependent(EncodeError::simulation(format!(
+            "Pool {} simulation failed: {}",
+            pool_id, err
+        )))
     })?;
     Ok((pre_state, result))
 }
 
-fn execution_error(pool_id: &str, err: SimulationExecutionError) -> EncodeError {
+fn execution_error(pool_id: &str, err: SimulationExecutionError) -> AttemptError {
     match err {
-        SimulationExecutionError::WorkerPanicked(_) => {
-            EncodeError::internal(format!("Pool {} simulation worker panicked", pool_id))
-        }
-        SimulationExecutionError::ResultDropped => {
-            EncodeError::internal(format!("Pool {} simulation result was dropped", pool_id))
-        }
+        SimulationExecutionError::WorkerPanicked(_) => AttemptError::deterministic(
+            EncodeError::internal(format!("Pool {} simulation worker panicked", pool_id)),
+        ),
+        SimulationExecutionError::ResultDropped => AttemptError::deterministic(
+            EncodeError::internal(format!("Pool {} simulation result was dropped", pool_id)),
+        ),
     }
 }
 
 fn require_non_zero_amount_out(
     pool_id: &str,
     expected_out: BigUint,
-) -> Result<BigUint, EncodeError> {
+) -> Result<BigUint, AttemptError> {
     if expected_out.is_zero() {
-        return Err(EncodeError::simulation(format!(
-            "Pool {} returned zero amountOut",
-            pool_id
+        return Err(AttemptError::state_dependent(EncodeError::simulation(
+            format!("Pool {} returned zero amountOut", pool_id),
         )));
     }
 
@@ -535,13 +555,15 @@ fn require_non_zero_amount_out(
 fn build_resimulated_segments(
     normalized: &NormalizedRouteInternal,
     segment_states: &mut [SegmentSimState],
-) -> Result<Vec<ResimulatedSegmentInternal>, EncodeError> {
+) -> Result<Vec<ResimulatedSegmentInternal>, AttemptError> {
     let mut resim_segments = Vec::with_capacity(normalized.segments.len());
     for (segment_index, segment) in normalized.segments.iter().enumerate() {
         let resim_hops = take_segment_hops(segment_states, segment_index, segment.hops.len())?;
-        let last_hop = resim_hops
-            .last()
-            .ok_or_else(|| EncodeError::internal("Segment hops missing after resimulation"))?;
+        let last_hop = resim_hops.last().ok_or_else(|| {
+            AttemptError::deterministic(EncodeError::internal(
+                "Segment hops missing after resimulation",
+            ))
+        })?;
         resim_segments.push(ResimulatedSegmentInternal {
             share_bps: segment.share_bps,
             amount_in: segment.amount_in.clone(),
@@ -556,15 +578,19 @@ fn take_segment_hops(
     segment_states: &mut [SegmentSimState],
     segment_index: usize,
     hop_len: usize,
-) -> Result<Vec<ResimulatedHopInternal>, EncodeError> {
-    let segment_state = segment_states
-        .get_mut(segment_index)
-        .ok_or_else(|| EncodeError::internal("Segment state missing after resimulation"))?;
+) -> Result<Vec<ResimulatedHopInternal>, AttemptError> {
+    let segment_state = segment_states.get_mut(segment_index).ok_or_else(|| {
+        AttemptError::deterministic(EncodeError::internal(
+            "Segment state missing after resimulation",
+        ))
+    })?;
     let mut resim_hops = Vec::with_capacity(hop_len);
     for hop_index in 0..hop_len {
-        let resim_hop = segment_state.hops[hop_index]
-            .take()
-            .ok_or_else(|| EncodeError::internal("Segment hops missing after resimulation"))?;
+        let resim_hop = segment_state.hops[hop_index].take().ok_or_else(|| {
+            AttemptError::deterministic(EncodeError::internal(
+                "Segment hops missing after resimulation",
+            ))
+        })?;
         resim_hops.push(resim_hop);
     }
     Ok(resim_hops)
@@ -573,11 +599,11 @@ fn take_segment_hops(
 fn validate_request_tokens(
     request_token_in: &Bytes,
     request_token_out: &Bytes,
-) -> Result<(), EncodeError> {
+) -> Result<(), AttemptError> {
     if request_token_in.is_empty() || request_token_out.is_empty() {
-        return Err(EncodeError::internal(
+        return Err(AttemptError::deterministic(EncodeError::internal(
             "Request tokens missing after resimulation",
-        ));
+        )));
     }
 
     Ok(())
@@ -590,7 +616,7 @@ fn ensure_native_swap_supported(
     component: &ProtocolComponent,
     component_id: &str,
     native_token_protocol_allowlist: &[String],
-) -> Result<bool, EncodeError> {
+) -> Result<bool, AttemptError> {
     let native_address = chain.native_token().address;
     let swap_uses_native = *token_in == native_address || *token_out == native_address;
     let protocol_supports_native =
@@ -598,10 +624,10 @@ fn ensure_native_swap_supported(
 
     if swap_uses_native && !protocol_supports_native {
         let supported = format_native_protocol_allowlist(native_token_protocol_allowlist);
-        return Err(EncodeError::invalid(format!(
+        return Err(AttemptError::deterministic(EncodeError::invalid(format!(
             "native tokenIn/tokenOut is only supported for protocols [{}]; pool {} uses {}",
             supported, component_id, component.protocol_system
-        )));
+        ))));
     }
 
     Ok(protocol_supports_native)
@@ -611,7 +637,7 @@ fn validate_native_request_tokens(
     normalized: &NormalizedRouteInternal,
     chain: Chain,
     native_token_protocol_allowlist: &[String],
-) -> Result<(), EncodeError> {
+) -> Result<(), AttemptError> {
     let native_address = chain.native_token().address;
 
     for segment in &normalized.segments {
@@ -629,10 +655,10 @@ fn validate_native_request_tokens(
                 ) {
                     let supported =
                         format_native_protocol_allowlist(native_token_protocol_allowlist);
-                    return Err(EncodeError::invalid(format!(
+                    return Err(AttemptError::deterministic(EncodeError::invalid(format!(
                         "native tokenIn/tokenOut is only supported for protocols [{}]; got {}",
                         supported, swap.pool.protocol
-                    )));
+                    ))));
                 }
             }
         }
@@ -648,7 +674,7 @@ fn ensure_erc4626_swap_supported(
     token_in: &Bytes,
     token_out: &Bytes,
     erc4626_deposits_enabled: bool,
-) -> Result<(), EncodeError> {
+) -> Result<(), AttemptError> {
     if !component_is_erc4626(component) {
         return Ok(());
     }
@@ -670,11 +696,13 @@ fn ensure_erc4626_swap_supported(
         token_out = token_out.to_string(),
         "Rejecting unsupported ERC4626 encode hop during resimulation"
     );
-    Err(EncodeError::invalid(unsupported_direction_message(
-        token_in,
-        token_out,
-        erc4626_deposits_enabled,
-        &state.erc4626_pair_policies,
+    Err(AttemptError::deterministic(EncodeError::invalid(
+        unsupported_direction_message(
+            token_in,
+            token_out,
+            erc4626_deposits_enabled,
+            &state.erc4626_pair_policies,
+        ),
     )))
 }
 
@@ -703,14 +731,14 @@ impl<'a> TokenCache<'a> {
         &mut self,
         address: &Bytes,
         native_pin: Option<&PublishedStatePin>,
-    ) -> Result<Token, EncodeError> {
+    ) -> Result<Token, AttemptError> {
         if let Some(token) = self.cache.get(address) {
             return Ok(token.clone());
         }
         if let Some(native_pin) = native_pin {
-            let token = native_pin
-                .token(address)
-                .ok_or_else(|| EncodeError::invalid("Token not found"))?;
+            let token = native_pin.token(address).ok_or_else(|| {
+                AttemptError::state_dependent(EncodeError::invalid("Token not found"))
+            })?;
             self.cache.insert(address.clone(), token.clone());
             return Ok(token);
         }
@@ -719,8 +747,13 @@ impl<'a> TokenCache<'a> {
             .tokens
             .ensure(address)
             .await
-            .map_err(|err| EncodeError::simulation(format!("Token lookup failed: {}", err)))?
-            .ok_or_else(|| EncodeError::invalid("Token not found"))?;
+            .map_err(|err| {
+                AttemptError::deterministic(EncodeError::simulation(format!(
+                    "Token lookup failed: {}",
+                    err
+                )))
+            })?
+            .ok_or_else(|| AttemptError::deterministic(EncodeError::invalid("Token not found")))?;
         self.cache.insert(address.clone(), token.clone());
         Ok(token)
     }
@@ -753,8 +786,8 @@ mod tests {
     use super::*;
     use crate::models::state::RfqClientConfig;
     use crate::services::encode::fixtures::{
-        component_with_protocol, component_with_tokens, dummy_token, pool_ref, test_app_state,
-        test_state_stores, token_store_with_tokens, TestAppStateConfig,
+        component_with_protocol, component_with_tokens, dummy_token, fixture_bytes, pool_ref,
+        test_app_state, test_state_stores, token_store_with_tokens, TestAppStateConfig,
     };
     use crate::services::encode::mocks::{step_multiplier, StepProtocolSim};
     use crate::services::encode::model::{
@@ -765,6 +798,52 @@ mod tests {
         app_state
             .acquire_simulation_rebuild_guard(false, false)
             .await
+    }
+
+    #[test]
+    fn allocation_errors_follow_hop_amount_source() {
+        let swaps = vec![
+            NormalizedSwapDraftInternal {
+                pool: pool_ref("p1"),
+                token_in: fixture_bytes("0x0000000000000000000000000000000000000001"),
+                token_out: fixture_bytes("0x0000000000000000000000000000000000000002"),
+                split_bps: 1,
+            },
+            NormalizedSwapDraftInternal {
+                pool: pool_ref("p2"),
+                token_in: fixture_bytes("0x0000000000000000000000000000000000000001"),
+                token_out: fixture_bytes("0x0000000000000000000000000000000000000002"),
+                split_bps: 0,
+            },
+        ];
+
+        let first_hop = match allocate_swaps_by_bps(BigUint::from(1u32), &swaps, 0, 0)
+            .map_err(|error| classify_allocation_error(error, 0))
+        {
+            Ok(_) => panic!("first-hop split should round to zero"),
+            Err(error) => error,
+        };
+        assert!(!first_hop.is_state_dependent());
+
+        let later_hop = match allocate_swaps_by_bps(BigUint::from(1u32), &swaps, 0, 1)
+            .map_err(|error| classify_allocation_error(error, 1))
+        {
+            Ok(_) => panic!("later-hop split should round to zero"),
+            Err(error) => error,
+        };
+        assert!(later_hop.is_state_dependent());
+    }
+
+    #[test]
+    fn simulation_state_and_worker_failures_use_separate_buckets() {
+        let zero_output = match require_non_zero_amount_out("pool", BigUint::zero()) {
+            Ok(_) => panic!("zero output should fail"),
+            Err(error) => error,
+        };
+        assert!(zero_output.is_state_dependent());
+
+        let dropped_result = execution_error("pool", SimulationExecutionError::ResultDropped);
+        assert!(!dropped_result.is_state_dependent());
     }
 
     fn rfq_client_config() -> RfqClientConfig {
@@ -944,6 +1023,7 @@ mod tests {
             err.kind(),
             crate::services::encode::EncodeErrorKind::Internal
         );
+        assert!(!err.is_state_dependent());
         assert_eq!(
             err.message(),
             "RFQ pool pool-unknown has unsupported state type"
@@ -1334,6 +1414,7 @@ mod tests {
             err.kind(),
             crate::services::encode::EncodeErrorKind::InvalidRequest
         );
+        assert!(!err.is_state_dependent());
 
         let enabled_state = test_app_state(
             tokens_store,
@@ -1507,6 +1588,7 @@ mod tests {
             err.kind(),
             crate::services::encode::EncodeErrorKind::Simulation
         );
+        assert!(!err.is_state_dependent());
         assert!(err.message().contains("Token lookup failed"));
     }
 
@@ -1569,6 +1651,19 @@ mod tests {
 
         assert_eq!(from_pin.symbol, "PINNED");
         assert_eq!(from_pin.decimals, 18);
+
+        let missing_address = dummy_token("0x0000000000000000000000000000000000000003").address;
+        let missing_error = match cache.get(&missing_address, Some(&native_pin)).await {
+            Ok(_) => panic!("missing pinned metadata should fail"),
+            Err(error) => error,
+        };
+        assert!(missing_error.is_state_dependent());
+        assert_eq!(
+            missing_error.kind(),
+            crate::services::encode::EncodeErrorKind::InvalidRequest
+        );
+        assert_eq!(missing_error.message(), "Token not found");
+
         assert!(
             !app_state
                 .tokens

--- a/crates/runtime/src/services/encode/response.rs
+++ b/crates/runtime/src/services/encode/response.rs
@@ -174,6 +174,26 @@ pub(super) fn log_retry_fired(
     );
 }
 
+pub(super) fn log_fence_evaluation(
+    request_id: Option<&str>,
+    attempt: u8,
+    generation_moved: bool,
+    identity_changed: bool,
+    native_pool_count: usize,
+    outcome: &str,
+) {
+    info!(
+        scope = "encode_fence",
+        request_id,
+        attempt,
+        generation_moved,
+        identity_changed,
+        native_pool_count,
+        outcome,
+        "Evaluated encode native-state fence"
+    );
+}
+
 pub(super) fn log_retry_skipped_budget(
     request_id: Option<&str>,
     remaining: Duration,

--- a/crates/runtime/src/services/encode/response.rs
+++ b/crates/runtime/src/services/encode/response.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeSet;
+use std::time::Duration;
 
 use num_bigint::BigUint;
 use num_traits::Zero;
@@ -73,12 +74,14 @@ pub(super) fn compute_expected_total(resimulated: &ResimulatedRouteInternal) -> 
 
 pub(super) fn log_resimulation_amounts(
     request_id: Option<&str>,
+    attempt: u8,
     resimulated: &ResimulatedRouteInternal,
 ) {
     // Keep the hop-by-hop trace available for debugging without making it the primary signal.
     for (segment_index, segment) in resimulated.segments.iter().enumerate() {
         debug!(
             request_id,
+            attempt,
             segment_index,
             share_bps = segment.share_bps,
             amount_in = %segment.amount_in,
@@ -89,6 +92,7 @@ pub(super) fn log_resimulation_amounts(
         for (hop_index, hop) in segment.hops.iter().enumerate() {
             debug!(
                 request_id,
+                attempt,
                 segment_index,
                 hop_index,
                 token_in = %format_address(&hop.token_in),
@@ -101,6 +105,7 @@ pub(super) fn log_resimulation_amounts(
             for (swap_index, swap) in hop.swaps.iter().enumerate() {
                 debug!(
                     request_id,
+                    attempt,
                     segment_index,
                     hop_index,
                     swap_index,
@@ -135,11 +140,74 @@ pub fn log_success(request: &RouteEncodeRequest, computation: &EncodeComputation
         min_amount_out = summary.min_amount_out.as_str(),
         is_native_input = summary.is_native_input,
         reset_approval = computation.reset_approval,
+        attempts = computation.attempts,
+        first_attempt_expected_amount_out =
+            computation.first_attempt_expected_amount_out.as_deref(),
         expected_amount_out = computation.expected_amount_out.as_str(),
         amount_out_delta = computation.amount_out_delta.as_str(),
         interactions = computation.response.interactions.len(),
         block_number = response_block_number(&computation.response),
         "Encode request completed"
+    );
+}
+
+pub(super) fn log_retry_fired(
+    request_id: Option<&str>,
+    trigger: &str,
+    first_error_kind: Option<EncodeErrorKind>,
+    first_error_message: Option<&str>,
+    first_expected_amount_out: Option<&str>,
+    elapsed: Duration,
+    route_uses_rfq: bool,
+) {
+    info!(
+        scope = "encode_retry",
+        outcome = "retry_fired",
+        request_id,
+        trigger,
+        first_error_kind = first_error_kind.map(encode_error_kind_label),
+        first_error_message,
+        first_expected_amount_out,
+        elapsed_ms = elapsed.as_millis() as u64,
+        route_uses_rfq,
+        "Retrying encode against current native state"
+    );
+}
+
+pub(super) fn log_retry_skipped_budget(
+    request_id: Option<&str>,
+    remaining: Duration,
+    elapsed: Duration,
+    route_uses_rfq: bool,
+) {
+    warn!(
+        scope = "encode_retry",
+        outcome = "retry_skipped_budget",
+        request_id,
+        remaining_ms = remaining.as_millis() as u64,
+        elapsed_ms = elapsed.as_millis() as u64,
+        route_uses_rfq,
+        "Encode retry skipped because the request budget is too low"
+    );
+}
+
+pub(super) fn log_second_trip_abort(
+    request_id: Option<&str>,
+    provisional_outcome: &str,
+    provisional_error_message: Option<&str>,
+    provisional_expected_amount_out: Option<&str>,
+    elapsed: Duration,
+) {
+    warn!(
+        scope = "encode_retry",
+        outcome = "second_trip_abort",
+        request_id,
+        attempts = 2,
+        provisional_outcome,
+        provisional_error_message,
+        provisional_expected_amount_out,
+        elapsed_ms = elapsed.as_millis() as u64,
+        "Encode aborted after native state changed during both attempts"
     );
 }
 

--- a/crates/runtime/src/services/encode/tycho_swaps.rs
+++ b/crates/runtime/src/services/encode/tycho_swaps.rs
@@ -8,6 +8,7 @@ use tycho_simulation::tycho_common::{
     models::protocol::ProtocolComponent as CommonProtocolComponent, Bytes,
 };
 
+use super::error::AttemptError;
 use super::model::ResimulatedRouteInternal;
 use super::wire::format_address;
 use super::EncodeError;
@@ -20,7 +21,7 @@ struct SplitStats {
 
 pub(super) fn build_route_swaps(
     resimulated: &ResimulatedRouteInternal,
-) -> Result<Vec<Swap>, EncodeError> {
+) -> Result<Vec<Swap>, AttemptError> {
     // Tycho split validation allows only one remainder per tokenIn, so depths must be consistent.
     ensure_token_in_single_depth(resimulated)?;
 
@@ -58,9 +59,11 @@ pub(super) fn build_route_swaps(
 
     let mut swaps = Vec::with_capacity(ordered_swaps.len());
     for (index, swap) in ordered_swaps.iter().enumerate() {
-        let stats = split_stats
-            .get(&swap.token_in)
-            .ok_or_else(|| EncodeError::internal("Missing split stats for swap tokenIn"))?;
+        let stats = split_stats.get(&swap.token_in).ok_or_else(|| {
+            AttemptError::deterministic(EncodeError::internal(
+                "Missing split stats for swap tokenIn",
+            ))
+        })?;
         // Tycho split validation requires exactly one remainder (split=0) per tokenIn, and it must
         // be the last occurrence in order.
         let is_remainder = stats.count == 1 || stats.last_index == index;
@@ -88,17 +91,19 @@ pub(super) fn build_route_swaps(
     Ok(swaps)
 }
 
-fn ensure_token_in_single_depth(resimulated: &ResimulatedRouteInternal) -> Result<(), EncodeError> {
+fn ensure_token_in_single_depth(
+    resimulated: &ResimulatedRouteInternal,
+) -> Result<(), AttemptError> {
     let mut token_depths: HashMap<Bytes, usize> = HashMap::new();
     for segment in &resimulated.segments {
         for (hop_index, hop) in segment.hops.iter().enumerate() {
             for swap in &hop.swaps {
                 if let Some(existing_depth) = token_depths.get(&swap.token_in) {
                     if *existing_depth != hop_index {
-                        return Err(EncodeError::invalid(format!(
+                        return Err(AttemptError::deterministic(EncodeError::invalid(format!(
                             "tokenIn {} appears at multiple hop depths",
                             format_address(&swap.token_in)
-                        )));
+                        ))));
                     }
                 } else {
                     token_depths.insert(swap.token_in.clone(), hop_index);
@@ -115,32 +120,38 @@ pub(super) fn compute_split_fraction(
     is_remainder: bool,
     count: usize,
     token_in: &Bytes,
-) -> Result<f64, EncodeError> {
+) -> Result<f64, AttemptError> {
     if count <= 1 || is_remainder {
         return Ok(0.0);
     }
 
     if total_in.is_zero() {
-        return Err(EncodeError::invalid(
+        return Err(AttemptError::deterministic(EncodeError::invalid(
             "TokenIn total amount must be positive for split calculation",
-        ));
+        )));
     }
     if amount_in.is_zero() || amount_in >= total_in {
-        return Err(EncodeError::invalid(format!(
+        return Err(AttemptError::deterministic(EncodeError::invalid(format!(
             "Invalid split ratio for tokenIn {}",
             format_address(token_in)
-        )));
+        ))));
     }
 
     let amount_in = amount_in.to_f64().ok_or_else(|| {
-        EncodeError::invalid("Failed to convert swap amountIn for split calculation")
+        AttemptError::deterministic(EncodeError::invalid(
+            "Failed to convert swap amountIn for split calculation",
+        ))
     })?;
     let total_in = total_in.to_f64().ok_or_else(|| {
-        EncodeError::invalid("Failed to convert tokenIn total amount for split calculation")
+        AttemptError::deterministic(EncodeError::invalid(
+            "Failed to convert tokenIn total amount for split calculation",
+        ))
     })?;
     let mut split = amount_in / total_in;
     if !split.is_finite() {
-        return Err(EncodeError::invalid("Invalid split ratio for tokenIn"));
+        return Err(AttemptError::deterministic(EncodeError::invalid(
+            "Invalid split ratio for tokenIn",
+        )));
     }
     if split <= 0.0 {
         // Clamp away from 0 for very skewed splits that lose precision in f64.
@@ -606,6 +617,7 @@ mod tests {
         };
 
         let err = build_route_swaps(&resimulated).expect_err("rejects repeated token depth");
+        assert!(!err.is_state_dependent());
         assert!(
             err.message().contains("multiple hop depths"),
             "unexpected error: {err:?}"

--- a/crates/runtime/src/services/quotes.rs
+++ b/crates/runtime/src/services/quotes.rs
@@ -23,7 +23,9 @@ use crate::models::messages::{
     QuoteFailureKind, QuoteMeta, QuotePartialKind, QuoteResultQuality, QuoteStatus,
 };
 use crate::models::protocol::ProtocolKind;
-use crate::models::state::{AppState, PublishedStatePin, SimulationRebuildGuard};
+use crate::models::state::{
+    AppState, NativePoolFenceStatus, PublishedStatePin, SimulationRebuildGuard,
+};
 use crate::models::tokens::TokenStoreError;
 
 use super::simulation_executor::{SimulationExecutionError, SimulationExecutor};
@@ -334,7 +336,7 @@ struct PreparedQuoteExecution {
 }
 
 struct NativeFence {
-    request_generation: u64,
+    pin: PublishedStatePin,
     native_pool_ids: HashSet<String>,
 }
 
@@ -383,6 +385,7 @@ pub async fn get_amounts_out(
     request: AmountOutRequest,
     cancel: Option<CancellationToken>,
 ) -> QuoteComputation {
+    let request_id = request.request_id.clone();
     let runner = QuoteRequestRunner::new(state.clone(), request, cancel).await;
     let (mut computation, native_fence) = runner.run().await;
     if let Some(native_fence) = native_fence.filter(|fence| {
@@ -391,15 +394,44 @@ pub async fn get_amounts_out(
             .iter()
             .any(|response| fence.native_pool_ids.contains(&response.pool))
     }) {
-        // The fence covers simulated native outputs only: pinned token metadata is
-        // version-independent, native routes reject mid-request updates, and VM/RFQ-only
-        // requests never consult native request freshness.
-        if !state
-            .native_request_is_current(native_fence.request_generation)
-            .await
-        {
-            discard_stale_native_responses(&mut computation, &native_fence.native_pool_ids);
-        }
+        // Native response states are cloned for simulation, so compare pool identities
+        // between pins. Pinned token metadata is version-independent, and VM/RFQ-only
+        // requests never build this fence.
+        let fence_status = state
+            .native_pool_fence_status(&native_fence.pin, &native_fence.native_pool_ids)
+            .await;
+        let generation_moved = state.native_state_store.pin().await.request_generation()
+            != native_fence.pin.request_generation();
+        let response_count = computation.responses.len();
+        let unavailable = matches!(&fence_status, NativePoolFenceStatus::Unavailable);
+        let changed_pool_count = match fence_status {
+            NativePoolFenceStatus::Available(changed_pool_ids) => {
+                let changed_pool_count = changed_pool_ids.len();
+                discard_stale_native_responses(&mut computation, &changed_pool_ids);
+                changed_pool_count
+            }
+            NativePoolFenceStatus::Unavailable => {
+                discard_stale_native_responses(&mut computation, &native_fence.native_pool_ids);
+                0
+            }
+        };
+        let dropped = response_count - computation.responses.len();
+        let outcome = if unavailable {
+            "unavailable"
+        } else if dropped == 0 {
+            "pass"
+        } else {
+            "identity_drop"
+        };
+        info!(
+            scope = "quote_fence",
+            request_id = request_id.as_str(),
+            generation_moved,
+            changed_pool_count,
+            dropped,
+            outcome,
+            "Evaluated quote native-state fence"
+        );
     }
     computation
 }
@@ -527,7 +559,7 @@ impl QuoteRequestRunner {
             None
         } else {
             self.native_pin.as_ref().map(|pin| NativeFence {
-                request_generation: pin.request_generation(),
+                pin: pin.clone(),
                 native_pool_ids: std::mem::take(&mut self.native_pool_ids),
             })
         };
@@ -2741,20 +2773,21 @@ mod tests {
     }
 
     #[test]
-    fn stale_native_fence_preserves_vm_and_rfq_responses() {
+    fn stale_native_fence_preserves_untouched_responses() {
         let mut computation = fence_test_computation(
-            &["native-pool", "vm-pool"],
+            &["native-pool-changed", "native-pool-unchanged", "vm-pool"],
             QuoteResultQuality::Complete,
             None,
         );
 
         discard_stale_native_responses(
             &mut computation,
-            &HashSet::from(["native-pool".to_string()]),
+            &HashSet::from(["native-pool-changed".to_string()]),
         );
 
-        assert_eq!(computation.responses.len(), 1);
-        assert_eq!(computation.responses[0].pool, "vm-pool");
+        assert_eq!(computation.responses.len(), 2);
+        assert_eq!(computation.responses[0].pool, "native-pool-unchanged");
+        assert_eq!(computation.responses[1].pool, "vm-pool");
         assert!(matches!(computation.meta.status, QuoteStatus::Ready));
         assert_eq!(computation.meta.result_quality, QuoteResultQuality::Partial);
         assert_eq!(
@@ -4727,7 +4760,85 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn native_quote_is_still_fenced_when_generation_advances() {
+    async fn native_quote_drops_only_changed_pool_responses() {
+        let fixture = BasicQuoteFixture::new();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut states = HashMap::new();
+        let mut new_pairs = HashMap::new();
+        insert_pool_state(
+            &mut states,
+            &mut new_pairs,
+            "native-pool-changed",
+            "0x0000000000000000000000000000000000000016",
+            "uniswap_v2",
+            "uniswap_v2",
+            fixture.pair_tokens(),
+            Box::new(DelayedAmountOrderSim {
+                calls: Arc::clone(&calls),
+            }),
+        );
+        insert_pool_state(
+            &mut states,
+            &mut new_pairs,
+            "native-pool-unchanged",
+            "0x0000000000000000000000000000000000000017",
+            "uniswap_v2",
+            "uniswap_v2",
+            fixture.pair_tokens(),
+            Box::new(DelayedAmountOrderSim {
+                calls: Arc::clone(&calls),
+            }),
+        );
+        fixture
+            .native_state_store
+            .apply_update(Update::new(1, states, new_pairs))
+            .await;
+        let app_state = make_test_app_state(
+            Arc::clone(&fixture.token_store),
+            Arc::clone(&fixture.native_state_store),
+            Arc::clone(&fixture.vm_state_store),
+            Arc::clone(&fixture.rfq_state_store),
+            TestAppStateConfig::default(),
+        );
+        let request = fixture.request("req-native-subset-update", &["10"]);
+        let quote_task = tokio::spawn(get_amounts_out(app_state, request, None));
+
+        tokio::time::timeout(Duration::from_millis(500), async {
+            while calls.load(Ordering::SeqCst) == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("native quote should begin before the timeout");
+        let mut replacement_states = HashMap::new();
+        replacement_states.insert(
+            "native-pool-changed".to_string(),
+            Box::new(LinearAmountSim { multiplier: 2 }) as Box<dyn ProtocolSim>,
+        );
+        fixture
+            .native_state_store
+            .apply_update(Update::new(2, replacement_states, HashMap::new()))
+            .await;
+
+        let computation = quote_task.await.expect("quote task should not panic");
+        assert_eq!(computation.responses.len(), 1);
+        assert_eq!(computation.responses[0].pool, "native-pool-unchanged");
+        assert_eq!(computation.meta.result_quality, QuoteResultQuality::Partial);
+        assert_eq!(
+            computation.meta.partial_kind,
+            Some(QuotePartialKind::PoolCoverage)
+        );
+        let stale_failure = computation
+            .meta
+            .failures
+            .iter()
+            .find(|failure| matches!(failure.kind, QuoteFailureKind::StaleNativeState))
+            .expect("changed native pool should add a stale-state failure");
+        assert!(stale_failure.message.contains("dropped 1"));
+    }
+
+    #[tokio::test]
+    async fn native_quote_keeps_responses_when_generation_moves_without_pool_changes() {
         let fixture = BasicQuoteFixture::new();
         let calls = Arc::new(AtomicUsize::new(0));
         let mut states = HashMap::new();
@@ -4755,7 +4866,7 @@ mod tests {
             Arc::clone(&fixture.rfq_state_store),
             TestAppStateConfig::default(),
         );
-        let request = fixture.request("req-native-generation-advance", &["10"]);
+        let request = fixture.request("req-native-generation-only-update", &["10"]);
         let quote_task = tokio::spawn(get_amounts_out(app_state, request, None));
 
         tokio::time::timeout(Duration::from_millis(500), async {
@@ -4771,15 +4882,76 @@ mod tests {
             .await;
 
         let computation = quote_task.await.expect("quote task should not panic");
-        assert!(computation
-            .responses
-            .iter()
-            .all(|response| response.pool != "native-pool"));
+        assert_eq!(computation.responses.len(), 1);
+        assert_eq!(computation.responses[0].pool, "native-pool");
+        assert_eq!(
+            computation.meta.result_quality,
+            QuoteResultQuality::Complete
+        );
+        assert!(computation.meta.partial_kind.is_none());
         assert!(computation
             .meta
             .failures
             .iter()
-            .any(|failure| matches!(failure.kind, QuoteFailureKind::StaleNativeState)));
+            .all(|failure| !matches!(failure.kind, QuoteFailureKind::StaleNativeState)));
+    }
+
+    #[tokio::test]
+    async fn unavailable_native_fence_drops_all_responses() {
+        let fixture = BasicQuoteFixture::new();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut states = HashMap::new();
+        let mut new_pairs = HashMap::new();
+        insert_pool_state(
+            &mut states,
+            &mut new_pairs,
+            "native-pool",
+            "0x0000000000000000000000000000000000000016",
+            "uniswap_v2",
+            "uniswap_v2",
+            fixture.pair_tokens(),
+            Box::new(DelayedAmountOrderSim {
+                calls: Arc::clone(&calls),
+            }),
+        );
+        fixture
+            .native_state_store
+            .apply_update(Update::new(1, states, new_pairs))
+            .await;
+        let app_state = make_test_app_state(
+            Arc::clone(&fixture.token_store),
+            Arc::clone(&fixture.native_state_store),
+            Arc::clone(&fixture.vm_state_store),
+            Arc::clone(&fixture.rfq_state_store),
+            TestAppStateConfig::default(),
+        );
+        let request = fixture.request("req-native-fence-unavailable", &["10"]);
+        let quote_task = tokio::spawn(get_amounts_out(app_state, request, None));
+
+        tokio::time::timeout(Duration::from_millis(500), async {
+            while calls.load(Ordering::SeqCst) == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("native quote should begin before the timeout");
+        fixture.native_state_store.fence_requests().await;
+
+        let computation = quote_task.await.expect("quote task should not panic");
+        assert!(computation.responses.is_empty());
+        assert!(matches!(computation.meta.status, QuoteStatus::Ready));
+        assert_eq!(
+            computation.meta.result_quality,
+            QuoteResultQuality::RequestLevelFailure
+        );
+        assert!(computation.meta.partial_kind.is_none());
+        let stale_failure = computation
+            .meta
+            .failures
+            .iter()
+            .find(|failure| matches!(failure.kind, QuoteFailureKind::StaleNativeState))
+            .expect("unavailable native fence should add a stale-state failure");
+        assert!(stale_failure.message.contains("dropped 1"));
     }
 
     #[tokio::test]

--- a/crates/runtime/src/services/quotes.rs
+++ b/crates/runtime/src/services/quotes.rs
@@ -23,9 +23,7 @@ use crate::models::messages::{
     QuoteFailureKind, QuoteMeta, QuotePartialKind, QuoteResultQuality, QuoteStatus,
 };
 use crate::models::protocol::ProtocolKind;
-use crate::models::state::{
-    AppState, NativePoolFenceStatus, PublishedStatePin, SimulationRebuildGuard,
-};
+use crate::models::state::{AppState, PublishedStatePin, SimulationRebuildGuard};
 use crate::models::tokens::TokenStoreError;
 
 use super::simulation_executor::{SimulationExecutionError, SimulationExecutor};
@@ -336,7 +334,7 @@ struct PreparedQuoteExecution {
 }
 
 struct NativeFence {
-    pin: PublishedStatePin,
+    request_generation: u64,
     native_pool_ids: HashSet<String>,
 }
 
@@ -388,47 +386,22 @@ pub async fn get_amounts_out(
     let request_id = request.request_id.clone();
     let runner = QuoteRequestRunner::new(state.clone(), request, cancel).await;
     let (mut computation, native_fence) = runner.run().await;
-    if let Some(native_fence) = native_fence.filter(|fence| {
-        computation
-            .responses
-            .iter()
-            .any(|response| fence.native_pool_ids.contains(&response.pool))
-    }) {
-        // Native response states are cloned for simulation, so compare pool identities
-        // between pins. Pinned token metadata is version-independent, and VM/RFQ-only
-        // requests never build this fence.
-        let fence_status = state
-            .native_pool_fence_status(&native_fence.pin, &native_fence.native_pool_ids)
-            .await;
-        let generation_moved = state.native_state_store.pin().await.request_generation()
-            != native_fence.pin.request_generation();
-        let response_count = computation.responses.len();
-        let unavailable = matches!(&fence_status, NativePoolFenceStatus::Unavailable);
-        let changed_pool_count = match fence_status {
-            NativePoolFenceStatus::Available(changed_pool_ids) => {
-                let changed_pool_count = changed_pool_ids.len();
-                discard_stale_native_responses(&mut computation, &changed_pool_ids);
-                changed_pool_count
-            }
-            NativePoolFenceStatus::Unavailable => {
-                discard_stale_native_responses(&mut computation, &native_fence.native_pool_ids);
-                0
-            }
-        };
-        let dropped = response_count - computation.responses.len();
-        let outcome = if unavailable {
-            "unavailable"
-        } else if dropped == 0 {
+    if let Some(native_fence) = native_fence {
+        let pinned_generation = native_fence.request_generation;
+        let (available, current_generation) = state.native_request_availability().await;
+        let generation_moved = pinned_generation != current_generation;
+        let outcome = if available {
             "pass"
         } else {
-            "identity_drop"
+            discard_stale_native_responses(&mut computation, &native_fence.native_pool_ids);
+            "unavailable"
         };
         info!(
             scope = "quote_fence",
             request_id = request_id.as_str(),
             generation_moved,
-            changed_pool_count,
-            dropped,
+            pinned_generation,
+            current_generation,
             outcome,
             "Evaluated quote native-state fence"
         );
@@ -452,8 +425,8 @@ fn discard_stale_native_responses(
     computation.meta.failures.push(make_failure(
         QuoteFailureKind::StaleNativeState,
         format!(
-            "Native state changed while the quote was running; dropped {dropped} native pool \
-             result(s), retry against the current version"
+            "Native state was unavailable at the end of the quote, dropped {dropped} native pool \
+             result(s), retry once the simulator is ready"
         ),
         None,
     ));
@@ -559,7 +532,7 @@ impl QuoteRequestRunner {
             None
         } else {
             self.native_pin.as_ref().map(|pin| NativeFence {
-                pin: pin.clone(),
+                request_generation: pin.request_generation(),
                 native_pool_ids: std::mem::take(&mut self.native_pool_ids),
             })
         };
@@ -2773,21 +2746,20 @@ mod tests {
     }
 
     #[test]
-    fn stale_native_fence_preserves_untouched_responses() {
+    fn unavailable_native_fence_preserves_vm_responses() {
         let mut computation = fence_test_computation(
-            &["native-pool-changed", "native-pool-unchanged", "vm-pool"],
+            &["native-pool-1", "native-pool-2", "vm-pool"],
             QuoteResultQuality::Complete,
             None,
         );
 
         discard_stale_native_responses(
             &mut computation,
-            &HashSet::from(["native-pool-changed".to_string()]),
+            &HashSet::from(["native-pool-1".to_string(), "native-pool-2".to_string()]),
         );
 
-        assert_eq!(computation.responses.len(), 2);
-        assert_eq!(computation.responses[0].pool, "native-pool-unchanged");
-        assert_eq!(computation.responses[1].pool, "vm-pool");
+        assert_eq!(computation.responses.len(), 1);
+        assert_eq!(computation.responses[0].pool, "vm-pool");
         assert!(matches!(computation.meta.status, QuoteStatus::Ready));
         assert_eq!(computation.meta.result_quality, QuoteResultQuality::Partial);
         assert_eq!(
@@ -2799,11 +2771,11 @@ mod tests {
             computation.meta.failures[0].kind,
             QuoteFailureKind::StaleNativeState
         ));
-        assert!(computation.meta.failures[0].message.contains("dropped 1"));
+        assert!(computation.meta.failures[0].message.contains("dropped 2"));
     }
 
     #[test]
-    fn stale_native_fence_drops_all_native_responses_with_ready_status() {
+    fn unavailable_native_fence_drops_all_native_responses_with_ready_status() {
         let mut computation = fence_test_computation(
             &["native-pool-1", "native-pool-2"],
             QuoteResultQuality::Complete,
@@ -2831,7 +2803,7 @@ mod tests {
     }
 
     #[test]
-    fn stale_native_fence_upgrades_amount_ladders_partial_to_mixed() {
+    fn unavailable_native_fence_upgrades_amount_ladders_partial_to_mixed() {
         let mut computation = fence_test_computation(
             &["native-pool", "vm-pool"],
             QuoteResultQuality::Partial,
@@ -4760,7 +4732,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn native_quote_drops_only_changed_pool_responses() {
+    async fn native_quote_keeps_all_responses_after_mid_request_update() {
         let fixture = BasicQuoteFixture::new();
         let calls = Arc::new(AtomicUsize::new(0));
         let mut states = HashMap::new();
@@ -4821,69 +4793,15 @@ mod tests {
             .await;
 
         let computation = quote_task.await.expect("quote task should not panic");
-        assert_eq!(computation.responses.len(), 1);
-        assert_eq!(computation.responses[0].pool, "native-pool-unchanged");
-        assert_eq!(computation.meta.result_quality, QuoteResultQuality::Partial);
+        assert_eq!(computation.responses.len(), 2);
         assert_eq!(
-            computation.meta.partial_kind,
-            Some(QuotePartialKind::PoolCoverage)
+            computation
+                .responses
+                .iter()
+                .map(|response| response.pool.as_str())
+                .collect::<HashSet<_>>(),
+            HashSet::from(["native-pool-changed", "native-pool-unchanged"])
         );
-        let stale_failure = computation
-            .meta
-            .failures
-            .iter()
-            .find(|failure| matches!(failure.kind, QuoteFailureKind::StaleNativeState))
-            .expect("changed native pool should add a stale-state failure");
-        assert!(stale_failure.message.contains("dropped 1"));
-    }
-
-    #[tokio::test]
-    async fn native_quote_keeps_responses_when_generation_moves_without_pool_changes() {
-        let fixture = BasicQuoteFixture::new();
-        let calls = Arc::new(AtomicUsize::new(0));
-        let mut states = HashMap::new();
-        let mut new_pairs = HashMap::new();
-        insert_pool_state(
-            &mut states,
-            &mut new_pairs,
-            "native-pool",
-            "0x0000000000000000000000000000000000000016",
-            "uniswap_v2",
-            "uniswap_v2",
-            fixture.pair_tokens(),
-            Box::new(DelayedAmountOrderSim {
-                calls: Arc::clone(&calls),
-            }),
-        );
-        fixture
-            .native_state_store
-            .apply_update(Update::new(1, states, new_pairs))
-            .await;
-        let app_state = make_test_app_state(
-            Arc::clone(&fixture.token_store),
-            Arc::clone(&fixture.native_state_store),
-            Arc::clone(&fixture.vm_state_store),
-            Arc::clone(&fixture.rfq_state_store),
-            TestAppStateConfig::default(),
-        );
-        let request = fixture.request("req-native-generation-only-update", &["10"]);
-        let quote_task = tokio::spawn(get_amounts_out(app_state, request, None));
-
-        tokio::time::timeout(Duration::from_millis(500), async {
-            while calls.load(Ordering::SeqCst) == 0 {
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("native quote should begin before the timeout");
-        fixture
-            .native_state_store
-            .apply_update(Update::new(2, HashMap::new(), HashMap::new()))
-            .await;
-
-        let computation = quote_task.await.expect("quote task should not panic");
-        assert_eq!(computation.responses.len(), 1);
-        assert_eq!(computation.responses[0].pool, "native-pool");
         assert_eq!(
             computation.meta.result_quality,
             QuoteResultQuality::Complete

--- a/docs/encode_example.md
+++ b/docs/encode_example.md
@@ -215,3 +215,22 @@ Note: this validation is deterministic for the **first hop** (route `amountIn` a
 ### Local analysis note
 
 The repo-local analyzer uses a SimpleSwap, MultiSwap, and MegaSwap route matrix built from `/simulate` results and records how `/encode` behaves for those routes. It is meant to surface behavior, latency, and oddities in a standardized report, not to act like a strict pass/fail encode contract test.
+
+## Staleness and retry
+
+Each encode attempt pins native state at the start and resimulates the route from that pin. Before
+returning, the service compares the route's own pools between the pinned and current published
+state by allocation identity. Updates that do not touch the route's pools never invalidate an
+encode.
+
+If the route's pools did change, the service re-pins and retries once internally, whether the first
+attempt produced a result or a state-dependent error. Both attempts share the request timeout, and
+the retry only starts when enough budget remains (an RFQ hop needs the firm quote window,
+native-only routes need a small floor). A second stale attempt returns 503 with "Native state
+changed while the route was being encoded". When native state is unavailable (bootstrap incomplete,
+stale update lease, or recovery fenced requests) the service returns 503 with "Native state is
+unavailable for encoding" without retrying.
+
+Operators can follow this behavior in logs through the `encode_fence` and `encode_retry` scopes,
+keyed by request id (`/simulate` logs the `quote_fence` scope). Both attempts' resimulated amounts
+and the attempt count are logged per request.

--- a/docs/quote_service.md
+++ b/docs/quote_service.md
@@ -180,9 +180,11 @@ Important failure kinds include:
 - `internal`
 - `invalid_request`
 
-Native pool rows computed against pool state or component data that changed while the request was
-running are dropped and reported through `stale_native_state`. Unrelated native updates do not
-invalidate them. If native state becomes unavailable before the fence, all native rows are dropped.
+Native rows are never dropped just because native state changes while `/simulate` is running.
+`/encode` re-simulates the selected route, verifies its native pools against current state, and
+retries once when needed. Native rows are dropped only if native state is unavailable at the end of
+the request because bootstrap is incomplete, the update lease is stale, or recovery has fenced
+requests. In that case all native rows are dropped and reported through `stale_native_state`.
 VM/RFQ-only requests are never fenced.
 
 `meta.pool_results` is the per-pool anomaly layer.

--- a/docs/quote_service.md
+++ b/docs/quote_service.md
@@ -180,10 +180,10 @@ Important failure kinds include:
 - `internal`
 - `invalid_request`
 
-Native pool rows computed against a superseded native version are dropped and reported through
-`stale_native_state`. A natively-routed request that consistently runs longer than one native
-update interval will always be fenced, so operators must keep the request timeout below that
-interval. VM/RFQ-only requests are never fenced.
+Native pool rows computed against pool state or component data that changed while the request was
+running are dropped and reported through `stale_native_state`. Unrelated native updates do not
+invalidate them. If native state becomes unavailable before the fence, all native rows are dropped.
+VM/RFQ-only requests are never fenced.
 
 `meta.pool_results` is the per-pool anomaly layer.
 


### PR DESCRIPTION
Stops encode aborts on unrelated native updates and lets /encode retry once when its route really changed.