### PR TITLE
fix: pin native encode state regardless of request protocol hints

### DIFF
--- a/crates/apps/tests/integration/encode_route.rs
+++ b/crates/apps/tests/integration/encode_route.rs
@@ -912,6 +912,41 @@ async fn add_native_echo_pool(
     Ok(())
 }
 
+async fn add_vm_echo_pool(
+    state: &AppState,
+    request: &RouteEncodeRequest,
+    pool_id: &str,
+) -> Result<()> {
+    let token_in = parse_bytes(&request.token_in)?;
+    let token_out = parse_bytes(&request.token_out)?;
+    let component = ProtocolComponent::new(
+        parse_bytes("0x00000000000000000000000000000000000000cc")?,
+        "vm:maverick_v2".to_string(),
+        "maverick_v2".to_string(),
+        state.chain,
+        vec![
+            make_token(&token_in, "TK1", state.chain),
+            make_token(&token_out, "TK2", state.chain),
+        ],
+        Vec::new(),
+        HashMap::new(),
+        Bytes::default(),
+        NaiveDateTime::default(),
+    );
+    state
+        .vm_state_store
+        .apply_update(Update::new(
+            43,
+            HashMap::from([(
+                pool_id.to_string(),
+                Box::new(EchoAmountSim) as Box<dyn ProtocolSim>,
+            )]),
+            HashMap::from([(pool_id.to_string(), component)]),
+        ))
+        .await;
+    Ok(())
+}
+
 async fn post_encode(
     app: axum::Router,
     request: &RouteEncodeRequest,
@@ -1215,6 +1250,76 @@ async fn encode_route_returns_deterministic_error_without_retry_after_publicatio
         "Encoded router address does not match request tychoRouterAddress"
     );
     assert_eq!(encoder.call_count(), 1);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn encode_route_retries_for_native_pool_with_vm_protocol_hint() -> Result<()> {
+    // The hint says VM but the stored component is native. The fence must still hold a
+    // pin for the component-resolved native pool and catch the mid-attempt update.
+    let config = EncodeFixtureConfig {
+        request_pool_protocol: "vm:maverick_v2",
+        enable_vm_pools: true,
+        request_id: "req-hint-mismatch-retry",
+        ..EncodeFixtureConfig::default()
+    };
+    let (state, request) = build_app_state_and_request(config).await?;
+    add_vm_echo_pool(&state, &request, "vm-ready").await?;
+    let encoder = Arc::new(PublishUpdateOnFirstCallEncoder::new(
+        Arc::clone(&state.native_state_store),
+        parse_bytes(&request.tycho_router_address)?,
+        request.segments[0].hops[0].swaps[0]
+            .pool
+            .component_id
+            .clone(),
+    ));
+    let runtime_encoder: Arc<dyn TychoEncoder> = encoder.clone();
+    let app = create_router(SimulatorRuntime::new_with_encoder(state, runtime_encoder));
+
+    let (status, body) = post_encode(app, &request).await?;
+
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "unexpected status {}: {}",
+        status,
+        String::from_utf8_lossy(&body)
+    );
+    assert_eq!(encoder.call_count(), 2);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn encode_route_aborts_for_native_pool_with_vm_protocol_hint_after_second_publication(
+) -> Result<()> {
+    let config = EncodeFixtureConfig {
+        request_pool_protocol: "vm:maverick_v2",
+        enable_vm_pools: true,
+        request_id: "req-hint-mismatch-second-trip",
+        ..EncodeFixtureConfig::default()
+    };
+    let (state, request) = build_app_state_and_request(config).await?;
+    add_vm_echo_pool(&state, &request, "vm-ready").await?;
+    let encoder = Arc::new(PublishUpdateOnEveryCallEncoder::new(
+        Arc::clone(&state.native_state_store),
+        parse_bytes(&request.tycho_router_address)?,
+        request.segments[0].hops[0].swaps[0]
+            .pool
+            .component_id
+            .clone(),
+    ));
+    let runtime_encoder: Arc<dyn TychoEncoder> = encoder.clone();
+    let app = create_router(SimulatorRuntime::new_with_encoder(state, runtime_encoder));
+
+    let (status, body) = post_encode(app, &request).await?;
+
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    let response: EncodeErrorResponse = serde_json::from_slice(&body)?;
+    assert_eq!(
+        response.error,
+        "Native state changed while the route was being encoded; retry against the current version"
+    );
+    assert_eq!(encoder.call_count(), 2);
     Ok(())
 }
 

--- a/crates/runtime/src/services/encode.rs
+++ b/crates/runtime/src/services/encode.rs
@@ -321,43 +321,32 @@ async fn encode_attempt(
     prepared: &PreparedEncodeRoute,
     attempt_number: AttemptNumber,
 ) -> EncodeAttempt {
-    let native_pin = if prepared.backend_usage.native {
-        Some(state.native_state_store.pin().await)
-    } else {
-        None
-    };
+    // Protocol hints can label a native pool VM or RFQ, and the component-resolved lookup
+    // still serves it, so neither the pin nor the fence can follow backend_usage. Pin
+    // every attempt and key the fence on the pools the attempt resolved as native.
+    let native_pin = state.native_state_store.pin().await;
     let execution =
         encode_attempt_with_pin(state, prepared, attempt_number, native_pin.clone()).await;
-    let native_pool_ids = execution
-        .native_pool_ids
-        .unwrap_or_else(|| normalized_native_pool_ids(&prepared.normalized));
-    let native_fence = NativeAttemptFence::new(native_pin, native_pool_ids);
-    // Protocol hints can misclassify a pool's backend; the resimulated route carries the
-    // component-resolved truth. The retry budget must know about a real RFQ hop, or a
-    // retry approved under the native floor would run a firm quote inside block_in_place
-    // that the request timeout cannot interrupt.
-    let route_uses_rfq = execution
-        .route_uses_rfq
-        .unwrap_or(prepared.backend_usage.rfq);
+    let native_fence = NativeAttemptFence::new(native_pin, execution.native_pool_ids);
 
     EncodeAttempt {
         outcome: AttemptOutcome::from_result(execution.outcome),
         native_fence,
-        route_uses_rfq,
+        route_uses_rfq: execution.route_uses_rfq,
     }
 }
 
 struct EncodeAttemptExecution {
     outcome: Result<EncodeComputation, AttemptError>,
-    native_pool_ids: Option<HashSet<String>>,
-    route_uses_rfq: Option<bool>,
+    native_pool_ids: HashSet<String>,
+    route_uses_rfq: bool,
 }
 
 async fn encode_attempt_with_pin(
     state: &AppState,
     prepared: &PreparedEncodeRoute,
     attempt_number: AttemptNumber,
-    native_pin: Option<PublishedStatePin>,
+    native_pin: PublishedStatePin,
 ) -> EncodeAttemptExecution {
     let rebuild_guard = state
         .acquire_simulation_rebuild_guard(prepared.backend_usage.vm, prepared.backend_usage.rfq)
@@ -374,11 +363,11 @@ async fn encode_attempt_with_pin(
             outcome: Err(AttemptError::deterministic(EncodeError::unavailable(
                 message,
             ))),
-            native_pool_ids: None,
-            route_uses_rfq: None,
+            native_pool_ids: normalized_native_pool_ids(&prepared.normalized),
+            route_uses_rfq: prepared.backend_usage.rfq,
         };
     }
-    let resimulated = match resimulate::resimulate_route_with_native_pin(
+    let resimulation = resimulate::resimulate_route_with_native_pin(
         state,
         &prepared.normalized,
         prepared.chain,
@@ -388,25 +377,31 @@ async fn encode_attempt_with_pin(
         rebuild_guard,
         native_pin,
     )
-    .await
-    {
-        Ok(resimulated) => resimulated,
-        Err(error) => {
-            return EncodeAttemptExecution {
-                outcome: Err(error),
-                native_pool_ids: None,
-                route_uses_rfq: None,
-            };
+    .await;
+    match resimulation.result {
+        Ok(resimulated) => {
+            let outcome =
+                complete_encode_attempt(state, prepared, attempt_number, resimulated).await;
+            EncodeAttemptExecution {
+                outcome,
+                native_pool_ids: resimulation.native_pool_ids,
+                route_uses_rfq: resimulation.uses_rfq,
+            }
         }
-    };
-    let native_pool_ids = resimulated_native_pool_ids(&resimulated);
-    let route_uses_rfq = resimulated_route_uses_rfq(&resimulated);
-    let outcome = complete_encode_attempt(state, prepared, attempt_number, resimulated).await;
-
-    EncodeAttemptExecution {
-        outcome,
-        native_pool_ids: Some(native_pool_ids),
-        route_uses_rfq: Some(route_uses_rfq),
+        Err(error) => {
+            // Failure can strike before every pool resolves, so widen the resolved view
+            // with the hinted pools. An id wrongly treated as native never registers as
+            // changed, while a missed RFQ hop would let a retry approved under the native
+            // floor run a firm quote inside block_in_place that the request timeout cannot
+            // interrupt.
+            let mut native_pool_ids = resimulation.native_pool_ids;
+            native_pool_ids.extend(normalized_native_pool_ids(&prepared.normalized));
+            EncodeAttemptExecution {
+                outcome: Err(error),
+                native_pool_ids,
+                route_uses_rfq: resimulation.uses_rfq || prepared.backend_usage.rfq,
+            }
+        }
     }
 }
 
@@ -475,35 +470,13 @@ fn normalized_native_pool_ids(normalized: &NormalizedRouteInternal) -> HashSet<S
         .collect()
 }
 
-fn resimulated_route_uses_rfq(resimulated: &model::ResimulatedRouteInternal) -> bool {
-    resimulated
-        .segments
-        .iter()
-        .flat_map(|segment| segment.hops.iter())
-        .flat_map(|hop| hop.swaps.iter())
-        .any(|swap| swap.backend.is_rfq())
-}
-
-fn resimulated_native_pool_ids(resimulated: &model::ResimulatedRouteInternal) -> HashSet<String> {
-    // Reused pools can carry route-local state Arcs. Compare the published entries by ID.
-    // Store fallback can find a native pool absent from the pin. One retry converges.
-    resimulated
-        .segments
-        .iter()
-        .flat_map(|segment| segment.hops.iter())
-        .flat_map(|hop| hop.swaps.iter())
-        .filter(|swap| swap.backend.is_native())
-        .map(|swap| swap.pool.component_id.clone())
-        .collect()
-}
-
 struct NativeAttemptFence {
-    pin: Option<PublishedStatePin>,
+    pin: PublishedStatePin,
     native_pool_ids: HashSet<String>,
 }
 
 impl NativeAttemptFence {
-    fn new(pin: Option<PublishedStatePin>, native_pool_ids: HashSet<String>) -> Self {
+    fn new(pin: PublishedStatePin, native_pool_ids: HashSet<String>) -> Self {
         Self {
             pin,
             native_pool_ids,
@@ -511,13 +484,17 @@ impl NativeAttemptFence {
     }
 
     async fn evaluate(&self, state: &AppState) -> Option<NativeFenceEvaluation> {
-        let pinned = self.pin.as_ref()?;
+        // Every attempt holds a pin, but a route with no native pools must stay
+        // independent of native readiness, so only native involvement arms the fence.
+        if self.native_pool_ids.is_empty() {
+            return None;
+        }
         let check = state
-            .native_route_fence_status(pinned, &self.native_pool_ids)
+            .native_route_fence_status(&self.pin, &self.native_pool_ids)
             .await;
         Some(NativeFenceEvaluation {
             status: check.status,
-            generation_moved: check.current_generation != pinned.request_generation(),
+            generation_moved: check.current_generation != self.pin.request_generation(),
             identity_changed: check.status == NativeFenceStatus::Changed,
             native_pool_count: self.native_pool_ids.len(),
         })

--- a/crates/runtime/src/services/encode/resimulate.rs
+++ b/crates/runtime/src/services/encode/resimulate.rs
@@ -58,7 +58,7 @@ struct RouteResimulator<'a> {
     token_cache: TokenCache<'a>,
     pool_cache: HashMap<String, CachedPoolEntry>,
     rebuild_guard: Arc<SimulationRebuildGuard>,
-    native_pin: Option<PublishedStatePin>,
+    native_pin: PublishedStatePin,
 }
 
 struct SwapSimulationRequest {
@@ -80,7 +80,7 @@ async fn resimulate_route(
     native_token_protocol_allowlist: &[String],
     rebuild_guard: Arc<SimulationRebuildGuard>,
 ) -> Result<ResimulatedRouteInternal, AttemptError> {
-    let native_pin = Some(state.native_state_store.pin().await);
+    let native_pin = state.native_state_store.pin().await;
     resimulate_route_with_native_pin(
         state,
         normalized,
@@ -92,6 +92,13 @@ async fn resimulate_route(
         native_pin,
     )
     .await
+    .result
+}
+
+pub(super) struct ResimulationOutcome {
+    pub(super) result: Result<ResimulatedRouteInternal, AttemptError>,
+    pub(super) native_pool_ids: HashSet<String>,
+    pub(super) uses_rfq: bool,
 }
 
 #[expect(
@@ -106,24 +113,25 @@ pub(super) async fn resimulate_route_with_native_pin(
     request_token_out: &Bytes,
     native_token_protocol_allowlist: &[String],
     rebuild_guard: Arc<SimulationRebuildGuard>,
-    native_pin: Option<PublishedStatePin>,
-) -> Result<ResimulatedRouteInternal, AttemptError> {
+    native_pin: PublishedStatePin,
+) -> ResimulationOutcome {
     let mut resimulator =
         RouteResimulator::new(state, normalized, chain, rebuild_guard, native_pin);
-
-    // Resimulate in hop-depth order to match build_route_swaps execution order.
-    for hop_index in 0..resimulator.max_hop_depth() {
-        for segment_index in 0..normalized.segments.len() {
-            resimulator
-                .resimulate_segment_hop(segment_index, hop_index)
-                .await?;
-        }
+    let result = resimulator
+        .run(
+            request_token_in,
+            request_token_out,
+            native_token_protocol_allowlist,
+        )
+        .await;
+    // The fence needs the component-resolved backends even when the route failed partway,
+    // so the resolved view survives the result either way.
+    let (native_pool_ids, uses_rfq) = resimulator.resolved_backends();
+    ResimulationOutcome {
+        result,
+        native_pool_ids,
+        uses_rfq,
     }
-
-    validate_request_tokens(request_token_in, request_token_out)?;
-    validate_native_request_tokens(normalized, chain, native_token_protocol_allowlist)?;
-    let segments = resimulator.build_resimulated_segments()?;
-    Ok(ResimulatedRouteInternal { segments })
 }
 
 impl<'a> RouteResimulator<'a> {
@@ -132,7 +140,7 @@ impl<'a> RouteResimulator<'a> {
         normalized: &'a NormalizedRouteInternal,
         chain: Chain,
         rebuild_guard: Arc<SimulationRebuildGuard>,
-        native_pin: Option<PublishedStatePin>,
+        native_pin: PublishedStatePin,
     ) -> Self {
         Self {
             state,
@@ -144,6 +152,44 @@ impl<'a> RouteResimulator<'a> {
             rebuild_guard,
             native_pin,
         }
+    }
+
+    async fn run(
+        &mut self,
+        request_token_in: &Bytes,
+        request_token_out: &Bytes,
+        native_token_protocol_allowlist: &[String],
+    ) -> Result<ResimulatedRouteInternal, AttemptError> {
+        // Resimulate in hop-depth order to match build_route_swaps execution order.
+        for hop_index in 0..self.max_hop_depth() {
+            for segment_index in 0..self.normalized.segments.len() {
+                self.resimulate_segment_hop(segment_index, hop_index)
+                    .await?;
+            }
+        }
+
+        validate_request_tokens(request_token_in, request_token_out)?;
+        validate_native_request_tokens(
+            self.normalized,
+            self.chain,
+            native_token_protocol_allowlist,
+        )?;
+        let segments = self.build_resimulated_segments()?;
+        Ok(ResimulatedRouteInternal { segments })
+    }
+
+    // The cache holds exactly the pools the route loaded so far, including pools the store
+    // fallback served that are absent from the pin. Publication compares work by ID because
+    // reused pools carry route-local state Arcs.
+    fn resolved_backends(&self) -> (HashSet<String>, bool) {
+        let native_pool_ids = self
+            .pool_cache
+            .iter()
+            .filter(|(_, entry)| entry.backend.is_native())
+            .map(|(id, _)| id.clone())
+            .collect();
+        let uses_rfq = self.pool_cache.values().any(|entry| entry.backend.is_rfq());
+        (native_pool_ids, uses_rfq)
     }
 
     fn max_hop_depth(&self) -> usize {
@@ -245,11 +291,7 @@ impl<'a> RouteResimulator<'a> {
         )?;
         let sim_token_in = map_swap_token(&allocated.token_in, self.chain, keep_native_unwrapped);
         let sim_token_out = map_swap_token(&allocated.token_out, self.chain, keep_native_unwrapped);
-        let native_pin = pool_entry
-            .backend
-            .is_native()
-            .then_some(self.native_pin.as_ref())
-            .flatten();
+        let native_pin = pool_entry.backend.is_native().then_some(&self.native_pin);
         let token_in = self.token_cache.get(&sim_token_in, native_pin).await?;
         let token_out = self.token_cache.get(&sim_token_out, native_pin).await?;
         let (pre_state, result) = simulate_swap(SwapSimulationRequest {
@@ -293,11 +335,7 @@ impl<'a> RouteResimulator<'a> {
             return Ok(entry.clone());
         }
 
-        if let Some((pool_state, component)) = self
-            .native_pin
-            .as_ref()
-            .and_then(|pin| pin.pool_by_id(pool_id))
-        {
+        if let Some((pool_state, component)) = self.native_pin.pool_by_id(pool_id) {
             let entry = CachedPoolEntry {
                 backend: PoolBackend::from_component(component.as_ref()),
                 pool_state,
@@ -1137,6 +1175,88 @@ mod tests {
         assert_eq!(swaps[1].expected_amount_out, BigUint::from(10u32));
         assert_eq!(step_multiplier(swaps[0].pool_state.as_ref()), 1);
         assert_eq!(step_multiplier(swaps[1].pool_state.as_ref()), 2);
+    }
+
+    #[tokio::test]
+    async fn resimulation_outcome_keeps_resolved_native_pools_on_failure() {
+        let token_in = dummy_token("0x0000000000000000000000000000000000000001");
+        let token_out = dummy_token("0x0000000000000000000000000000000000000002");
+        let tokens_store = token_store_with_tokens(vec![token_in.clone(), token_out.clone()]);
+        let (native_state_store, vm_state_store, rfq_state_store) =
+            test_state_stores(Arc::clone(&tokens_store));
+
+        let component = component_with_tokens(
+            "0x0000000000000000000000000000000000000009",
+            vec![token_in.clone(), token_out.clone()],
+        );
+        let mut states = HashMap::new();
+        states.insert(
+            "pool-1".to_string(),
+            Box::new(StepProtocolSim { multiplier: 1 }) as Box<dyn ProtocolSim>,
+        );
+        let mut new_pairs = HashMap::new();
+        new_pairs.insert("pool-1".to_string(), component);
+        native_state_store
+            .apply_update(Update::new(1, states, new_pairs))
+            .await;
+
+        let app_state = test_app_state(
+            tokens_store,
+            Arc::clone(&native_state_store),
+            vm_state_store,
+            rfq_state_store,
+            TestAppStateConfig::default(),
+        );
+
+        let normalized = NormalizedRouteInternal {
+            segments: vec![NormalizedSegmentInternal {
+                share_bps: 10_000,
+                amount_in: BigUint::from(10u32),
+                hops: vec![NormalizedHopInternal {
+                    token_in: token_in.address.clone(),
+                    token_out: token_out.address.clone(),
+                    swaps: vec![
+                        NormalizedSwapDraftInternal {
+                            pool: pool_ref("pool-1"),
+                            token_in: token_in.address.clone(),
+                            token_out: token_out.address.clone(),
+                            split_bps: 5000,
+                        },
+                        NormalizedSwapDraftInternal {
+                            pool: pool_ref("pool-missing"),
+                            token_in: token_in.address.clone(),
+                            token_out: token_out.address.clone(),
+                            split_bps: 0,
+                        },
+                    ],
+                }],
+            }],
+        };
+
+        let rebuild_guard = test_rebuild_guard(&app_state).await;
+        let native_pin = app_state.native_state_store.pin().await;
+        let outcome = resimulate_route_with_native_pin(
+            &app_state,
+            &normalized,
+            Chain::Ethereum,
+            &token_in.address,
+            &token_out.address,
+            &app_state.native_token_protocol_allowlist,
+            rebuild_guard,
+            native_pin,
+        )
+        .await;
+
+        let error = match outcome.result {
+            Ok(_) => panic!("missing pool should fail"),
+            Err(error) => error,
+        };
+        assert!(error.is_state_dependent());
+        assert_eq!(
+            outcome.native_pool_ids,
+            HashSet::from(["pool-1".to_string()])
+        );
+        assert!(!outcome.uses_rfq);
     }
 
     #[tokio::test]

--- a/docs/encode_example.md
+++ b/docs/encode_example.md
@@ -221,7 +221,9 @@ The repo-local analyzer uses a SimpleSwap, MultiSwap, and MegaSwap route matrix 
 Each encode attempt pins native state at the start and resimulates the route from that pin. Before
 returning, the service compares the route's own pools between the pinned and current published
 state by allocation identity. Updates that do not touch the route's pools never invalidate an
-encode.
+encode. The pin always covers the whole native publication and the fence keys on the pools the
+attempt actually resolved as native, so a request protocol hint that mislabels a native pool as
+VM or RFQ does not bypass the fence.
 
 If the route's pools did change, the service re-pins and retries once internally, whether the first
 attempt produced a result or a state-dependent error. Both attempts share the request timeout, and


### PR DESCRIPTION
The encode fence only pinned native state when the request protocol hints said the route used native pools. A hint can label a native pool as VM or RFQ while the stored component still resolves as native, so those routes read live state without a pin and the fence never ran, which could return calldata built from state that changed while the route was being encoded.

Every attempt now pins the native publication and the fence keys on the pools the attempt actually resolved as native, including the ones resolved before a failure, so mislabeled pools read from pinned state and get the same retry and telemetry as any native route.