### PR TITLE
feat: add bounded state history reader

### DIFF
--- a/crates/apps/src/bin/state-history-analysis.rs
+++ b/crates/apps/src/bin/state-history-analysis.rs
@@ -98,7 +98,7 @@ async fn run() -> anyhow::Result<()> {
 
     let pool = store.pool().clone();
     let reader = StateHistoryReader::new(
-        store,
+        pool.clone(),
         object_store(&bucket, &prefix, &region, &endpoint).await,
     );
 
@@ -114,13 +114,7 @@ async fn run() -> anyhow::Result<()> {
 
     let explicit_request = range_request(100, 115)?;
     let explicit_plan = reader.resolve_range(&explicit_request).await?;
-    let recorded_gap = RangeGap {
-        kind: RangeGapKind::Recorded,
-        generation: Some(2),
-        from_message_seq: Some(8),
-        to_message_seq: Some(10),
-        reason: "queue_overflow".to_owned(),
-    };
+    let recorded_gap = expected_recorded_gap();
     let replay_legs = [
         (position(1, 10), positions(1, 11, 40)),
         (position(2, 1), positions(2, 2, 15)),
@@ -698,6 +692,12 @@ fn assert_failed_boundary(failed_plan: &RangePlan, recorded_gap: RangeGap) -> an
         generation: Some(2),
         from_message_seq: Some(1),
         to_message_seq: Some(15),
+        from_position: Some(position(2, 1)),
+        to_position: Some(position(2, 15)),
+        from_block: None,
+        to_block_inclusive: None,
+        from_observed_at_ms: None,
+        to_observed_at_ms: None,
         reason: "no complete boundary checkpoint at generation 2 message sequence 1".to_owned(),
     };
     assert_plan(
@@ -705,6 +705,22 @@ fn assert_failed_boundary(failed_plan: &RangePlan, recorded_gap: RangeGap) -> an
         &[(position(1, 10), positions(1, 11, 40))],
         &[missing_checkpoint, recorded_gap],
     )
+}
+
+fn expected_recorded_gap() -> RangeGap {
+    RangeGap {
+        kind: RangeGapKind::Recorded,
+        generation: Some(2),
+        from_message_seq: Some(8),
+        to_message_seq: Some(10),
+        from_position: Some(position(2, 8)),
+        to_position: Some(position(2, 10)),
+        from_block: Some(112),
+        to_block_inclusive: Some(113),
+        from_observed_at_ms: Some(block_timestamp_ms(113) - 1),
+        to_observed_at_ms: Some(block_timestamp_ms(114) - 1),
+        reason: "queue_overflow".to_owned(),
+    }
 }
 
 struct SeededCheckpoint {

--- a/crates/apps/src/bin/state-history-check.rs
+++ b/crates/apps/src/bin/state-history-check.rs
@@ -48,7 +48,7 @@ async fn run() -> anyhow::Result<String> {
     let start_block = end_block.saturating_sub(arguments.block_count - 1);
 
     let objects = checkpoint_object_store_from_env(bucket).await?;
-    let reader = StateHistoryReader::new(store, objects);
+    let reader = StateHistoryReader::new(store.pool().clone(), objects);
     let plan = reader
         .resolve_backtest_range(&BacktestRequest::new(
             arguments.chain_id,

--- a/crates/apps/src/bin/state-history-migrate.rs
+++ b/crates/apps/src/bin/state-history-migrate.rs
@@ -4,7 +4,7 @@ use anyhow::{ensure, Context};
 use serde_json::json;
 use state_history::{
     StateHistoryStore, STATE_HISTORY_MIGRATOR, STATE_HISTORY_OBSERVER_ROLE,
-    STATE_HISTORY_WRITER_ROLE,
+    STATE_HISTORY_SCHEMA_VERSION, STATE_HISTORY_WRITER_ROLE,
 };
 
 const DATABASE_URL_ENV: &str = "STATE_HISTORY_MIGRATION_DATABASE_URL";
@@ -30,7 +30,7 @@ async fn main() -> anyhow::Result<()> {
         serde_json::to_string(&json!({
             "event": "state_history_migration_complete",
             "migrationCatalogEntries": migration_count,
-            "schemaVersion": 1,
+            "schemaVersion": STATE_HISTORY_SCHEMA_VERSION,
             "writerRole": STATE_HISTORY_WRITER_ROLE,
             "observerRole": STATE_HISTORY_OBSERVER_ROLE,
         }))?

--- a/crates/runtime/src/broadcaster/app.rs
+++ b/crates/runtime/src/broadcaster/app.rs
@@ -39,6 +39,7 @@ use simulator_core::broadcaster::{
     BroadcasterBackend, BroadcasterEnvelope, BroadcasterSnapshotSessionResponse,
     BroadcasterTokenDto, BroadcasterTokenLookupResponse, BroadcasterTokenSnapshotResponse,
 };
+use simulator_replay::RETAINED_TOKEN_QUALITY_V1;
 use state_history::{CheckpointKind, StreamPosition};
 use tokio_util::sync::CancellationToken;
 use tycho_simulation::tycho_common::Bytes;
@@ -348,7 +349,7 @@ pub async fn build_broadcaster_service() -> Result<BroadcasterServiceParts> {
         .token_catalog_store()
         .context("raw cache is missing its token catalog")?;
     let (state_history_config, state_history) =
-        initialize_state_history(&config, capture_tokens).await?;
+        initialize_state_history(&config, capture_tokens, token_min_quality).await?;
     let redis_publisher =
         build_redis_publisher(&config, heartbeat_interval, state_history.as_ref()).await?;
     let raw_upstream_state = BroadcasterUpstreamState::default();
@@ -467,11 +468,13 @@ pub async fn build_broadcaster_service() -> Result<BroadcasterServiceParts> {
 async fn initialize_state_history(
     config: &BroadcasterConfig,
     tokens: Arc<TokenStore>,
+    token_min_quality: u32,
 ) -> Result<(
     Option<crate::config::StateHistoryConfig>,
     Option<Arc<StateHistoryRuntime>>,
 )> {
     let state_history_config = load_state_history_config();
+    validate_retained_history_decoder_profile(state_history_config.is_some(), token_min_quality)?;
     let state_history = match state_history_config.as_ref() {
         Some(state_history_config) => match build_state_history_runtime(
             state_history_config,
@@ -503,6 +506,19 @@ async fn initialize_state_history(
         None => None,
     };
     Ok((state_history_config, state_history))
+}
+
+fn validate_retained_history_decoder_profile(
+    state_history_enabled: bool,
+    token_min_quality: u32,
+) -> Result<()> {
+    if state_history_enabled {
+        anyhow::ensure!(
+            token_min_quality == RETAINED_TOKEN_QUALITY_V1,
+            "state history delta format 1 requires BROADCASTER_TOKEN_MIN_QUALITY={RETAINED_TOKEN_QUALITY_V1}; got {token_min_quality}"
+        );
+    }
+    Ok(())
 }
 
 fn combine_status_snapshots(
@@ -991,7 +1007,10 @@ mod tests {
     use tokio_util::sync::CancellationToken;
     use tycho_simulation::tycho_common::{models::Chain, Bytes};
 
-    use super::{raw_configured_backends, rfq_configured_backends, BroadcasterTasks};
+    use super::{
+        raw_configured_backends, rfq_configured_backends,
+        validate_retained_history_decoder_profile, BroadcasterTasks,
+    };
     use crate::config::{BroadcasterConfig, BroadcasterTuning, ChainProfile, MemoryConfig};
 
     #[tokio::test]
@@ -1102,5 +1121,12 @@ mod tests {
         config.enable_rfq_pools = false;
 
         assert_eq!(rfq_configured_backends(&config), None);
+    }
+
+    #[test]
+    fn state_history_format_one_rejects_nonzero_token_quality() {
+        assert!(validate_retained_history_decoder_profile(true, 1).is_err());
+        assert!(validate_retained_history_decoder_profile(true, 0).is_ok());
+        assert!(validate_retained_history_decoder_profile(false, 100).is_ok());
     }
 }

--- a/crates/runtime/src/broadcaster/redis_subscription/processor.rs
+++ b/crates/runtime/src/broadcaster/redis_subscription/processor.rs
@@ -357,7 +357,7 @@ impl BroadcasterSubscriptionProcessor {
         };
 
         let backend = ReplayBackend::from(self.controls.backend());
-        let decoded = self.decoder.decode_delta(update, &[backend]).await?;
+        let decoded = self.decoder.decode_live_delta(update, &[backend]).await?;
         if !decoded.had_applicable_partition {
             return Ok(());
         }

--- a/crates/simulator-replay/src/decoder.rs
+++ b/crates/simulator-replay/src/decoder.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
+use serde_json::value::RawValue;
 use thiserror::Error;
 use tycho_simulation::{
     evm::{
@@ -28,7 +29,8 @@ use tycho_simulation::{
 };
 
 use simulator_core::broadcaster::{
-    BroadcasterProtocolMessage, BroadcasterSnapshotPartition, BroadcasterUpdateMessage,
+    BroadcasterEnvelope, BroadcasterPayload, BroadcasterProtocolMessage,
+    BroadcasterSnapshotPartition, BroadcasterUpdateMessage,
 };
 
 use crate::payload::{live_partition_update, snapshot_partition_update};
@@ -36,10 +38,37 @@ use crate::{DecodedReplay, ReplayBackend};
 
 pub type TokenMap = HashMap<Bytes, Token>;
 
+pub const RETAINED_DELTA_FORMAT_VERSION_V1: i16 = 1;
+pub const RETAINED_TOKEN_QUALITY_V1: u32 = 0;
+
+const RETAINED_NATIVE_PROTOCOLS_V1: &[&str] = &[
+    "aerodrome_slipstreams",
+    "ekubo_v2",
+    "ekubo_v3",
+    "erc4626",
+    "fluid_v1",
+    "pancakeswap_v2",
+    "pancakeswap_v3",
+    "rocketpool",
+    "sushiswap_v2",
+    "uniswap_v2",
+    "uniswap_v3",
+    "uniswap_v4",
+];
+const RETAINED_VM_PROTOCOLS_V1: &[&str] = &["vm:balancer_v2", "vm:curve", "vm:maverick_v2"];
+const RETAINED_RFQ_PROTOCOLS_V1: &[&str] = &["rfq:bebop", "rfq:hashflow", "rfq:liquorice"];
+
 #[derive(Debug, Clone)]
 pub struct DecoderConfig {
-    pub min_token_quality: u32,
+    min_token_quality: u32,
     protocols: BTreeMap<ReplayBackend, Vec<String>>,
+    profile: DecoderProfile,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DecoderProfile {
+    Live,
+    RetainedV1,
 }
 
 impl DecoderConfig {
@@ -51,6 +80,7 @@ impl DecoderConfig {
         Self {
             min_token_quality,
             protocols,
+            profile: DecoderProfile::Live,
         }
     }
 
@@ -60,6 +90,42 @@ impl DecoderConfig {
         min_token_quality: u32,
     ) -> Self {
         Self::new(min_token_quality, [(backend, protocols)])
+    }
+
+    pub fn retained_v1() -> Self {
+        Self {
+            min_token_quality: RETAINED_TOKEN_QUALITY_V1,
+            protocols: [
+                (
+                    ReplayBackend::Native,
+                    RETAINED_NATIVE_PROTOCOLS_V1
+                        .iter()
+                        .map(|protocol| (*protocol).to_owned())
+                        .collect(),
+                ),
+                (
+                    ReplayBackend::Vm,
+                    RETAINED_VM_PROTOCOLS_V1
+                        .iter()
+                        .map(|protocol| (*protocol).to_owned())
+                        .collect(),
+                ),
+                (
+                    ReplayBackend::Rfq,
+                    RETAINED_RFQ_PROTOCOLS_V1
+                        .iter()
+                        .map(|protocol| (*protocol).to_owned())
+                        .collect(),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+            profile: DecoderProfile::RetainedV1,
+        }
+    }
+
+    pub const fn min_token_quality(&self) -> u32 {
+        self.min_token_quality
     }
 
     pub fn protocols(&self, backend: ReplayBackend) -> Option<&[String]> {
@@ -90,6 +156,12 @@ pub enum ReplayDecodeError {
     RawRfqUnsupported,
     #[error("failed to decode broadcaster raw payload: {0}")]
     PayloadDecode(String),
+    #[error("unsupported delta payload format {0}")]
+    UnsupportedDeltaFormat(i16),
+    #[error("delta payload format {0} requires its pinned retained decoder profile")]
+    RetainedDecoderProfileRequired(i16),
+    #[error("stored delta payload is not a broadcaster update")]
+    StoredDeltaIsNotUpdate,
 }
 
 pub struct ReplayDecoder {
@@ -172,6 +244,38 @@ impl ReplayDecoder {
     }
 
     pub async fn decode_delta(
+        &self,
+        payload_format_version: i16,
+        payload: &RawValue,
+        applicable_backends: &[ReplayBackend],
+    ) -> Result<DecodedReplay, ReplayDecodeError> {
+        match payload_format_version {
+            RETAINED_DELTA_FORMAT_VERSION_V1 => {
+                if self.config.profile != DecoderProfile::RetainedV1 {
+                    return Err(ReplayDecodeError::RetainedDecoderProfileRequired(
+                        payload_format_version,
+                    ));
+                }
+                let envelope: BroadcasterEnvelope = serde_json::from_str(payload.get())
+                    .map_err(|error| ReplayDecodeError::PayloadDecode(error.to_string()))?;
+                let BroadcasterPayload::Update(update) = envelope.payload else {
+                    return Err(ReplayDecodeError::StoredDeltaIsNotUpdate);
+                };
+                self.decode_delta_v1(update, applicable_backends).await
+            }
+            other => Err(ReplayDecodeError::UnsupportedDeltaFormat(other)),
+        }
+    }
+
+    pub async fn decode_live_delta(
+        &self,
+        update: BroadcasterUpdateMessage,
+        applicable_backends: &[ReplayBackend],
+    ) -> Result<DecodedReplay, ReplayDecodeError> {
+        self.decode_delta_v1(update, applicable_backends).await
+    }
+
+    async fn decode_delta_v1(
         &self,
         update: BroadcasterUpdateMessage,
         applicable_backends: &[ReplayBackend],
@@ -319,4 +423,107 @@ fn register_vm_decoder(
         other => return Err(ReplayDecodeError::UnknownVmProtocol(other.to_string())),
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retained_v1_profile_is_pinned() {
+        let config = DecoderConfig::retained_v1();
+
+        assert_eq!(config.min_token_quality(), RETAINED_TOKEN_QUALITY_V1);
+        assert_eq!(
+            config.protocols(ReplayBackend::Native),
+            Some(
+                RETAINED_NATIVE_PROTOCOLS_V1
+                    .iter()
+                    .map(|protocol| (*protocol).to_owned())
+                    .collect::<Vec<_>>()
+                    .as_slice()
+            )
+        );
+        assert_eq!(
+            config.protocols(ReplayBackend::Vm),
+            Some(
+                RETAINED_VM_PROTOCOLS_V1
+                    .iter()
+                    .map(|protocol| (*protocol).to_owned())
+                    .collect::<Vec<_>>()
+                    .as_slice()
+            )
+        );
+        assert_eq!(
+            config.protocols(ReplayBackend::Rfq),
+            Some(
+                RETAINED_RFQ_PROTOCOLS_V1
+                    .iter()
+                    .map(|protocol| (*protocol).to_owned())
+                    .collect::<Vec<_>>()
+                    .as_slice()
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn retained_delta_version_one_decodes_the_stored_envelope() -> anyhow::Result<()> {
+        let payload = RawValue::from_string(
+            include_str!("../../simulator-core/tests/fixtures/wire/native_update.json").to_owned(),
+        )?;
+        let decoder = test_decoder();
+
+        let decoded = decoder
+            .decode_delta(RETAINED_DELTA_FORMAT_VERSION_V1, &payload, &[])
+            .await?;
+
+        assert!(!decoded.had_applicable_partition);
+        assert_eq!(decoded.block_number, 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn unknown_retained_delta_version_fails_closed() -> anyhow::Result<()> {
+        let payload = RawValue::from_string("{}".to_owned())?;
+        let Err(error) = test_decoder().decode_delta(99, &payload, &[]).await else {
+            anyhow::bail!("unknown retained delta formats must fail closed");
+        };
+
+        assert!(matches!(
+            error,
+            ReplayDecodeError::UnsupportedDeltaFormat(99)
+        ));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn retained_delta_version_one_rejects_a_live_decoder_profile() -> anyhow::Result<()> {
+        let payload = RawValue::from_string(
+            include_str!("../../simulator-core/tests/fixtures/wire/native_update.json").to_owned(),
+        )?;
+        let decoder = ReplayDecoder::with_decoder(
+            DecoderConfig::for_backend(ReplayBackend::Native, Vec::new(), 100),
+            Arc::new(TychoStreamDecoder::<BlockHeader>::new()),
+        );
+
+        let Err(error) = decoder
+            .decode_delta(RETAINED_DELTA_FORMAT_VERSION_V1, &payload, &[])
+            .await
+        else {
+            anyhow::bail!("format 1 must reject a live decoder profile");
+        };
+
+        assert!(matches!(
+            error,
+            ReplayDecodeError::RetainedDecoderProfileRequired(RETAINED_DELTA_FORMAT_VERSION_V1)
+        ));
+        Ok(())
+    }
+
+    fn test_decoder() -> ReplayDecoder {
+        ReplayDecoder::with_decoder(
+            DecoderConfig::retained_v1(),
+            Arc::new(TychoStreamDecoder::<BlockHeader>::new()),
+        )
+    }
 }

--- a/crates/simulator-replay/src/lib.rs
+++ b/crates/simulator-replay/src/lib.rs
@@ -5,7 +5,10 @@ mod quote;
 mod snapshot;
 mod state;
 
-pub use decoder::{DecoderConfig, ReplayDecodeError, ReplayDecoder, TokenMap};
+pub use decoder::{
+    DecoderConfig, ReplayDecodeError, ReplayDecoder, TokenMap, RETAINED_DELTA_FORMAT_VERSION_V1,
+    RETAINED_TOKEN_QUALITY_V1,
+};
 pub use execution::{SimulationExecutionError, SimulationExecutor};
 pub use payload::{DecodedReplay, ReplayBackend};
 pub use quote::{simulate_amount_out, ExactPoolQuote, ReplayQuoteError};

--- a/crates/simulator-replay/tests/live_parity.rs
+++ b/crates/simulator-replay/tests/live_parity.rs
@@ -109,7 +109,7 @@ async fn delta_applies_only_listed_backends() -> Result<()> {
             .ok_or_else(|| anyhow!("checkpoint did not decode"))?,
     );
 
-    let decoded_delta = decoder.decode_delta(delta.update, &[]).await?;
+    let decoded_delta = decoder.decode_live_delta(delta.update, &[]).await?;
     assert!(!decoded_delta.had_applicable_partition);
     assert!(decoded_delta.update.is_none());
     assert_eq!(decoded_delta.block_number, 0);
@@ -254,7 +254,7 @@ async fn run_extracted_fixture(
         .map(ReplayBackend::from)
         .collect::<Vec<_>>();
     let decoded_delta = decoder
-        .decode_delta(delta.update, &applicable_backends)
+        .decode_live_delta(delta.update, &applicable_backends)
         .await?;
     let delta_report = world.apply(
         decoded_delta

--- a/crates/state-history/migrations/20260813000100_add_delta_payload_format_version.sql
+++ b/crates/state-history/migrations/20260813000100_add_delta_payload_format_version.sql
@@ -1,0 +1,6 @@
+ALTER TABLE state_history.deltas
+    ADD COLUMN payload_format_version SMALLINT NOT NULL DEFAULT 1,
+    ADD CONSTRAINT deltas_payload_format_version_positive
+        CHECK (payload_format_version > 0);
+
+UPDATE state_history.schema_meta SET version = 2;

--- a/crates/state-history/src/archive.rs
+++ b/crates/state-history/src/archive.rs
@@ -4,10 +4,17 @@ use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
 use sha2::{Digest, Sha256};
 
+use crate::reader::{decode_zstd_with_limit, ReadLimitError};
 use crate::{Backend, CheckpointKind, EncodedArchiveInfo, StreamPosition};
 
 pub const ARCHIVE_SCHEMA_VERSION: u32 = 1;
 const ZSTD_COMPRESSION_LEVEL: i32 = 3;
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ArchiveCodecError {
+    #[error("unsupported checkpoint archive schema version {0}")]
+    UnsupportedSchemaVersion(u32),
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CheckpointArchive {
@@ -107,25 +114,56 @@ pub(crate) fn decode_archive_with_info(
         actual_sha256 == expected_sha256,
         "checkpoint archive sha256 mismatch: expected {expected_sha256}, got {actual_sha256}"
     );
+    let envelope: DecodedArchiveEnvelope =
+        serde_json::from_slice(&archive_json).context("failed to parse checkpoint archive")?;
+    match envelope.schema_version {
+        ARCHIVE_SCHEMA_VERSION => {
+            decode_archive_v1(envelope, archive_json, bytes).map_err(anyhow::Error::from)
+        }
+        other => Err(ArchiveCodecError::UnsupportedSchemaVersion(other).into()),
+    }
+}
+
+pub(crate) fn decode_archive_with_info_and_limit(
+    bytes: &[u8],
+    expected_sha256: &str,
+    max_decoded_bytes: u64,
+) -> Result<DecodedArchive, ReadLimitError> {
+    let archive_json = decode_zstd_with_limit(bytes, max_decoded_bytes, "checkpoint archive")?;
+    let actual_sha256 = hex::encode(Sha256::digest(&archive_json));
+    if actual_sha256 != expected_sha256 {
+        return Err(ReadLimitError::Read(anyhow::anyhow!(
+            "checkpoint archive sha256 mismatch: expected {expected_sha256}, got {actual_sha256}"
+        )));
+    }
 
     let envelope: DecodedArchiveEnvelope =
         serde_json::from_slice(&archive_json).context("failed to parse checkpoint archive")?;
-    ensure!(
-        envelope.schema_version == ARCHIVE_SCHEMA_VERSION,
-        "unsupported checkpoint archive schema version {}; expected {ARCHIVE_SCHEMA_VERSION}",
-        envelope.schema_version
-    );
-    ensure!(
-        envelope.metadata.schema_version == envelope.schema_version,
-        "checkpoint archive metadata schema version {} does not match envelope version {}",
-        envelope.metadata.schema_version,
-        envelope.schema_version
-    );
+    match envelope.schema_version {
+        ARCHIVE_SCHEMA_VERSION => decode_archive_v1(envelope, archive_json, bytes),
+        other => Err(ReadLimitError::Read(
+            ArchiveCodecError::UnsupportedSchemaVersion(other).into(),
+        )),
+    }
+}
+
+fn decode_archive_v1(
+    envelope: DecodedArchiveEnvelope,
+    archive_json: Vec<u8>,
+    compressed: &[u8],
+) -> Result<DecodedArchive, ReadLimitError> {
+    if envelope.metadata.schema_version != envelope.schema_version {
+        return Err(ReadLimitError::Read(anyhow::anyhow!(
+            "checkpoint archive metadata schema version {} does not match envelope version {}",
+            envelope.metadata.schema_version,
+            envelope.schema_version
+        )));
+    }
 
     Ok(DecodedArchive {
         archive_bytes: u64::try_from(archive_json.len())
             .context("checkpoint archive length exceeds u64")?,
-        compressed_bytes: u64::try_from(bytes.len())
+        compressed_bytes: u64::try_from(compressed.len())
             .context("compressed checkpoint archive length exceeds u64")?,
         archive: CheckpointArchive {
             metadata: envelope.metadata,
@@ -211,6 +249,18 @@ impl CheckpointObjectStore {
     }
 
     pub async fn fetch(&self, key: &str) -> anyhow::Result<Vec<u8>> {
+        self.fetch_with_limit(key, u64::MAX)
+            .await
+            .map_err(anyhow::Error::from)
+    }
+
+    pub async fn fetch_with_limit(
+        &self,
+        key: &str,
+        max_compressed_bytes: u64,
+    ) -> Result<Vec<u8>, ReadLimitError> {
+        use tokio::io::AsyncReadExt;
+
         let output = self
             .client
             .get_object()
@@ -224,18 +274,35 @@ impl CheckpointObjectStore {
                     self.bucket
                 )
             })?;
-        let bytes = output
+        if let Some(content_length) = output.content_length() {
+            let content_length = u64::try_from(content_length)
+                .context("checkpoint object content length is negative")?;
+            if content_length > max_compressed_bytes {
+                return Err(ReadLimitError::CompressedBytesExceeded {
+                    declared: content_length,
+                    limit: max_compressed_bytes,
+                });
+            }
+        }
+        let mut reader = output
             .body
-            .collect()
-            .await
-            .with_context(|| {
-                format!(
-                    "failed to read checkpoint object s3://{}/{key}",
-                    self.bucket
-                )
-            })?
-            .into_bytes()
-            .to_vec();
+            .into_async_read()
+            .take(max_compressed_bytes.saturating_add(1));
+        let mut bytes = Vec::new();
+        reader.read_to_end(&mut bytes).await.with_context(|| {
+            format!(
+                "failed to read checkpoint object s3://{}/{key}",
+                self.bucket
+            )
+        })?;
+        let compressed_bytes =
+            u64::try_from(bytes.len()).context("checkpoint object length exceeds u64")?;
+        if compressed_bytes > max_compressed_bytes {
+            return Err(ReadLimitError::CompressedBytesExceeded {
+                declared: compressed_bytes,
+                limit: max_compressed_bytes,
+            });
+        }
         Ok(bytes)
     }
 }
@@ -255,6 +322,34 @@ mod tests {
         let decoded = decode_archive(&encoded.bytes, &encoded.info.sha256).unwrap();
         assert_eq!(decoded.payloads_json, archive.payloads_json);
         assert!(decode_archive(&encoded.bytes, "deadbeef").is_err());
+    }
+
+    #[expect(
+        clippy::expect_used,
+        clippy::unwrap_used,
+        reason = "the generated unknown-version fixture must stay valid"
+    )]
+    #[test]
+    fn unknown_archive_schema_version_fails_closed() {
+        let archive = CheckpointArchive {
+            metadata: test_metadata(),
+            payloads_json: vec![r#"{"k":1}"#.into()],
+        };
+        let encoded = encode_archive(archive).unwrap();
+        let json = zstd::stream::decode_all(encoded.bytes.as_slice()).unwrap();
+        let mut envelope: serde_json::Value = serde_json::from_slice(&json).unwrap();
+        envelope["schema_version"] = serde_json::json!(99);
+        envelope["metadata"]["schema_version"] = serde_json::json!(99);
+        let json = serde_json::to_vec(&envelope).unwrap();
+        let sha256 = hex::encode(Sha256::digest(&json));
+        let bytes = zstd::stream::encode_all(json.as_slice(), ZSTD_COMPRESSION_LEVEL).unwrap();
+
+        let error = decode_archive(&bytes, &sha256)
+            .expect_err("unknown checkpoint archive schemas must fail closed");
+
+        assert!(error
+            .to_string()
+            .contains("unsupported checkpoint archive schema version 99"));
     }
 
     #[test]

--- a/crates/state-history/src/models.rs
+++ b/crates/state-history/src/models.rs
@@ -2,6 +2,8 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
+pub const DELTA_PAYLOAD_FORMAT_VERSION: i16 = 1;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct StreamPosition {
     pub generation: u64,
@@ -372,6 +374,10 @@ pub enum ModelError {
     InvalidGapReason(String),
     #[error("backends must not be empty")]
     EmptyBackends,
+    #[error("target blocks must not be empty")]
+    EmptyTargetBlocks,
+    #[error("RFQ target block {0} has no representable next block")]
+    RfqTargetHasNoSuccessor(u64),
     #[error("range start block {start} must not exceed end block {end}")]
     InvalidBlockRange { start: u64, end: u64 },
     #[error("RFQ range start timestamp {start_ms} must not exceed end timestamp {end_ms}")]

--- a/crates/state-history/src/reader.rs
+++ b/crates/state-history/src/reader.rs
@@ -1,13 +1,18 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt,
+    future::Future,
+    ops::{Deref, DerefMut},
 };
 
 use anyhow::{ensure, Context};
 use serde_json::value::RawValue;
 use sha2::{Digest, Sha256};
 use simulator_core::broadcaster::BroadcasterTokenDto;
-use sqlx::{postgres::PgRow, Postgres, Row, Transaction};
+use sqlx::{
+    pool::PoolConnection, postgres::PgRow, Connection, PgConnection, PgPool, Postgres, Row,
+    Transaction,
+};
 
 use crate::{
     archive::decode_archive_with_info, tokens::decode_token_snapshot_raw_with_info, Backend,
@@ -16,20 +21,67 @@ use crate::{
     TokenSnapshotRef,
 };
 
-pub struct StateHistoryReader {
-    store: StateHistoryStore,
-    objects: CheckpointObjectStore,
+mod checkpoints;
+mod coverage;
+mod limits;
+
+pub use checkpoints::*;
+pub use coverage::*;
+pub use limits::*;
+
+pub trait ReadConnectionProvider: Send + Sync + 'static {
+    type Connection<'a>: Deref<Target = PgConnection> + DerefMut + Send + 'a
+    where
+        Self: 'a;
+
+    fn acquire(&self) -> impl Future<Output = Result<Self::Connection<'_>, sqlx::Error>> + Send;
 }
 
-impl StateHistoryReader {
-    pub fn new(store: StateHistoryStore, objects: CheckpointObjectStore) -> Self {
-        Self { store, objects }
+impl ReadConnectionProvider for PgPool {
+    type Connection<'a> = PoolConnection<Postgres>;
+
+    fn acquire(&self) -> impl Future<Output = Result<Self::Connection<'_>, sqlx::Error>> + Send {
+        PgPool::acquire(self)
+    }
+}
+
+impl ReadConnectionProvider for StateHistoryStore {
+    type Connection<'a> = PoolConnection<Postgres>;
+
+    fn acquire(&self) -> impl Future<Output = Result<Self::Connection<'_>, sqlx::Error>> + Send {
+        self.pool().acquire()
+    }
+}
+
+pub struct StateHistoryReader<P: ReadConnectionProvider = PgPool> {
+    pub(super) connections: P,
+    pub(super) objects: CheckpointObjectStore,
+}
+
+impl<P: ReadConnectionProvider> StateHistoryReader<P> {
+    pub fn new(connections: P, objects: CheckpointObjectStore) -> Self {
+        Self {
+            connections,
+            objects,
+        }
     }
 
     pub async fn resolve_range(&self, request: &RangeRequest) -> anyhow::Result<RangePlan> {
         let rfq_bounds = request.rfq_bounds()?;
-        let mut transaction = self.begin_range_transaction().await?;
-        let plan = resolve_range_in_transaction(&mut transaction, request, rfq_bounds).await?;
+        let mut connection = self
+            .connections
+            .acquire()
+            .await
+            .context("failed to acquire state history read connection")?;
+        let mut transaction = begin_range_transaction(&mut connection).await?;
+        let plan = resolve_range_in_transaction(
+            &mut transaction,
+            request,
+            rfq_bounds,
+            ReadLimits::unbounded(),
+        )
+        .await?
+        .plan;
         transaction
             .commit()
             .await
@@ -50,16 +102,33 @@ impl StateHistoryReader {
         &self,
         request: &BacktestRequest,
     ) -> anyhow::Result<BacktestPlan> {
+        let mut connection = self
+            .connections
+            .acquire()
+            .await
+            .context("failed to acquire state history read connection")?;
+        let mut transaction = begin_range_transaction(&mut connection).await?;
         if !request.includes_rfq() {
-            let range = self.resolve_range(&request.range_request(None)).await?;
+            let range = resolve_range_in_transaction(
+                &mut transaction,
+                &request.range_request(None),
+                None,
+                ReadLimits::unbounded(),
+            )
+            .await?
+            .plan;
             let (start_block_timestamp_ms, end_block_timestamp_ms) =
                 fetch_informational_timestamps(
-                    self.store.pool(),
+                    &mut transaction,
                     request.chain_id,
                     request.start_block,
                     request.end_block,
                 )
                 .await?;
+            transaction
+                .commit()
+                .await
+                .context("failed to commit state history backtest transaction")?;
             return Ok(BacktestPlan {
                 start_block_timestamp_ms,
                 end_block_timestamp_ms,
@@ -69,7 +138,6 @@ impl StateHistoryReader {
         }
 
         let end_plus_one = request.end_block + 1;
-        let mut transaction = self.begin_range_transaction().await?;
         let start = require_block_time(
             fetch_block_time(&mut transaction, request.chain_id, request.start_block).await?,
             RequiredBlockTime::Start {
@@ -99,9 +167,14 @@ impl StateHistoryReader {
 
         let rfq_bounds = (start.timestamp_ms, next.timestamp_ms - 1);
         let range_request = request.range_request(Some(rfq_bounds));
-        let range =
-            resolve_range_in_transaction(&mut transaction, &range_request, Some(rfq_bounds))
-                .await?;
+        let range = resolve_range_in_transaction(
+            &mut transaction,
+            &range_request,
+            Some(rfq_bounds),
+            ReadLimits::unbounded(),
+        )
+        .await?
+        .plan;
         transaction
             .commit()
             .await
@@ -277,20 +350,20 @@ impl StateHistoryReader {
         );
         Ok(decoded.snapshot)
     }
+}
 
-    async fn begin_range_transaction(&self) -> anyhow::Result<Transaction<'_, Postgres>> {
-        let mut transaction = self
-            .store
-            .pool()
-            .begin()
-            .await
-            .context("failed to start state history range transaction")?;
-        sqlx::query("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY")
-            .execute(&mut *transaction)
-            .await
-            .context("failed to configure state history range transaction")?;
-        Ok(transaction)
-    }
+async fn begin_range_transaction(
+    connection: &mut PgConnection,
+) -> anyhow::Result<Transaction<'_, Postgres>> {
+    let mut transaction = connection
+        .begin()
+        .await
+        .context("failed to start state history range transaction")?;
+    sqlx::query("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY")
+        .execute(&mut *transaction)
+        .await
+        .context("failed to configure state history range transaction")?;
+    Ok(transaction)
 }
 
 /// A validated block range and backend set for backtest resolution.
@@ -433,6 +506,11 @@ pub struct RangePlan {
     pub gaps: Vec<RangeGap>,
 }
 
+pub(super) struct RangeResolution {
+    pub(super) plan: RangePlan,
+    pub(super) estimated_decoded_bytes: u64,
+}
+
 impl RangePlan {
     pub fn ensure_gap_free(&self) -> Result<(), GapFreeError> {
         if self.gaps.is_empty() {
@@ -459,6 +537,7 @@ pub struct RangeLeg {
 pub struct StoredDelta {
     pub position: StreamPosition,
     pub observed_at_ms: u64,
+    pub payload_format_version: i16,
     /// Exact stored payload. Apply only partitions listed in `applicable_backends`.
     pub raw_payload: Box<RawValue>,
     pub applicable_backends: Vec<DeltaBackendCursor>,
@@ -488,6 +567,12 @@ pub struct RangeGap {
     pub generation: Option<u64>,
     pub from_message_seq: Option<u64>,
     pub to_message_seq: Option<u64>,
+    pub from_position: Option<StreamPosition>,
+    pub to_position: Option<StreamPosition>,
+    pub from_block: Option<u64>,
+    pub to_block_inclusive: Option<u64>,
+    pub from_observed_at_ms: Option<u64>,
+    pub to_observed_at_ms: Option<u64>,
     pub reason: String,
 }
 
@@ -514,8 +599,14 @@ impl std::error::Error for GapFreeError {}
 struct DeltaRow {
     position: StreamPosition,
     observed_at_ms: u64,
+    payload_format_version: i16,
     payload: Box<RawValue>,
     backends: Vec<DeltaBackendCursor>,
+}
+
+struct DeltaFetch {
+    rows: Vec<DeltaRow>,
+    decoded_bytes: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -539,8 +630,15 @@ struct EncodedDeltaRow {
     id: i64,
     position: StreamPosition,
     observed_at_ms: u64,
+    payload_format_version: i16,
     payload: Vec<u8>,
     payload_sha256: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum StoredPayloadError {
+    #[error("unsupported delta payload format {0}")]
+    UnsupportedDeltaFormat(i16),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -565,11 +663,12 @@ enum RequiredBlockTime {
     EndPlusOne { block_number: u64 },
 }
 
-async fn resolve_range_in_transaction(
+pub(super) async fn resolve_range_in_transaction(
     transaction: &mut Transaction<'_, Postgres>,
     request: &RangeRequest,
     rfq_bounds: Option<(u64, u64)>,
-) -> anyhow::Result<RangePlan> {
+    limits: ReadLimits,
+) -> anyhow::Result<RangeResolution> {
     let Some(anchor) = fetch_anchor(
         &mut *transaction,
         request,
@@ -577,30 +676,115 @@ async fn resolve_range_in_transaction(
     )
     .await?
     else {
-        return Ok(RangePlan {
-            legs: vec![],
-            gaps: vec![RangeGap {
-                kind: RangeGapKind::MissingCheckpoint,
-                generation: None,
-                from_message_seq: None,
-                to_message_seq: None,
-                reason: format!(
-                    "no complete checkpoint at or before block {}",
-                    request.start_block
-                ),
-            }],
+        return Ok(RangeResolution {
+            plan: RangePlan {
+                legs: vec![],
+                gaps: vec![RangeGap {
+                    kind: RangeGapKind::MissingCheckpoint,
+                    generation: None,
+                    from_message_seq: None,
+                    to_message_seq: None,
+                    from_position: None,
+                    to_position: None,
+                    from_block: Some(request.start_block),
+                    to_block_inclusive: Some(request.end_block),
+                    from_observed_at_ms: rfq_bounds.map(|bounds| bounds.0),
+                    to_observed_at_ms: rfq_bounds.map(|bounds| bounds.1),
+                    reason: format!(
+                        "no complete checkpoint at or before block {}",
+                        request.start_block
+                    ),
+                }],
+            },
+            estimated_decoded_bytes: 0,
         });
     };
 
-    let deltas = fetch_deltas(&mut *transaction, request, &anchor, rfq_bounds).await?;
     let boundaries = fetch_boundaries(&mut *transaction, &anchor).await?;
+    let (checkpoint_compressed_bytes, checkpoint_decoded_bytes) =
+        declared_checkpoint_bytes(&mut *transaction, &anchor, &boundaries, request).await?;
+    limits.check_compressed(checkpoint_compressed_bytes)?;
+    limits.check_decoded(checkpoint_decoded_bytes)?;
+    let delta_limits = ReadLimits {
+        max_compressed_bytes: limits
+            .max_compressed_bytes
+            .saturating_sub(checkpoint_compressed_bytes),
+        max_decoded_bytes: limits
+            .max_decoded_bytes
+            .saturating_sub(checkpoint_decoded_bytes),
+    };
+    let delta_fetch = fetch_deltas(
+        &mut *transaction,
+        request,
+        &anchor,
+        rfq_bounds,
+        delta_limits,
+    )
+    .await?;
     let gaps = fetch_gap_rows(&mut *transaction, request, &anchor, rfq_bounds).await?;
-    let (legs, gaps) = build_legs(anchor, deltas, boundaries, gaps, request);
-    Ok(RangePlan { legs, gaps })
+    let (legs, gaps) = build_legs(anchor, delta_fetch.rows, boundaries, gaps, request);
+    Ok(RangeResolution {
+        plan: RangePlan { legs, gaps },
+        estimated_decoded_bytes: checkpoint_decoded_bytes
+            .checked_add(delta_fetch.decoded_bytes)
+            .context("state history decoded byte estimate overflowed")?,
+    })
+}
+
+async fn declared_checkpoint_bytes(
+    connection: &mut PgConnection,
+    anchor: &CheckpointManifest,
+    boundaries: &[ManifestRow],
+    request: &RangeRequest,
+) -> anyhow::Result<(u64, u64)> {
+    let manifests =
+        std::iter::once(anchor).chain(boundaries.iter().map(|row| &row.manifest).filter(
+            |manifest| {
+                manifest.status == CheckpointStatus::Complete
+                    && boundary_fits_request_end(manifest, request)
+                    && request
+                        .backends
+                        .iter()
+                        .all(|backend| manifest.backends.binary_search(backend).is_ok())
+            },
+        ));
+    let mut compressed_bytes = 0_u64;
+    let mut decoded_bytes = 0_u64;
+    let mut token_hashes = BTreeSet::new();
+    for manifest in manifests {
+        compressed_bytes = compressed_bytes
+            .checked_add(
+                manifest
+                    .compressed_bytes
+                    .context("complete checkpoint is missing its compressed byte length")?,
+            )
+            .context("checkpoint compressed byte estimate overflowed")?;
+        decoded_bytes = decoded_bytes
+            .checked_add(
+                manifest
+                    .archive_bytes
+                    .context("complete checkpoint is missing its archive byte length")?,
+            )
+            .context("checkpoint decoded byte estimate overflowed")?;
+        let token_reference = match manifest.token_reference.clone() {
+            Some(reference) => Some(reference),
+            None => checkpoints::token_fallback_in_segment(connection, manifest)
+                .await?
+                .and_then(|checkpoint| checkpoint.token_reference),
+        };
+        if let Some(reference) =
+            token_reference.filter(|reference| token_hashes.insert(reference.sha256.clone()))
+        {
+            decoded_bytes = decoded_bytes
+                .checked_add(reference.token_bytes)
+                .context("token snapshot decoded byte estimate overflowed")?;
+        }
+    }
+    Ok((compressed_bytes, decoded_bytes))
 }
 
 async fn fetch_informational_timestamps(
-    pool: &sqlx::PgPool,
+    connection: &mut PgConnection,
     chain_id: u64,
     start_block: u64,
     end_block: u64,
@@ -616,7 +800,7 @@ async fn fetch_informational_timestamps(
         database_i64(start_block, "backtest start_block")?,
         database_i64(end_block, "backtest end_block")?,
     ])
-    .fetch_all(pool)
+    .fetch_all(connection)
     .await
     .context("failed to select informational backtest block timestamps")?;
 
@@ -806,10 +990,99 @@ async fn fetch_deltas(
     request: &RangeRequest,
     anchor: &CheckpointManifest,
     rfq_bounds: Option<(u64, u64)>,
-) -> anyhow::Result<Vec<DeltaRow>> {
+    limits: ReadLimits,
+) -> anyhow::Result<DeltaFetch> {
+    preflight_delta_payloads(connection, request, anchor, rfq_bounds, limits).await?;
+    let encoded = fetch_encoded_deltas(connection, request, anchor, rfq_bounds).await?;
+    let backend_cursors = fetch_delta_backends(
+        connection,
+        &encoded.iter().map(|row| row.id).collect::<Vec<_>>(),
+    )
+    .await?;
+    let mut decoded_bytes = 0_u64;
+    let mut decoded = Vec::with_capacity(encoded.len());
+    for row in encoded {
+        let remaining = limits.max_decoded_bytes.saturating_sub(decoded_bytes);
+        let (row, row_decoded_bytes) =
+            decode_delta_row_with_limit(row, &backend_cursors, remaining)?;
+        decoded_bytes = decoded_bytes
+            .checked_add(row_decoded_bytes)
+            .context("delta decoded byte total overflowed")?;
+        decoded.push(row);
+    }
+    Ok(DeltaFetch {
+        rows: decoded,
+        decoded_bytes,
+    })
+}
+
+async fn preflight_delta_payloads(
+    connection: &mut PgConnection,
+    request: &RangeRequest,
+    anchor: &CheckpointManifest,
+    rfq_bounds: Option<(u64, u64)>,
+    limits: ReadLimits,
+) -> anyhow::Result<()> {
+    let (compressed_bytes, payload_formats): (i64, Vec<i16>) = sqlx::query_as(
+        "SELECT COALESCE(sum(octet_length(d.payload)), 0)::bigint,
+                COALESCE(
+                    array_agg(DISTINCT d.payload_format_version ORDER BY d.payload_format_version),
+                    ARRAY[]::smallint[]
+                )
+         FROM state_history.deltas d
+         WHERE d.chain_id = $1
+           AND (d.generation, d.message_seq) > ($2, $3)
+           AND EXISTS (
+               SELECT 1
+               FROM state_history.delta_backends matched
+               WHERE matched.delta_id = d.id
+                 AND matched.backend = ANY($4::text[])
+                 AND (
+                     (matched.backend <> 'rfq' AND matched.block_number <= $5)
+                     OR
+                     (matched.backend = 'rfq' AND matched.observed_at_ms <= $6)
+                 )
+           )",
+    )
+    .bind(database_i64(request.chain_id, "range chain_id")?)
+    .bind(database_i64(
+        anchor.position.generation,
+        "anchor generation",
+    )?)
+    .bind(database_i64(
+        anchor.position.message_seq,
+        "anchor message_seq",
+    )?)
+    .bind(database_backends(&request.backends))
+    .bind(database_i64(request.end_block, "range end_block")?)
+    .bind(
+        rfq_bounds
+            .map(|bounds| database_i64(bounds.1, "range RFQ end_ms"))
+            .transpose()?,
+    )
+    .fetch_one(&mut *connection)
+    .await
+    .context("failed to preflight state history delta bytes")?;
+    let compressed_bytes = database_u64(compressed_bytes, "delta compressed byte total")?;
+    limits.check_compressed(compressed_bytes)?;
+    if let Some(format) = payload_formats
+        .into_iter()
+        .find(|format| *format != crate::DELTA_PAYLOAD_FORMAT_VERSION)
+    {
+        return Err(StoredPayloadError::UnsupportedDeltaFormat(format).into());
+    }
+    Ok(())
+}
+
+async fn fetch_encoded_deltas(
+    connection: &mut PgConnection,
+    request: &RangeRequest,
+    anchor: &CheckpointManifest,
+    rfq_bounds: Option<(u64, u64)>,
+) -> anyhow::Result<Vec<EncodedDeltaRow>> {
     let rows = sqlx::query(
         "SELECT d.id, d.generation, d.message_seq, d.observed_at_ms,
-                d.payload, d.payload_sha256
+                d.payload_format_version, d.payload, d.payload_sha256
          FROM state_history.deltas d
          WHERE d.chain_id = $1
            AND (d.generation, d.message_seq) > ($2, $3)
@@ -845,20 +1118,7 @@ async fn fetch_deltas(
     .fetch_all(&mut *connection)
     .await
     .context("failed to select state history range deltas")?;
-
-    let encoded = rows
-        .iter()
-        .map(encoded_delta_from_row)
-        .collect::<anyhow::Result<Vec<_>>>()?;
-    let backend_cursors = fetch_delta_backends(
-        connection,
-        &encoded.iter().map(|row| row.id).collect::<Vec<_>>(),
-    )
-    .await?;
-    encoded
-        .into_iter()
-        .map(|row| decode_delta_row(row, &backend_cursors))
-        .collect()
+    rows.iter().map(encoded_delta_from_row).collect()
 }
 
 async fn fetch_delta_backends(
@@ -1028,17 +1288,25 @@ fn encoded_delta_from_row(row: &PgRow) -> anyhow::Result<EncodedDeltaRow> {
             message_seq: database_u64(row.try_get("message_seq")?, "delta message_seq")?,
         },
         observed_at_ms: database_u64(row.try_get("observed_at_ms")?, "delta observed_at_ms")?,
+        payload_format_version: row.try_get("payload_format_version")?,
         payload: row.try_get("payload")?,
         payload_sha256: row.try_get("payload_sha256")?,
     })
 }
 
-fn decode_delta_row(
+fn decode_delta_row_with_limit(
     row: EncodedDeltaRow,
     backend_cursors: &BTreeMap<i64, Vec<DeltaBackendCursor>>,
-) -> anyhow::Result<DeltaRow> {
-    let payload_json =
-        zstd::stream::decode_all(row.payload.as_slice()).context("failed to decompress delta")?;
+    max_decoded_bytes: u64,
+) -> anyhow::Result<(DeltaRow, u64)> {
+    let payload_json = match row.payload_format_version {
+        crate::DELTA_PAYLOAD_FORMAT_VERSION => {
+            decode_zstd_with_limit(row.payload.as_slice(), max_decoded_bytes, "delta format 1")?
+        }
+        other => return Err(StoredPayloadError::UnsupportedDeltaFormat(other).into()),
+    };
+    let decoded_bytes =
+        u64::try_from(payload_json.len()).context("delta decoded byte length exceeds u64")?;
     let actual_sha256 = hex::encode(Sha256::digest(&payload_json));
     ensure!(
         actual_sha256 == row.payload_sha256,
@@ -1049,12 +1317,16 @@ fn decode_delta_row(
     let payload_json =
         String::from_utf8(payload_json).context("delta payload is not valid UTF-8")?;
     let payload = RawValue::from_string(payload_json).context("delta payload is not valid JSON")?;
-    Ok(DeltaRow {
-        position: row.position,
-        observed_at_ms: row.observed_at_ms,
-        payload,
-        backends: backend_cursors.get(&row.id).cloned().unwrap_or_default(),
-    })
+    Ok((
+        DeltaRow {
+            position: row.position,
+            observed_at_ms: row.observed_at_ms,
+            payload_format_version: row.payload_format_version,
+            payload,
+            backends: backend_cursors.get(&row.id).cloned().unwrap_or_default(),
+        },
+        decoded_bytes,
+    ))
 }
 
 fn manifest_from_row(row: &PgRow) -> anyhow::Result<CheckpointManifest> {
@@ -1352,6 +1624,7 @@ fn stored_delta(row: &DeltaRow, request: &RangeRequest) -> StoredDelta {
     StoredDelta {
         position: row.position,
         observed_at_ms: row.observed_at_ms,
+        payload_format_version: row.payload_format_version,
         raw_payload: row.payload.clone(),
         applicable_backends: row
             .backends
@@ -1387,11 +1660,25 @@ fn missing_span(position: StreamPosition, deltas: &[&DeltaRow]) -> PositionSpan 
 }
 
 fn missing_checkpoint_gap(span: PositionSpan) -> RangeGap {
+    let from_position = StreamPosition {
+        generation: span.generation,
+        message_seq: span.from_message_seq,
+    };
+    let to_position = StreamPosition {
+        generation: span.generation,
+        message_seq: span.to_message_seq,
+    };
     RangeGap {
         kind: RangeGapKind::MissingCheckpoint,
         generation: Some(span.generation),
         from_message_seq: Some(span.from_message_seq),
         to_message_seq: Some(span.to_message_seq),
+        from_position: Some(from_position),
+        to_position: Some(to_position),
+        from_block: None,
+        to_block_inclusive: None,
+        from_observed_at_ms: None,
+        to_observed_at_ms: None,
         reason: format!(
             "no complete boundary checkpoint at generation {} message sequence {}",
             span.generation, span.from_message_seq
@@ -1420,6 +1707,18 @@ fn recorded_range_gaps(
             generation: Some(gap.generation),
             from_message_seq: Some(gap.from_message_seq),
             to_message_seq: Some(gap.to_message_seq),
+            from_position: Some(StreamPosition {
+                generation: gap.generation,
+                message_seq: gap.from_message_seq,
+            }),
+            to_position: Some(StreamPosition {
+                generation: gap.generation,
+                message_seq: gap.to_message_seq,
+            }),
+            from_block: gap.from_block_number,
+            to_block_inclusive: gap.to_block_number,
+            from_observed_at_ms: gap.from_observed_at_ms,
+            to_observed_at_ms: gap.to_observed_at_ms,
             reason: gap.reason.clone(),
         })
         .collect()
@@ -1493,6 +1792,18 @@ fn incomplete_tail_gaps(
                 generation: None,
                 from_message_seq: None,
                 to_message_seq: None,
+                from_position: None,
+                to_position: None,
+                from_block: matches!(backend, Backend::Native | Backend::Vm)
+                    .then_some(covered.map_or(request.start_block, |head| head.saturating_add(1))),
+                to_block_inclusive: matches!(backend, Backend::Native | Backend::Vm)
+                    .then_some(request.end_block),
+                from_observed_at_ms: (*backend == Backend::Rfq).then_some(
+                    covered.map_or(request.rfq_start_ms.unwrap_or_default(), |head| {
+                        head.saturating_add(1)
+                    }),
+                ),
+                to_observed_at_ms: (*backend == Backend::Rfq).then_some(requested_end),
                 reason: incomplete_tail_reason(*backend, covered, requested_end),
             })
         })
@@ -1786,6 +2097,12 @@ mod tests {
                 generation: Some(2),
                 from_message_seq: Some(1),
                 to_message_seq: Some(1),
+                from_position: Some(position(2, 1)),
+                to_position: Some(position(2, 1)),
+                from_block: None,
+                to_block_inclusive: None,
+                from_observed_at_ms: None,
+                to_observed_at_ms: None,
                 reason: "no complete boundary checkpoint at generation 2 message sequence 1"
                     .to_owned(),
             }]
@@ -1920,6 +2237,12 @@ mod tests {
                 generation: Some(2),
                 from_message_seq: Some(500),
                 to_message_seq: Some(600),
+                from_position: Some(position(2, 500)),
+                to_position: Some(position(2, 600)),
+                from_block: None,
+                to_block_inclusive: None,
+                from_observed_at_ms: None,
+                to_observed_at_ms: None,
                 reason: "no complete boundary checkpoint at generation 2 message sequence 500"
                     .to_owned(),
             }]
@@ -1978,6 +2301,12 @@ mod tests {
                 generation: Some(1),
                 from_message_seq: Some(2),
                 to_message_seq: Some(3),
+                from_position: Some(position(1, 2)),
+                to_position: Some(position(1, 3)),
+                from_block: None,
+                to_block_inclusive: None,
+                from_observed_at_ms: None,
+                to_observed_at_ms: None,
                 reason: "no complete boundary checkpoint at generation 1 message sequence 2"
                     .to_owned(),
             }]
@@ -2665,6 +2994,12 @@ mod tests {
                 generation: Some(1),
                 from_message_seq: Some(2),
                 to_message_seq: Some(2),
+                from_position: Some(position(1, 2)),
+                to_position: Some(position(1, 2)),
+                from_block: None,
+                to_block_inclusive: None,
+                from_observed_at_ms: None,
+                to_observed_at_ms: None,
                 reason: "no complete boundary checkpoint at generation 1 message sequence 2"
                     .to_owned(),
             }
@@ -2684,6 +3019,12 @@ mod tests {
                     generation: Some(2),
                     from_message_seq: Some(1),
                     to_message_seq: Some(2),
+                    from_position: Some(position(2, 1)),
+                    to_position: Some(position(2, 2)),
+                    from_block: None,
+                    to_block_inclusive: None,
+                    from_observed_at_ms: None,
+                    to_observed_at_ms: None,
                     reason: "missing boundary".to_owned(),
                 },
                 RangeGap {
@@ -2691,6 +3032,12 @@ mod tests {
                     generation: Some(2),
                     from_message_seq: Some(2),
                     to_message_seq: Some(2),
+                    from_position: Some(position(2, 2)),
+                    to_position: Some(position(2, 2)),
+                    from_block: None,
+                    to_block_inclusive: None,
+                    from_observed_at_ms: None,
+                    to_observed_at_ms: None,
                     reason: "write_failed".to_owned(),
                 },
             ],
@@ -3905,6 +4252,7 @@ mod tests {
         DeltaRow {
             position: position(generation, message_seq),
             observed_at_ms: block_number * 1_000,
+            payload_format_version: crate::DELTA_PAYLOAD_FORMAT_VERSION,
             payload: RawValue::from_string(format!(
                 r#"{{"generation":{generation},"message_seq":{message_seq}}}"#
             ))
@@ -3922,6 +4270,7 @@ mod tests {
         DeltaRow {
             position: position(generation, message_seq),
             observed_at_ms,
+            payload_format_version: crate::DELTA_PAYLOAD_FORMAT_VERSION,
             payload: RawValue::from_string(format!(
                 r#"{{"generation":{generation},"message_seq":{message_seq}}}"#
             ))

--- a/crates/state-history/src/reader/checkpoints.rs
+++ b/crates/state-history/src/reader/checkpoints.rs
@@ -1,0 +1,347 @@
+use anyhow::{ensure, Context};
+use sqlx::Row;
+
+use super::{
+    begin_range_transaction, database_i64, manifest_from_row, BlockInterval,
+    ReadConnectionProvider, StateHistoryReader,
+};
+use crate::{CheckpointKind, CheckpointManifest, CheckpointStatus, StreamPosition};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TokenAnchor {
+    Available {
+        checkpoint: Box<CheckpointManifest>,
+        used_fallback: bool,
+    },
+    Missing,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExplicitCheckpointPair {
+    pub earlier_position: StreamPosition,
+    pub target_position: StreamPosition,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CheckpointPairSelection {
+    BlockRange(BlockInterval),
+    Explicit(Vec<ExplicitCheckpointPair>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckpointPairQuery {
+    pub chain_id: u64,
+    pub selection: CheckpointPairSelection,
+}
+
+impl CheckpointPairQuery {
+    pub const fn new(chain_id: u64, selection: CheckpointPairSelection) -> Self {
+        Self {
+            chain_id,
+            selection,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckpointPair {
+    pub earlier: CheckpointManifest,
+    pub target: CheckpointManifest,
+}
+
+impl<P: ReadConnectionProvider> StateHistoryReader<P> {
+    pub async fn select_token_anchor(
+        &self,
+        selected: &CheckpointManifest,
+    ) -> anyhow::Result<TokenAnchor> {
+        ensure!(
+            selected.status == CheckpointStatus::Complete,
+            "token anchor selection requires a complete checkpoint"
+        );
+        let mut connection = self
+            .connections
+            .acquire()
+            .await
+            .context("failed to acquire token anchor connection")?;
+        let mut transaction = begin_range_transaction(&mut connection).await?;
+        let stored = exact_checkpoint(&mut transaction, selected.chain_id, selected.position)
+            .await?
+            .context("selected checkpoint does not exist as a complete retained checkpoint")?;
+        ensure!(
+            stored.id == selected.id,
+            "selected checkpoint does not match the retained checkpoint at its position"
+        );
+
+        let anchor = if stored.token_reference.is_some() {
+            TokenAnchor::Available {
+                checkpoint: Box::new(stored),
+                used_fallback: false,
+            }
+        } else {
+            match token_fallback_in_segment(&mut transaction, &stored).await? {
+                Some(checkpoint) => TokenAnchor::Available {
+                    checkpoint: Box::new(checkpoint),
+                    used_fallback: true,
+                },
+                None => TokenAnchor::Missing,
+            }
+        };
+        transaction
+            .commit()
+            .await
+            .context("failed to commit token anchor transaction")?;
+        Ok(anchor)
+    }
+
+    pub async fn resolve_checkpoint_pairs(
+        &self,
+        query: &CheckpointPairQuery,
+    ) -> anyhow::Result<Vec<CheckpointPair>> {
+        let mut connection = self
+            .connections
+            .acquire()
+            .await
+            .context("failed to acquire checkpoint pair connection")?;
+        let mut transaction = begin_range_transaction(&mut connection).await?;
+        let pairs = match &query.selection {
+            CheckpointPairSelection::BlockRange(bounds) => {
+                range_checkpoint_pairs(&mut transaction, query.chain_id, *bounds).await?
+            }
+            CheckpointPairSelection::Explicit(selections) => {
+                explicit_checkpoint_pairs(&mut transaction, query.chain_id, selections).await?
+            }
+        };
+        transaction
+            .commit()
+            .await
+            .context("failed to commit checkpoint pair transaction")?;
+        Ok(pairs)
+    }
+}
+
+pub(super) async fn token_fallback_in_segment(
+    connection: &mut sqlx::PgConnection,
+    selected: &CheckpointManifest,
+) -> anyhow::Result<Option<CheckpointManifest>> {
+    let boundary = sqlx::query(
+        "SELECT id, chain_id, generation, message_seq, state_version, kind, block_number,
+                rfq_observed_at_ms, backends, s3_key, archive_sha256, archive_bytes,
+                compressed_bytes, token_s3_key, token_sha256, token_count, token_bytes,
+                status, error
+         FROM state_history.checkpoints
+         WHERE chain_id = $1 AND status = 'complete' AND kind = 'boundary'
+           AND (generation, message_seq) <= ($2, $3)
+         ORDER BY generation DESC, message_seq DESC
+         LIMIT 1",
+    )
+    .bind(database_i64(selected.chain_id, "token anchor chain_id")?)
+    .bind(database_i64(
+        selected.position.generation,
+        "token anchor generation",
+    )?)
+    .bind(database_i64(
+        selected.position.message_seq,
+        "token anchor message_seq",
+    )?)
+    .fetch_optional(&mut *connection)
+    .await
+    .context("failed to select token anchor segment boundary")?
+    .as_ref()
+    .map(manifest_from_row)
+    .transpose()?;
+    let Some(boundary) = boundary else {
+        return Ok(None);
+    };
+
+    let row = sqlx::query(
+        "SELECT id, chain_id, generation, message_seq, state_version, kind, block_number,
+                rfq_observed_at_ms, backends, s3_key, archive_sha256, archive_bytes,
+                compressed_bytes, token_s3_key, token_sha256, token_count, token_bytes,
+                status, error
+         FROM state_history.checkpoints
+         WHERE chain_id = $1 AND status = 'complete' AND token_s3_key IS NOT NULL
+           AND (generation, message_seq) >= ($2, $3)
+           AND (generation, message_seq) < ($4, $5)
+         ORDER BY generation DESC, message_seq DESC
+         LIMIT 1",
+    )
+    .bind(database_i64(selected.chain_id, "token anchor chain_id")?)
+    .bind(database_i64(
+        boundary.position.generation,
+        "token segment generation",
+    )?)
+    .bind(database_i64(
+        boundary.position.message_seq,
+        "token segment message_seq",
+    )?)
+    .bind(database_i64(
+        selected.position.generation,
+        "selected generation",
+    )?)
+    .bind(database_i64(
+        selected.position.message_seq,
+        "selected message_seq",
+    )?)
+    .fetch_optional(connection)
+    .await
+    .context("failed to select same-segment token fallback")?;
+    row.as_ref().map(manifest_from_row).transpose()
+}
+
+async fn range_checkpoint_pairs(
+    connection: &mut sqlx::PgConnection,
+    chain_id: u64,
+    bounds: BlockInterval,
+) -> anyhow::Result<Vec<CheckpointPair>> {
+    let rows = sqlx::query(
+        "SELECT id, chain_id, generation, message_seq, state_version, kind, block_number,
+                rfq_observed_at_ms, backends, s3_key, archive_sha256, archive_bytes,
+                compressed_bytes, token_s3_key, token_sha256, token_count, token_bytes,
+                status, error
+         FROM state_history.checkpoints
+         WHERE chain_id = $1 AND status = 'complete'
+           AND block_number BETWEEN $2 AND $3
+         ORDER BY generation, message_seq, kind",
+    )
+    .bind(database_i64(chain_id, "checkpoint pair chain_id")?)
+    .bind(database_i64(bounds.start, "checkpoint pair range start")?)
+    .bind(database_i64(
+        bounds.end_inclusive,
+        "checkpoint pair range end",
+    )?)
+    .fetch_all(connection)
+    .await
+    .context("failed to select checkpoint pair range")?;
+    let manifests = rows
+        .iter()
+        .map(manifest_from_row)
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    ensure_unique_positions(&manifests)?;
+
+    let mut pairs = Vec::new();
+    let mut previous: Option<CheckpointManifest> = None;
+    for manifest in manifests {
+        if manifest.kind == CheckpointKind::Boundary {
+            previous = Some(manifest);
+            continue;
+        }
+        if let Some(earlier) = previous.replace(manifest.clone()) {
+            pairs.push(CheckpointPair {
+                earlier,
+                target: manifest,
+            });
+        }
+    }
+    Ok(pairs)
+}
+
+async fn explicit_checkpoint_pairs(
+    connection: &mut sqlx::PgConnection,
+    chain_id: u64,
+    selections: &[ExplicitCheckpointPair],
+) -> anyhow::Result<Vec<CheckpointPair>> {
+    let mut pairs = Vec::with_capacity(selections.len());
+    for selection in selections {
+        ensure!(
+            selection.earlier_position < selection.target_position,
+            "explicit checkpoint pair must be ordered"
+        );
+        let earlier = exact_checkpoint(connection, chain_id, selection.earlier_position)
+            .await?
+            .with_context(|| {
+                format!(
+                    "missing complete checkpoint at generation {} message sequence {}",
+                    selection.earlier_position.generation, selection.earlier_position.message_seq
+                )
+            })?;
+        let target = exact_checkpoint(connection, chain_id, selection.target_position)
+            .await?
+            .with_context(|| {
+                format!(
+                    "missing complete checkpoint at generation {} message sequence {}",
+                    selection.target_position.generation, selection.target_position.message_seq
+                )
+            })?;
+        let segment_start = segment_boundary_position(connection, chain_id, target.position)
+            .await?
+            .context("target checkpoint has no complete segment boundary")?;
+        ensure!(
+            earlier.position >= segment_start,
+            "explicit checkpoint pair must stay in the same segment"
+        );
+        pairs.push(CheckpointPair { earlier, target });
+    }
+    Ok(pairs)
+}
+
+async fn exact_checkpoint(
+    connection: &mut sqlx::PgConnection,
+    chain_id: u64,
+    position: StreamPosition,
+) -> anyhow::Result<Option<CheckpointManifest>> {
+    let rows = sqlx::query(
+        "SELECT id, chain_id, generation, message_seq, state_version, kind, block_number,
+                rfq_observed_at_ms, backends, s3_key, archive_sha256, archive_bytes,
+                compressed_bytes, token_s3_key, token_sha256, token_count, token_bytes,
+                status, error
+         FROM state_history.checkpoints
+         WHERE chain_id = $1 AND status = 'complete'
+           AND generation = $2 AND message_seq = $3
+         ORDER BY kind",
+    )
+    .bind(database_i64(chain_id, "exact checkpoint chain_id")?)
+    .bind(database_i64(
+        position.generation,
+        "exact checkpoint generation",
+    )?)
+    .bind(database_i64(
+        position.message_seq,
+        "exact checkpoint message_seq",
+    )?)
+    .fetch_all(connection)
+    .await
+    .context("failed to select exact checkpoint")?;
+    ensure!(
+        rows.len() <= 1,
+        "checkpoint position is ambiguous because multiple complete kinds exist"
+    );
+    rows.first().map(manifest_from_row).transpose()
+}
+
+async fn segment_boundary_position(
+    connection: &mut sqlx::PgConnection,
+    chain_id: u64,
+    position: StreamPosition,
+) -> anyhow::Result<Option<StreamPosition>> {
+    let row = sqlx::query(
+        "SELECT generation, message_seq
+         FROM state_history.checkpoints
+         WHERE chain_id = $1 AND status = 'complete' AND kind = 'boundary'
+           AND (generation, message_seq) <= ($2, $3)
+         ORDER BY generation DESC, message_seq DESC
+         LIMIT 1",
+    )
+    .bind(database_i64(chain_id, "segment chain_id")?)
+    .bind(database_i64(position.generation, "segment generation")?)
+    .bind(database_i64(position.message_seq, "segment message_seq")?)
+    .fetch_optional(connection)
+    .await
+    .context("failed to select checkpoint segment boundary")?;
+    row.map(|row| {
+        Ok(StreamPosition {
+            generation: super::database_u64(row.try_get("generation")?, "segment generation")?,
+            message_seq: super::database_u64(row.try_get("message_seq")?, "segment message_seq")?,
+        })
+    })
+    .transpose()
+}
+
+fn ensure_unique_positions(manifests: &[CheckpointManifest]) -> anyhow::Result<()> {
+    for pair in manifests.windows(2) {
+        ensure!(
+            pair[0].position != pair[1].position,
+            "checkpoint position is ambiguous because multiple complete kinds exist"
+        );
+    }
+    Ok(())
+}

--- a/crates/state-history/src/reader/coverage.rs
+++ b/crates/state-history/src/reader/coverage.rs
@@ -1,0 +1,675 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use anyhow::Context;
+use sqlx::Row;
+
+use super::{
+    begin_range_transaction, database_backends, database_i64, database_u64, gap_from_row,
+    manifest_from_row, resolve_range_in_transaction, GapRow, RangeGap, RangeGapKind, RangeLeg,
+    RangeRequest, ReadConnectionProvider, ReadLimits, StateHistoryReader,
+};
+use crate::{Backend, BlockTimeObservation, ModelError, StreamPosition};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct BlockInterval {
+    pub start: u64,
+    pub end_inclusive: u64,
+}
+
+impl BlockInterval {
+    pub fn new(start: u64, end_inclusive: u64) -> Result<Self, ModelError> {
+        if start > end_inclusive {
+            return Err(ModelError::InvalidBlockRange {
+                start,
+                end: end_inclusive,
+            });
+        }
+        Ok(Self {
+            start,
+            end_inclusive,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CoverageQuery {
+    pub chain_id: u64,
+    pub backends: Vec<Backend>,
+    pub bounds: Option<BlockInterval>,
+}
+
+impl CoverageQuery {
+    pub fn new(
+        chain_id: u64,
+        mut backends: Vec<Backend>,
+        bounds: Option<BlockInterval>,
+    ) -> Result<Self, ModelError> {
+        if backends.is_empty() {
+            return Err(ModelError::EmptyBackends);
+        }
+        backends.sort_unstable();
+        backends.dedup();
+        Ok(Self {
+            chain_id,
+            backends,
+            bounds,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CoverageSnapshot {
+    pub visible_through_block: u64,
+    pub continuous_intervals: Vec<BlockInterval>,
+    pub known_gaps: Vec<RangeGap>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TargetPlanQuery {
+    pub chain_id: u64,
+    pub backends: Vec<Backend>,
+    pub target_blocks: BTreeSet<u64>,
+    pub limits: ReadLimits,
+}
+
+impl TargetPlanQuery {
+    pub fn new(
+        chain_id: u64,
+        mut backends: Vec<Backend>,
+        target_blocks: BTreeSet<u64>,
+        limits: ReadLimits,
+    ) -> Result<Self, ModelError> {
+        if backends.is_empty() {
+            return Err(ModelError::EmptyBackends);
+        }
+        if target_blocks.is_empty() {
+            return Err(ModelError::EmptyTargetBlocks);
+        }
+        backends.sort_unstable();
+        backends.dedup();
+        if backends.binary_search(&Backend::Rfq).is_ok()
+            && target_blocks.last().is_some_and(|block| *block == u64::MAX)
+        {
+            return Err(ModelError::RfqTargetHasNoSuccessor(u64::MAX));
+        }
+        Ok(Self {
+            chain_id,
+            backends,
+            target_blocks,
+            limits,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TargetPlan {
+    pub visible_through_block: u64,
+    pub block_times: BTreeMap<u64, BlockTimeObservation>,
+    pub legs: Vec<RangeLeg>,
+    pub gaps: Vec<RangeGap>,
+    pub lineage_invalid_intervals: Vec<BlockInterval>,
+    pub estimated_decoded_bytes: u64,
+}
+
+impl<P: ReadConnectionProvider> StateHistoryReader<P> {
+    pub async fn coverage(&self, query: &CoverageQuery) -> anyhow::Result<CoverageSnapshot> {
+        let mut connection = self
+            .connections
+            .acquire()
+            .await
+            .context("failed to acquire state history coverage connection")?;
+        let mut transaction = begin_range_transaction(&mut connection).await?;
+
+        let visible_through_block =
+            visible_through_block(&mut transaction, query.chain_id, &query.backends).await?;
+        let retained_floor =
+            earliest_compatible_checkpoint(&mut transaction, query.chain_id, &query.backends)
+                .await?
+                .context("state history has no complete checkpoint for the requested backends")?;
+        let retained_start = query
+            .bounds
+            .map_or(retained_floor, |bounds| bounds.start.max(retained_floor));
+        let requested_end = query
+            .bounds
+            .map_or(visible_through_block, |bounds| bounds.end_inclusive);
+        let interval_end = requested_end.min(visible_through_block);
+
+        let gap_rows = coverage_gap_rows(&mut transaction, query.chain_id).await?;
+        let known_gaps = gap_rows.iter().map(range_gap).collect::<Vec<_>>();
+        let mut unsafe_intervals = project_gap_intervals(
+            &mut transaction,
+            query,
+            &gap_rows,
+            retained_start,
+            interval_end,
+        )
+        .await?;
+        unsafe_intervals.extend(
+            lineage_invalid_intervals(
+                &mut transaction,
+                query.chain_id,
+                retained_start,
+                interval_end,
+            )
+            .await?,
+        );
+        let continuous_intervals = if retained_start > interval_end {
+            Vec::new()
+        } else {
+            subtract_intervals(
+                BlockInterval::new(retained_start, interval_end)?,
+                &unsafe_intervals,
+            )
+        };
+
+        transaction
+            .commit()
+            .await
+            .context("failed to commit state history coverage transaction")?;
+        Ok(CoverageSnapshot {
+            visible_through_block,
+            continuous_intervals,
+            known_gaps,
+        })
+    }
+
+    pub async fn plan_targets(&self, query: &TargetPlanQuery) -> anyhow::Result<TargetPlan> {
+        let start_block = *query
+            .target_blocks
+            .first()
+            .context("target plan has no start block")?;
+        let end_block = *query
+            .target_blocks
+            .last()
+            .context("target plan has no end block")?;
+        let includes_rfq = query.backends.binary_search(&Backend::Rfq).is_ok();
+        let mut required_blocks = query.target_blocks.clone();
+        if includes_rfq {
+            for target in &query.target_blocks {
+                required_blocks.insert(
+                    target
+                        .checked_add(1)
+                        .ok_or(ModelError::RfqTargetHasNoSuccessor(*target))?,
+                );
+            }
+        }
+
+        let mut connection = self
+            .connections
+            .acquire()
+            .await
+            .context("failed to acquire target planning connection")?;
+        let mut transaction = begin_range_transaction(&mut connection).await?;
+        let visible_through_block =
+            visible_through_block(&mut transaction, query.chain_id, &query.backends).await?;
+        let block_times =
+            required_block_times(&mut transaction, query.chain_id, &required_blocks).await?;
+        let lineage_end = required_blocks.last().copied().unwrap_or(end_block);
+        let lineage_invalid_intervals =
+            lineage_invalid_intervals(&mut transaction, query.chain_id, start_block, lineage_end)
+                .await?;
+
+        let mut range_request = RangeRequest::new(
+            query.chain_id,
+            start_block,
+            end_block,
+            query.backends.clone(),
+        )?;
+        let rfq_bounds = if includes_rfq {
+            let start_timestamp = block_times
+                .get(&start_block)
+                .context("target start block is missing its required timestamp")?
+                .timestamp_ms;
+            let end_plus_one = end_block
+                .checked_add(1)
+                .ok_or(ModelError::RfqTargetHasNoSuccessor(end_block))?;
+            let next_timestamp = block_times
+                .get(&end_plus_one)
+                .context("target end block is missing its required next-block timestamp")?
+                .timestamp_ms;
+            let end_timestamp = next_timestamp
+                .checked_sub(1)
+                .context("target next-block timestamp must be positive")?;
+            range_request = range_request.with_rfq_bounds(start_timestamp, end_timestamp)?;
+            Some((start_timestamp, end_timestamp))
+        } else {
+            None
+        };
+        let resolution = resolve_range_in_transaction(
+            &mut transaction,
+            &range_request,
+            rfq_bounds,
+            query.limits,
+        )
+        .await?;
+        transaction
+            .commit()
+            .await
+            .context("failed to commit target planning transaction")?;
+        Ok(TargetPlan {
+            visible_through_block,
+            block_times,
+            legs: resolution.plan.legs,
+            gaps: resolution.plan.gaps,
+            lineage_invalid_intervals,
+            estimated_decoded_bytes: resolution.estimated_decoded_bytes,
+        })
+    }
+}
+
+async fn required_block_times(
+    connection: &mut sqlx::PgConnection,
+    chain_id: u64,
+    required_blocks: &BTreeSet<u64>,
+) -> anyhow::Result<BTreeMap<u64, BlockTimeObservation>> {
+    let database_blocks = required_blocks
+        .iter()
+        .map(|block| database_i64(*block, "required target block"))
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    let rows = sqlx::query(
+        "SELECT block_number, timestamp_ms, block_hash, parent_hash
+         FROM state_history.block_times
+         WHERE chain_id = $1 AND block_number = ANY($2::bigint[])
+         ORDER BY block_number",
+    )
+    .bind(database_i64(chain_id, "target plan chain_id")?)
+    .bind(database_blocks)
+    .fetch_all(connection)
+    .await
+    .context("failed to select target block times")?;
+    let mut observations = BTreeMap::new();
+    for row in rows {
+        let observation = BlockTimeObservation {
+            block_number: database_u64(row.try_get("block_number")?, "target block number")?,
+            timestamp_ms: database_u64(row.try_get("timestamp_ms")?, "target timestamp")?,
+            block_hash: row.try_get("block_hash")?,
+            parent_hash: row.try_get("parent_hash")?,
+        };
+        observations.insert(observation.block_number, observation);
+    }
+    let missing = required_blocks
+        .iter()
+        .filter(|block| !observations.contains_key(block))
+        .copied()
+        .collect::<Vec<_>>();
+    if !missing.is_empty() {
+        anyhow::bail!("missing required block_times rows for blocks {missing:?}");
+    }
+    Ok(observations)
+}
+
+pub(super) async fn visible_through_block(
+    connection: &mut sqlx::PgConnection,
+    chain_id: u64,
+    backends: &[Backend],
+) -> anyhow::Result<u64> {
+    let mut cutoffs = Vec::with_capacity(backends.len());
+    for backend in backends {
+        let cutoff = match backend {
+            Backend::Native | Backend::Vm => {
+                let checkpoint: Option<i64> = sqlx::query_scalar(
+                    "SELECT max(block_number)
+                     FROM state_history.checkpoints
+                     WHERE chain_id = $1 AND status = 'complete' AND $2 = ANY(backends)",
+                )
+                .bind(database_i64(chain_id, "coverage chain_id")?)
+                .bind(backend.as_str())
+                .fetch_one(&mut *connection)
+                .await?;
+                let delta: Option<i64> = sqlx::query_scalar(
+                    "SELECT max(block_number)
+                     FROM state_history.delta_backends
+                     WHERE chain_id = $1 AND backend = $2",
+                )
+                .bind(database_i64(chain_id, "coverage chain_id")?)
+                .bind(backend.as_str())
+                .fetch_one(&mut *connection)
+                .await?;
+                checkpoint
+                    .into_iter()
+                    .chain(delta)
+                    .max()
+                    .map(|value| database_u64(value, "coverage backend cutoff"))
+                    .transpose()?
+            }
+            Backend::Rfq => {
+                let has_anchor: bool = sqlx::query_scalar(
+                    "SELECT EXISTS (
+                        SELECT 1 FROM state_history.checkpoints
+                        WHERE chain_id = $1 AND status = 'complete' AND 'rfq' = ANY(backends)
+                    )",
+                )
+                .bind(database_i64(chain_id, "coverage chain_id")?)
+                .fetch_one(&mut *connection)
+                .await?;
+                if !has_anchor {
+                    None
+                } else {
+                    let block: Option<i64> = sqlx::query_scalar(
+                        "SELECT max(block_number) - 1
+                         FROM state_history.block_times
+                         WHERE chain_id = $1",
+                    )
+                    .bind(database_i64(chain_id, "coverage chain_id")?)
+                    .fetch_one(&mut *connection)
+                    .await?;
+                    block
+                        .map(|value| database_u64(value, "coverage RFQ cutoff"))
+                        .transpose()?
+                }
+            }
+        };
+        cutoffs.push(cutoff.with_context(|| {
+            format!("state history has no visible {} cutoff", backend.as_str())
+        })?);
+    }
+    cutoffs
+        .into_iter()
+        .min()
+        .context("coverage backend set is empty")
+}
+
+async fn earliest_compatible_checkpoint(
+    connection: &mut sqlx::PgConnection,
+    chain_id: u64,
+    backends: &[Backend],
+) -> anyhow::Result<Option<u64>> {
+    let value: Option<i64> = sqlx::query_scalar(
+        "SELECT min(block_number)
+         FROM state_history.checkpoints
+         WHERE chain_id = $1 AND status = 'complete' AND backends @> $2::text[]",
+    )
+    .bind(database_i64(chain_id, "coverage chain_id")?)
+    .bind(database_backends(backends))
+    .fetch_one(connection)
+    .await?;
+    value
+        .map(|value| database_u64(value, "coverage retained start"))
+        .transpose()
+}
+
+async fn coverage_gap_rows(
+    connection: &mut sqlx::PgConnection,
+    chain_id: u64,
+) -> anyhow::Result<Vec<GapRow>> {
+    let rows = sqlx::query(
+        "SELECT generation, from_message_seq, to_message_seq, reason,
+                from_block_number, to_block_number, from_observed_at_ms, to_observed_at_ms
+         FROM state_history.gaps
+         WHERE chain_id = $1
+         ORDER BY generation, from_message_seq, to_message_seq, id",
+    )
+    .bind(database_i64(chain_id, "coverage chain_id")?)
+    .fetch_all(connection)
+    .await?;
+    rows.iter().map(gap_from_row).collect()
+}
+
+fn range_gap(gap: &GapRow) -> RangeGap {
+    RangeGap {
+        kind: RangeGapKind::Recorded,
+        generation: Some(gap.generation),
+        from_message_seq: Some(gap.from_message_seq),
+        to_message_seq: Some(gap.to_message_seq),
+        from_position: Some(StreamPosition {
+            generation: gap.generation,
+            message_seq: gap.from_message_seq,
+        }),
+        to_position: Some(StreamPosition {
+            generation: gap.generation,
+            message_seq: gap.to_message_seq,
+        }),
+        from_block: gap.from_block_number,
+        to_block_inclusive: gap.to_block_number,
+        from_observed_at_ms: gap.from_observed_at_ms,
+        to_observed_at_ms: gap.to_observed_at_ms,
+        reason: gap.reason.clone(),
+    }
+}
+
+async fn project_gap_intervals(
+    connection: &mut sqlx::PgConnection,
+    query: &CoverageQuery,
+    gaps: &[GapRow],
+    start: u64,
+    end: u64,
+) -> anyhow::Result<Vec<BlockInterval>> {
+    let mut projected = Vec::new();
+    for gap in gaps {
+        let includes_block_backend = query
+            .backends
+            .iter()
+            .any(|backend| matches!(backend, Backend::Native | Backend::Vm));
+        let includes_rfq = query.backends.binary_search(&Backend::Rfq).is_ok();
+        let no_bounds = gap.from_block_number.is_none()
+            && gap.to_block_number.is_none()
+            && gap.from_observed_at_ms.is_none()
+            && gap.to_observed_at_ms.is_none();
+        let mut needs_conservative_projection = no_bounds;
+
+        if includes_block_backend {
+            match (gap.from_block_number, gap.to_block_number) {
+                (Some(from), Some(to)) => push_clipped(&mut projected, from, to, start, end)?,
+                (None, None) => {}
+                _ => needs_conservative_projection = true,
+            }
+        }
+        if includes_rfq {
+            match (gap.from_observed_at_ms, gap.to_observed_at_ms) {
+                (Some(from), Some(to)) => {
+                    if let Some(interval) =
+                        rfq_time_gap_to_blocks(connection, query.chain_id, from, to).await?
+                    {
+                        push_clipped(
+                            &mut projected,
+                            interval.start,
+                            interval.end_inclusive,
+                            start,
+                            end,
+                        )?;
+                    }
+                }
+                (None, None) => {}
+                _ => needs_conservative_projection = true,
+            }
+        }
+        if needs_conservative_projection {
+            let (prior, next) = surrounding_boundaries(connection, query, gap).await?;
+            let unsafe_start = prior.unwrap_or(start).max(start);
+            let unsafe_end = next.map_or(end, |block| block.saturating_sub(1)).min(end);
+            if unsafe_start <= unsafe_end {
+                projected.push(BlockInterval::new(unsafe_start, unsafe_end)?);
+            }
+        }
+    }
+    Ok(projected)
+}
+
+async fn surrounding_boundaries(
+    connection: &mut sqlx::PgConnection,
+    query: &CoverageQuery,
+    gap: &GapRow,
+) -> anyhow::Result<(Option<u64>, Option<u64>)> {
+    let rows = sqlx::query(
+        "SELECT id, chain_id, generation, message_seq, state_version, kind, block_number,
+                rfq_observed_at_ms, backends, s3_key, archive_sha256, archive_bytes,
+                compressed_bytes, token_s3_key, token_sha256, token_count, token_bytes,
+                status, error
+         FROM state_history.checkpoints
+         WHERE chain_id = $1 AND status = 'complete' AND kind = 'boundary'
+           AND backends @> $2::text[]
+         ORDER BY generation, message_seq",
+    )
+    .bind(database_i64(query.chain_id, "coverage chain_id")?)
+    .bind(database_backends(&query.backends))
+    .fetch_all(connection)
+    .await?;
+    let from_position = StreamPosition {
+        generation: gap.generation,
+        message_seq: gap.from_message_seq,
+    };
+    let to_position = StreamPosition {
+        generation: gap.generation,
+        message_seq: gap.to_message_seq,
+    };
+    let manifests = rows
+        .iter()
+        .map(manifest_from_row)
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    let prior = manifests
+        .iter()
+        .filter(|manifest| manifest.position < from_position)
+        .map(|manifest| manifest.block_number)
+        .next_back();
+    let next = manifests
+        .iter()
+        .find(|manifest| manifest.position > to_position)
+        .map(|manifest| manifest.block_number);
+    Ok((prior, next))
+}
+
+async fn rfq_time_gap_to_blocks(
+    connection: &mut sqlx::PgConnection,
+    chain_id: u64,
+    from_ms: u64,
+    to_ms: u64,
+) -> anyhow::Result<Option<BlockInterval>> {
+    let row: (Option<i64>, Option<i64>) = sqlx::query_as(
+        "SELECT min(current.block_number), max(current.block_number)
+         FROM state_history.block_times current
+         JOIN state_history.block_times next
+           ON next.chain_id = current.chain_id AND next.block_number = current.block_number + 1
+         WHERE current.chain_id = $1
+           AND next.timestamp_ms > $2
+           AND current.timestamp_ms <= $3",
+    )
+    .bind(database_i64(chain_id, "coverage chain_id")?)
+    .bind(database_i64(from_ms, "coverage RFQ gap start")?)
+    .bind(database_i64(to_ms, "coverage RFQ gap end")?)
+    .fetch_one(connection)
+    .await?;
+    match row {
+        (Some(start), Some(end)) => Ok(Some(BlockInterval::new(
+            database_u64(start, "coverage RFQ gap block start")?,
+            database_u64(end, "coverage RFQ gap block end")?,
+        )?)),
+        (None, None) => Ok(None),
+        _ => anyhow::bail!("RFQ gap projection returned incomplete bounds"),
+    }
+}
+
+pub(super) async fn lineage_invalid_intervals(
+    connection: &mut sqlx::PgConnection,
+    chain_id: u64,
+    start: u64,
+    end: u64,
+) -> anyhow::Result<Vec<BlockInterval>> {
+    if start > end {
+        return Ok(Vec::new());
+    }
+    let rows = sqlx::query(
+        "SELECT block_number, block_hash, parent_hash
+         FROM state_history.block_times
+         WHERE chain_id = $1 AND block_number BETWEEN $2 AND $3
+         ORDER BY block_number",
+    )
+    .bind(database_i64(chain_id, "lineage chain_id")?)
+    .bind(database_i64(start, "lineage start")?)
+    .bind(database_i64(end, "lineage end")?)
+    .fetch_all(connection)
+    .await?;
+    let mut invalid = Vec::new();
+    let mut previous: Option<(u64, String)> = None;
+    let mut expected_block = start;
+    for row in rows {
+        let block = database_u64(row.try_get("block_number")?, "lineage block")?;
+        let hash: Option<String> = row.try_get("block_hash")?;
+        let parent: Option<String> = row.try_get("parent_hash")?;
+        let had_missing_predecessor = block > expected_block;
+        if had_missing_predecessor {
+            invalid.push(BlockInterval::new(expected_block, block - 1)?);
+            previous = None;
+        }
+        let is_invalid = match (&previous, hash.as_ref(), parent.as_ref()) {
+            (_, None, _) | (_, _, None) => true,
+            (Some((previous_block, previous_hash)), Some(_), Some(parent_hash)) => {
+                block != previous_block.saturating_add(1) || parent_hash != previous_hash
+            }
+            (None, Some(_), Some(_)) => block != start || had_missing_predecessor,
+        };
+        if is_invalid {
+            invalid.push(BlockInterval::new(block, block)?);
+        }
+        if let Some(hash) = hash {
+            previous = Some((block, hash));
+        }
+        expected_block = block.saturating_add(1);
+    }
+    if expected_block <= end {
+        invalid.push(BlockInterval::new(expected_block, end)?);
+    }
+    Ok(merge_intervals(invalid))
+}
+
+fn push_clipped(
+    intervals: &mut Vec<BlockInterval>,
+    from: u64,
+    to: u64,
+    start: u64,
+    end: u64,
+) -> anyhow::Result<()> {
+    let clipped_start = from.max(start);
+    let clipped_end = to.min(end);
+    if clipped_start <= clipped_end {
+        intervals.push(BlockInterval::new(clipped_start, clipped_end)?);
+    }
+    Ok(())
+}
+
+pub(super) fn subtract_intervals(
+    base: BlockInterval,
+    unsafe_intervals: &[BlockInterval],
+) -> Vec<BlockInterval> {
+    let unsafe_intervals = merge_intervals(unsafe_intervals.to_vec());
+    let mut safe = Vec::new();
+    let mut cursor = base.start;
+    for interval in unsafe_intervals {
+        if interval.end_inclusive < base.start || interval.start > base.end_inclusive {
+            continue;
+        }
+        let start = interval.start.max(base.start);
+        let end = interval.end_inclusive.min(base.end_inclusive);
+        if cursor < start {
+            safe.push(BlockInterval {
+                start: cursor,
+                end_inclusive: start - 1,
+            });
+        }
+        cursor = cursor.max(end.saturating_add(1));
+        if cursor > base.end_inclusive {
+            break;
+        }
+    }
+    if cursor <= base.end_inclusive {
+        safe.push(BlockInterval {
+            start: cursor,
+            end_inclusive: base.end_inclusive,
+        });
+    }
+    safe
+}
+
+fn merge_intervals(mut intervals: Vec<BlockInterval>) -> Vec<BlockInterval> {
+    intervals.sort_unstable();
+    let mut merged: Vec<BlockInterval> = Vec::new();
+    for interval in intervals {
+        if let Some(last) = merged.last_mut() {
+            if interval.start <= last.end_inclusive.saturating_add(1) {
+                last.end_inclusive = last.end_inclusive.max(interval.end_inclusive);
+                continue;
+            }
+        }
+        merged.push(interval);
+    }
+    merged
+}

--- a/crates/state-history/src/reader/limits.rs
+++ b/crates/state-history/src/reader/limits.rs
@@ -1,0 +1,269 @@
+use std::io::Read;
+
+use anyhow::Context;
+use simulator_core::broadcaster::BroadcasterTokenDto;
+
+use super::{ReadConnectionProvider, StateHistoryReader};
+use crate::{
+    archive::decode_archive_with_info_and_limit,
+    tokens::decode_token_snapshot_raw_with_info_and_limit, CheckpointArchive, CheckpointManifest,
+    CheckpointStatus, RawTokenSnapshot, TokenSnapshotRef,
+};
+
+macro_rules! read_ensure {
+    ($condition:expr, $($argument:tt)*) => {
+        if !$condition {
+            return Err(ReadLimitError::Read(anyhow::anyhow!($($argument)*)));
+        }
+    };
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReadLimits {
+    pub max_compressed_bytes: u64,
+    pub max_decoded_bytes: u64,
+}
+
+impl ReadLimits {
+    pub fn new(max_compressed_bytes: u64, max_decoded_bytes: u64) -> Result<Self, ReadLimitError> {
+        if max_compressed_bytes == 0 || max_decoded_bytes == 0 {
+            return Err(ReadLimitError::ZeroLimit);
+        }
+        Ok(Self {
+            max_compressed_bytes,
+            max_decoded_bytes,
+        })
+    }
+
+    pub const fn unbounded() -> Self {
+        Self {
+            max_compressed_bytes: u64::MAX,
+            max_decoded_bytes: u64::MAX,
+        }
+    }
+
+    pub(crate) fn check_compressed(self, declared: u64) -> Result<(), ReadLimitError> {
+        if declared > self.max_compressed_bytes {
+            return Err(ReadLimitError::CompressedBytesExceeded {
+                declared,
+                limit: self.max_compressed_bytes,
+            });
+        }
+        Ok(())
+    }
+
+    pub(crate) fn check_decoded(self, declared: u64) -> Result<(), ReadLimitError> {
+        if declared > self.max_decoded_bytes {
+            return Err(ReadLimitError::DecodedBytesExceeded {
+                declared,
+                limit: self.max_decoded_bytes,
+            });
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ReadLimitError {
+    #[error("read limits must be positive")]
+    ZeroLimit,
+    #[error("compressed bytes {declared} exceed limit {limit}")]
+    CompressedBytesExceeded { declared: u64, limit: u64 },
+    #[error("decoded bytes {declared} exceed limit {limit}")]
+    DecodedBytesExceeded { declared: u64, limit: u64 },
+    #[error(transparent)]
+    Read(#[from] anyhow::Error),
+}
+
+pub(crate) fn decode_zstd_with_limit(
+    compressed: &[u8],
+    max_decoded_bytes: u64,
+    object_name: &'static str,
+) -> Result<Vec<u8>, ReadLimitError> {
+    let decoder = zstd::stream::read::Decoder::new(compressed)
+        .with_context(|| format!("failed to create {object_name} decoder"))?;
+    let read_limit = max_decoded_bytes.saturating_add(1);
+    let mut limited = decoder.take(read_limit);
+    let mut decoded = Vec::new();
+    limited
+        .read_to_end(&mut decoded)
+        .with_context(|| format!("failed to decompress {object_name}"))?;
+    let decoded_bytes = u64::try_from(decoded.len()).context("decoded byte length exceeds u64")?;
+    if decoded_bytes > max_decoded_bytes {
+        return Err(ReadLimitError::DecodedBytesExceeded {
+            declared: decoded_bytes,
+            limit: max_decoded_bytes,
+        });
+    }
+    Ok(decoded)
+}
+
+impl<P: ReadConnectionProvider> StateHistoryReader<P> {
+    pub async fn fetch_checkpoint_with_limit(
+        &self,
+        manifest: &CheckpointManifest,
+        limits: ReadLimits,
+    ) -> Result<CheckpointArchive, ReadLimitError> {
+        read_ensure!(
+            manifest.status == CheckpointStatus::Complete,
+            "checkpoint manifest {} is not complete",
+            manifest.id
+        );
+        let key = manifest
+            .s3_key
+            .as_deref()
+            .context("complete checkpoint manifest is missing its S3 key")?;
+        let expected_sha256 = manifest
+            .archive_sha256
+            .as_deref()
+            .context("complete checkpoint manifest is missing its archive sha256")?;
+        let expected_archive_bytes = manifest
+            .archive_bytes
+            .context("complete checkpoint manifest is missing its archive byte length")?;
+        let expected_compressed_bytes = manifest
+            .compressed_bytes
+            .context("complete checkpoint manifest is missing its compressed byte length")?;
+        limits.check_compressed(expected_compressed_bytes)?;
+        limits.check_decoded(expected_archive_bytes)?;
+
+        let expected_key =
+            self.objects
+                .key_for(manifest.chain_id, manifest.position, manifest.kind);
+        read_ensure!(
+            key == expected_key,
+            "checkpoint manifest {} object key mismatch: expected {expected_key}, got {key}",
+            manifest.id
+        );
+        let bytes = self
+            .objects
+            .fetch_with_limit(key, limits.max_compressed_bytes)
+            .await?;
+        let decoded =
+            decode_archive_with_info_and_limit(&bytes, expected_sha256, limits.max_decoded_bytes)?;
+        read_ensure!(
+            decoded.archive_bytes == expected_archive_bytes,
+            "checkpoint manifest {} archive length mismatch: expected {expected_archive_bytes}, got {}",
+            manifest.id,
+            decoded.archive_bytes
+        );
+        read_ensure!(
+            decoded.compressed_bytes == expected_compressed_bytes,
+            "checkpoint manifest {} compressed length mismatch: expected {expected_compressed_bytes}, got {}",
+            manifest.id,
+            decoded.compressed_bytes
+        );
+        let metadata = &decoded.archive.metadata;
+        read_ensure!(
+            metadata.chain_id == manifest.chain_id
+                && metadata.position == manifest.position
+                && metadata.state_version == manifest.state_version
+                && metadata.kind == manifest.kind
+                && metadata.block_number == manifest.block_number
+                && metadata.rfq_observed_at_ms == manifest.rfq_observed_at_ms
+                && metadata.backends == manifest.backends,
+            "checkpoint manifest {} metadata does not match its archive",
+            manifest.id
+        );
+        read_ensure!(
+            !decoded.archive.payloads_json.is_empty(),
+            "checkpoint manifest {} archive contains no payloads",
+            manifest.id
+        );
+        Ok(decoded.archive)
+    }
+
+    pub async fn fetch_checkpoint_token_snapshot_with_limit(
+        &self,
+        manifest: &CheckpointManifest,
+        limits: ReadLimits,
+    ) -> Result<Option<RawTokenSnapshot>, ReadLimitError> {
+        read_ensure!(
+            manifest.status == CheckpointStatus::Complete,
+            "checkpoint manifest {} is not complete",
+            manifest.id
+        );
+        let Some(reference) = manifest.token_reference.as_ref() else {
+            return Ok(None);
+        };
+        let expected_key = self
+            .objects
+            .token_key_for(manifest.chain_id, &reference.sha256);
+        read_ensure!(
+            reference.s3_key == expected_key,
+            "checkpoint manifest {} token object key mismatch: expected {expected_key}, got {}",
+            manifest.id,
+            reference.s3_key
+        );
+        let snapshot = self
+            .fetch_token_snapshot_with_limit(reference, limits)
+            .await?;
+        read_ensure!(
+            snapshot.chain_id == manifest.chain_id,
+            "checkpoint manifest {} token chain mismatch: expected {}, got {}",
+            manifest.id,
+            manifest.chain_id,
+            snapshot.chain_id
+        );
+        Ok(Some(snapshot))
+    }
+
+    pub async fn fetch_token_snapshot_with_limit(
+        &self,
+        reference: &TokenSnapshotRef,
+        limits: ReadLimits,
+    ) -> Result<RawTokenSnapshot, ReadLimitError> {
+        limits.check_decoded(reference.token_bytes)?;
+        let bytes = self
+            .objects
+            .fetch_with_limit(&reference.s3_key, limits.max_compressed_bytes)
+            .await
+            .with_context(|| format!("failed to fetch token snapshot {}", reference.s3_key))?;
+        let decoded = decode_token_snapshot_raw_with_info_and_limit(
+            &bytes,
+            &reference.sha256,
+            limits.max_decoded_bytes,
+        )?;
+        let expected_key = self
+            .objects
+            .token_key_for(decoded.snapshot.chain_id, &reference.sha256);
+        read_ensure!(
+            reference.s3_key == expected_key,
+            "token snapshot object key mismatch: expected {expected_key}, got {}",
+            reference.s3_key
+        );
+        read_ensure!(
+            decoded.token_bytes == reference.token_bytes,
+            "token snapshot byte length mismatch: expected {}, got {}",
+            reference.token_bytes,
+            decoded.token_bytes
+        );
+        read_ensure!(
+            decoded.snapshot.token_count == reference.token_count,
+            "token snapshot count mismatch: expected {}, got {}",
+            reference.token_count,
+            decoded.snapshot.token_count
+        );
+        let tokens: Vec<BroadcasterTokenDto> = serde_json::from_str(decoded.snapshot.tokens.get())
+            .context("failed to parse token snapshot token array")?;
+        let actual_token_count =
+            u64::try_from(tokens.len()).context("token snapshot token count exceeds u64")?;
+        read_ensure!(
+            actual_token_count == decoded.snapshot.token_count,
+            "token snapshot envelope count mismatch: expected {}, got {actual_token_count}",
+            decoded.snapshot.token_count
+        );
+        read_ensure!(
+            tokens
+                .iter()
+                .all(|token| token.chain_id == decoded.snapshot.chain_id),
+            "token snapshot contains a token from a different chain"
+        );
+        read_ensure!(
+            tokens
+                .windows(2)
+                .all(|pair| pair[0].address < pair[1].address),
+            "token snapshot addresses are not strictly sorted and unique"
+        );
+        Ok(decoded.snapshot)
+    }
+}

--- a/crates/state-history/src/store.rs
+++ b/crates/state-history/src/store.rs
@@ -6,7 +6,10 @@ use sqlx::{migrate::Migrator, Connection, Postgres, Transaction};
 
 use crate::{
     BlockTimeObservation, CapturedState, DeltaEntry, GapRecord, StreamPosition, TokenSnapshotRef,
+    DELTA_PAYLOAD_FORMAT_VERSION,
 };
+
+pub const STATE_HISTORY_SCHEMA_VERSION: i32 = 2;
 
 const BLOCK_TIME_UPSERT: &str = r#"
     INSERT INTO state_history.block_times AS bt (chain_id, block_number, timestamp_ms, block_hash,
@@ -60,8 +63,8 @@ impl StateHistoryStore {
             .await
             .context("failed to read state history schema version")?;
         ensure!(
-            version == 1,
-            "unsupported state history schema version {version}; expected 1"
+            version == STATE_HISTORY_SCHEMA_VERSION,
+            "unsupported state history schema version {version}; expected {STATE_HISTORY_SCHEMA_VERSION}"
         );
 
         for table in [
@@ -292,8 +295,9 @@ impl StateHistoryStore {
 
         let inserted_id: Option<i64> = sqlx::query_scalar(
             "INSERT INTO state_history.deltas
-                (chain_id, generation, message_seq, block_number, observed_at_ms, payload, payload_sha256)
-             VALUES ($1, $2, $3, $4, $5, $6, $7)
+                (chain_id, generation, message_seq, block_number, observed_at_ms, payload,
+                 payload_sha256, payload_format_version)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
              ON CONFLICT (chain_id, generation, message_seq) DO NOTHING
              RETURNING id",
         )
@@ -304,6 +308,7 @@ impl StateHistoryStore {
         .bind(observed_at_ms)
         .bind(payload)
         .bind(&payload_sha256)
+        .bind(DELTA_PAYLOAD_FORMAT_VERSION)
         .fetch_optional(&mut *conn)
         .await
         .context("failed to insert state history delta")?;
@@ -311,24 +316,15 @@ impl StateHistoryStore {
         let (delta_id, outcome) = if let Some(id) = inserted_id {
             (id, DeltaInsertOutcome::Inserted(id))
         } else {
-            let (id, stored_sha256): (i64, String) = sqlx::query_as(
-                "SELECT id, payload_sha256
-                 FROM state_history.deltas
-                 WHERE chain_id = $1 AND generation = $2 AND message_seq = $3",
+            let id = validate_existing_delta(
+                conn,
+                delta,
+                chain_id,
+                generation,
+                message_seq,
+                &payload_sha256,
             )
-            .bind(chain_id)
-            .bind(generation)
-            .bind(message_seq)
-            .fetch_one(&mut *conn)
-            .await
-            .context("failed to read conflicting state history delta")?;
-            ensure!(
-                stored_sha256 == payload_sha256,
-                "delta content drift at chain_id={}, generation={}, message_seq={}",
-                delta.chain_id(),
-                position.generation,
-                position.message_seq
-            );
+            .await?;
             (id, DeltaInsertOutcome::Duplicate)
         };
 
@@ -678,6 +674,45 @@ pub struct EncodedArchiveInfo {
     pub compressed_bytes: u64,
 }
 
+async fn validate_existing_delta(
+    connection: &mut sqlx::PgConnection,
+    delta: &DeltaEntry,
+    chain_id: i64,
+    generation: i64,
+    message_seq: i64,
+    payload_sha256: &str,
+) -> anyhow::Result<i64> {
+    let (id, stored_sha256, stored_format): (i64, String, i16) = sqlx::query_as(
+        "SELECT id, payload_sha256, payload_format_version
+         FROM state_history.deltas
+         WHERE chain_id = $1 AND generation = $2 AND message_seq = $3",
+    )
+    .bind(chain_id)
+    .bind(generation)
+    .bind(message_seq)
+    .fetch_one(connection)
+    .await
+    .context("failed to read conflicting state history delta")?;
+    let position = delta.position();
+    ensure!(
+        stored_sha256 == payload_sha256,
+        "delta content drift at chain_id={}, generation={}, message_seq={}",
+        delta.chain_id(),
+        position.generation,
+        position.message_seq
+    );
+    ensure!(
+        stored_format == DELTA_PAYLOAD_FORMAT_VERSION,
+        "delta format drift at chain_id={}, generation={}, message_seq={}: stored {}, writer {}",
+        delta.chain_id(),
+        position.generation,
+        position.message_seq,
+        stored_format,
+        DELTA_PAYLOAD_FORMAT_VERSION
+    );
+    Ok(id)
+}
+
 async fn upsert_block_times(
     conn: &mut sqlx::PgConnection,
     chain_id: u64,
@@ -726,18 +761,23 @@ mod tests {
     };
 
     #[test]
-    fn embedded_migration_catalog_matches_schema_version_one() {
+    fn embedded_migration_catalog_keeps_initial_migration_and_adds_schema_version_two() {
         let migrations = STATE_HISTORY_MIGRATOR
             .iter()
             .filter(|migration| migration.migration_type.is_up_migration())
             .collect::<Vec<_>>();
 
-        assert_eq!(migrations.len(), 1);
+        assert_eq!(migrations.len(), 2);
         assert_eq!(migrations[0].version, 20_260_728_000_100);
         assert_eq!(migrations[0].description, "create state history");
         assert_eq!(
             hex::encode(migrations[0].checksum.as_ref()),
             "7e6f16f9c3faa11685000d13138297e01c39d192d239ac149edf24bfb51826300e6535b6e655398461e03171c6308884"
+        );
+        assert_eq!(migrations[1].version, 20_260_813_000_100);
+        assert_eq!(
+            migrations[1].description,
+            "add delta payload format version"
         );
     }
 

--- a/crates/state-history/src/tokens.rs
+++ b/crates/state-history/src/tokens.rs
@@ -5,6 +5,8 @@ use serde_json::value::RawValue;
 use sha2::{Digest, Sha256};
 use simulator_core::broadcaster::BroadcasterTokenDto;
 
+use crate::reader::{decode_zstd_with_limit, ReadLimitError};
+
 pub const TOKEN_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
 const ZSTD_COMPRESSION_LEVEL: i32 = 3;
 
@@ -169,6 +171,24 @@ pub(crate) fn decode_token_snapshot_raw_with_info(
     })
 }
 
+pub(crate) fn decode_token_snapshot_raw_with_info_and_limit(
+    bytes: &[u8],
+    expected_sha256: &str,
+    max_decoded_bytes: u64,
+) -> Result<DecodedRawTokenSnapshot, ReadLimitError> {
+    let snapshot_json =
+        decode_verified_token_snapshot_bytes_with_limit(bytes, expected_sha256, max_decoded_bytes)?;
+    let snapshot: RawTokenSnapshot =
+        serde_json::from_slice(&snapshot_json).context("failed to parse token snapshot")?;
+    validate_schema_version(&snapshot)?;
+
+    Ok(DecodedRawTokenSnapshot {
+        snapshot,
+        token_bytes: u64::try_from(snapshot_json.len())
+            .context("token snapshot length exceeds u64")?,
+    })
+}
+
 fn decode_verified_token_snapshot<T>(bytes: &[u8], expected_sha256: &str) -> anyhow::Result<T>
 where
     T: DeserializeOwned + DecodedTokenSnapshot,
@@ -176,8 +196,7 @@ where
     let snapshot_json = decode_verified_token_snapshot_bytes(bytes, expected_sha256)?;
     let envelope: T =
         serde_json::from_slice(&snapshot_json).context("failed to parse token snapshot")?;
-    validate_schema_version(&envelope)?;
-    Ok(envelope)
+    decode_token_snapshot_version(envelope)
 }
 
 fn decode_verified_token_snapshot_bytes(
@@ -194,19 +213,49 @@ fn decode_verified_token_snapshot_bytes(
         }
         .into());
     }
+    Ok(snapshot_json)
+}
+
+fn decode_verified_token_snapshot_bytes_with_limit(
+    bytes: &[u8],
+    expected_sha256: &str,
+    max_decoded_bytes: u64,
+) -> Result<Vec<u8>, ReadLimitError> {
+    let snapshot_json = decode_zstd_with_limit(bytes, max_decoded_bytes, "token snapshot")?;
+    let actual_sha256 = hex::encode(Sha256::digest(&snapshot_json));
+    if actual_sha256 != expected_sha256 {
+        return Err(ReadLimitError::Read(
+            TokenSnapshotCodecError::Sha256Mismatch {
+                expected: expected_sha256.to_owned(),
+                actual: actual_sha256,
+            }
+            .into(),
+        ));
+    }
 
     Ok(snapshot_json)
 }
 
 fn validate_schema_version<T: DecodedTokenSnapshot>(envelope: &T) -> anyhow::Result<()> {
-    if envelope.schema_version() != TOKEN_SNAPSHOT_SCHEMA_VERSION {
-        return Err(TokenSnapshotCodecError::UnsupportedSchemaVersion {
-            found: envelope.schema_version(),
+    match envelope.schema_version() {
+        TOKEN_SNAPSHOT_SCHEMA_VERSION => Ok(()),
+        found => Err(TokenSnapshotCodecError::UnsupportedSchemaVersion {
+            found,
             expected: TOKEN_SNAPSHOT_SCHEMA_VERSION,
         }
-        .into());
+        .into()),
     }
-    Ok(())
+}
+
+fn decode_token_snapshot_version<T: DecodedTokenSnapshot>(envelope: T) -> anyhow::Result<T> {
+    match envelope.schema_version() {
+        TOKEN_SNAPSHOT_SCHEMA_VERSION => Ok(envelope),
+        found => Err(TokenSnapshotCodecError::UnsupportedSchemaVersion {
+            found,
+            expected: TOKEN_SNAPSHOT_SCHEMA_VERSION,
+        }
+        .into()),
+    }
 }
 
 pub fn token_snapshot_s3_key(prefix: &str, chain_id: u64, sha256: &str) -> String {

--- a/crates/state-history/tests/history_reads.rs
+++ b/crates/state-history/tests/history_reads.rs
@@ -1,0 +1,563 @@
+use std::collections::BTreeSet;
+
+use anyhow::Context;
+use serde_json::value::RawValue;
+use sha2::Digest;
+use sqlx::PgPool;
+use state_history::{
+    Backend, BlockInterval, CheckpointKind, CheckpointManifest, CheckpointPairQuery,
+    CheckpointPairSelection, CheckpointStatus, CoverageQuery, ExplicitCheckpointPair,
+    ReadLimitError, ReadLimits, StateHistoryReader, StreamPosition, TargetPlanQuery, TokenAnchor,
+};
+
+const CHAIN_ID: u64 = 8453;
+
+#[sqlx::test(migrations = "./migrations")]
+#[ignore = "requires the state-history integration PostgreSQL"]
+async fn existing_delta_rows_are_format_one(pool: PgPool) -> anyhow::Result<()> {
+    sqlx::query(
+        "INSERT INTO state_history.deltas
+            (chain_id, generation, message_seq, block_number, observed_at_ms, payload, payload_sha256)
+         VALUES ($1, 1, 1, 100, 100000, $2, $3)",
+    )
+    .bind(database_i64(CHAIN_ID)?)
+    .bind(zstd::stream::encode_all(br#"{}"#.as_slice(), 3)?)
+    .bind(hex::encode(sha2::Sha256::digest(br#"{}"#)))
+    .execute(&pool)
+    .await?;
+
+    let (schema_version, payload_format_version): (i32, i16) = sqlx::query_as(
+        "SELECT
+            (SELECT version FROM state_history.schema_meta),
+            (SELECT payload_format_version FROM state_history.deltas LIMIT 1)",
+    )
+    .fetch_one(&pool)
+    .await?;
+
+    assert_eq!(schema_version, 2);
+    assert_eq!(payload_format_version, 1);
+    Ok(())
+}
+
+#[sqlx::test(migrations = "./migrations")]
+#[ignore = "requires the state-history integration PostgreSQL"]
+async fn coverage_splits_on_gap_and_reports_cutoff(pool: PgPool) -> anyhow::Result<()> {
+    seed_block_times(&pool, 100, 121).await?;
+    seed_checkpoint(&pool, 1, 0, 100, CheckpointKind::Boundary, true).await?;
+    seed_delta(&pool, 1, 1, 120, 1, &[Backend::Native]).await?;
+    seed_gap(&pool, 1, 2, 3, Some((108, 110)), None).await?;
+
+    let reader = StateHistoryReader::new(pool, object_store().await);
+    let snapshot = reader
+        .coverage(&CoverageQuery::new(
+            CHAIN_ID,
+            vec![Backend::Native],
+            Some(BlockInterval::new(100, 120)?),
+        )?)
+        .await?;
+
+    assert_eq!(snapshot.visible_through_block, 120);
+    assert_eq!(
+        snapshot.continuous_intervals,
+        vec![BlockInterval::new(100, 107)?, BlockInterval::new(111, 120)?]
+    );
+    assert_eq!(snapshot.known_gaps.len(), 1);
+    assert_eq!(snapshot.known_gaps[0].from_block, Some(108));
+    assert_eq!(snapshot.known_gaps[0].to_block_inclusive, Some(110));
+    assert_eq!(snapshot.known_gaps[0].from_position, Some(position(1, 2)));
+    assert_eq!(snapshot.known_gaps[0].to_position, Some(position(1, 3)));
+    Ok(())
+}
+
+#[sqlx::test(migrations = "./migrations")]
+#[ignore = "requires the state-history integration PostgreSQL"]
+async fn coverage_starts_at_the_first_retained_checkpoint(pool: PgPool) -> anyhow::Result<()> {
+    seed_block_times(&pool, 90, 110).await?;
+    seed_checkpoint(&pool, 1, 0, 100, CheckpointKind::Boundary, true).await?;
+    seed_delta(&pool, 1, 1, 110, 1, &[Backend::Native]).await?;
+
+    let reader = StateHistoryReader::new(pool, object_store().await);
+    let snapshot = reader
+        .coverage(&CoverageQuery::new(
+            CHAIN_ID,
+            vec![Backend::Native],
+            Some(BlockInterval::new(90, 110)?),
+        )?)
+        .await?;
+
+    assert_eq!(
+        snapshot.continuous_intervals,
+        vec![BlockInterval::new(100, 110)?]
+    );
+    Ok(())
+}
+
+#[sqlx::test(migrations = "./migrations")]
+#[ignore = "requires the state-history integration PostgreSQL"]
+async fn cursorless_gap_uses_its_full_span_for_boundary_projection(
+    pool: PgPool,
+) -> anyhow::Result<()> {
+    seed_block_times(&pool, 100, 120).await?;
+    seed_checkpoint(&pool, 1, 0, 100, CheckpointKind::Boundary, true).await?;
+    seed_checkpoint(&pool, 1, 10, 105, CheckpointKind::Boundary, true).await?;
+    seed_checkpoint(&pool, 1, 30, 115, CheckpointKind::Boundary, true).await?;
+    seed_delta(&pool, 1, 31, 120, 1, &[Backend::Native]).await?;
+    seed_gap(&pool, 1, 2, 20, None, None).await?;
+
+    let reader = StateHistoryReader::new(pool, object_store().await);
+    let snapshot = reader
+        .coverage(&CoverageQuery::new(
+            CHAIN_ID,
+            vec![Backend::Native],
+            Some(BlockInterval::new(100, 120)?),
+        )?)
+        .await?;
+
+    assert_eq!(
+        snapshot.continuous_intervals,
+        vec![BlockInterval::new(115, 120)?]
+    );
+    Ok(())
+}
+
+#[sqlx::test(migrations = "./migrations")]
+#[ignore = "requires the state-history integration PostgreSQL"]
+async fn target_plan_returns_every_required_next_block_time(pool: PgPool) -> anyhow::Result<()> {
+    seed_block_times(&pool, 100, 111).await?;
+    seed_checkpoint_with_backends(
+        &pool,
+        1,
+        0,
+        100,
+        CheckpointKind::Boundary,
+        true,
+        &[Backend::Native, Backend::Rfq],
+    )
+    .await?;
+    seed_delta(&pool, 1, 1, 110, 1, &[Backend::Native, Backend::Rfq]).await?;
+
+    let reader = StateHistoryReader::new(pool, object_store().await);
+    let plan = reader
+        .plan_targets(&TargetPlanQuery::new(
+            CHAIN_ID,
+            vec![Backend::Native, Backend::Rfq],
+            BTreeSet::from([100, 110]),
+            ReadLimits::new(1_000_000, 1_000_000)?,
+        )?)
+        .await?;
+
+    assert_eq!(
+        plan.block_times.keys().copied().collect::<Vec<_>>(),
+        vec![100, 101, 110, 111]
+    );
+    assert!(plan.lineage_invalid_intervals.is_empty());
+    assert_eq!(plan.visible_through_block, 110);
+    Ok(())
+}
+
+#[sqlx::test(migrations = "./migrations")]
+#[ignore = "requires the state-history integration PostgreSQL"]
+async fn target_plan_marks_broken_canonical_lineage(pool: PgPool) -> anyhow::Result<()> {
+    seed_block_times(&pool, 100, 111).await?;
+    sqlx::query(
+        "UPDATE state_history.block_times
+         SET parent_hash = 'wrong-parent'
+         WHERE chain_id = $1 AND block_number = 110",
+    )
+    .bind(database_i64(CHAIN_ID)?)
+    .execute(&pool)
+    .await?;
+    seed_checkpoint(&pool, 1, 0, 100, CheckpointKind::Boundary, true).await?;
+    seed_delta(&pool, 1, 1, 110, 1, &[Backend::Native]).await?;
+
+    let reader = StateHistoryReader::new(pool, object_store().await);
+    let plan = reader
+        .plan_targets(&TargetPlanQuery::new(
+            CHAIN_ID,
+            vec![Backend::Native],
+            BTreeSet::from([100, 110]),
+            ReadLimits::new(1_000_000, 1_000_000)?,
+        )?)
+        .await?;
+
+    assert_eq!(
+        plan.lineage_invalid_intervals,
+        vec![BlockInterval::new(110, 110)?]
+    );
+    Ok(())
+}
+
+#[sqlx::test(migrations = "./migrations")]
+#[ignore = "requires the state-history integration PostgreSQL"]
+async fn token_anchor_stays_inside_the_selected_segment(pool: PgPool) -> anyhow::Result<()> {
+    let first_boundary = seed_checkpoint(&pool, 1, 0, 100, CheckpointKind::Boundary, true).await?;
+    let interval = seed_checkpoint(&pool, 1, 10, 110, CheckpointKind::Interval, false).await?;
+    let second_boundary =
+        seed_checkpoint(&pool, 2, 0, 120, CheckpointKind::Boundary, false).await?;
+
+    let reader = StateHistoryReader::new(pool, object_store().await);
+    assert_eq!(
+        reader.select_token_anchor(&interval).await?,
+        TokenAnchor::Available {
+            checkpoint: Box::new(first_boundary),
+            used_fallback: true,
+        }
+    );
+    assert_eq!(
+        reader.select_token_anchor(&second_boundary).await?,
+        TokenAnchor::Missing
+    );
+    Ok(())
+}
+
+#[sqlx::test(migrations = "./migrations")]
+#[ignore = "requires the state-history integration PostgreSQL"]
+#[expect(
+    clippy::expect_used,
+    reason = "the rejected explicit pair is the fixture outcome"
+)]
+async fn checkpoint_pairs_are_adjacent_and_never_cross_segments(
+    pool: PgPool,
+) -> anyhow::Result<()> {
+    seed_checkpoint(&pool, 1, 0, 100, CheckpointKind::Boundary, true).await?;
+    seed_checkpoint(&pool, 1, 10, 110, CheckpointKind::Interval, true).await?;
+    seed_checkpoint(&pool, 1, 20, 120, CheckpointKind::Interval, true).await?;
+    seed_checkpoint(&pool, 2, 0, 200, CheckpointKind::Boundary, true).await?;
+    seed_checkpoint(&pool, 2, 10, 210, CheckpointKind::Interval, true).await?;
+
+    let reader = StateHistoryReader::new(pool, object_store().await);
+    let pairs = reader
+        .resolve_checkpoint_pairs(&CheckpointPairQuery::new(
+            CHAIN_ID,
+            CheckpointPairSelection::BlockRange(BlockInterval::new(100, 210)?),
+        ))
+        .await?;
+    assert_eq!(pairs.len(), 3);
+    assert_eq!(pairs[0].earlier.position, position(1, 0));
+    assert_eq!(pairs[0].target.position, position(1, 10));
+    assert_eq!(pairs[1].earlier.position, position(1, 10));
+    assert_eq!(pairs[1].target.position, position(1, 20));
+    assert_eq!(pairs[2].earlier.position, position(2, 0));
+    assert_eq!(pairs[2].target.position, position(2, 10));
+
+    let error = reader
+        .resolve_checkpoint_pairs(&CheckpointPairQuery::new(
+            CHAIN_ID,
+            CheckpointPairSelection::Explicit(vec![ExplicitCheckpointPair {
+                earlier_position: position(1, 20),
+                target_position: position(2, 0),
+            }]),
+        ))
+        .await
+        .expect_err("an explicit pair must not cross a segment boundary");
+    assert!(error.to_string().contains("same segment"));
+    Ok(())
+}
+
+#[sqlx::test(migrations = "./migrations")]
+#[ignore = "requires the state-history integration PostgreSQL"]
+#[expect(
+    clippy::expect_used,
+    reason = "the preflight rejection is the fixture outcome"
+)]
+async fn checkpoint_limit_fails_before_object_download(pool: PgPool) -> anyhow::Result<()> {
+    let mut manifest = manifest(1, 0, 100, CheckpointKind::Boundary, true);
+    manifest.compressed_bytes = Some(101);
+    manifest.archive_bytes = Some(1_000);
+    let reader = StateHistoryReader::new(pool, object_store().await);
+
+    let error = reader
+        .fetch_checkpoint_with_limit(&manifest, ReadLimits::new(100, 2_000)?)
+        .await
+        .expect_err("the declared compressed size exceeds the limit");
+    assert!(matches!(
+        error,
+        ReadLimitError::CompressedBytesExceeded {
+            declared: 101,
+            limit: 100
+        }
+    ));
+    Ok(())
+}
+
+#[sqlx::test(migrations = "./migrations")]
+#[ignore = "requires the state-history integration PostgreSQL"]
+#[expect(
+    clippy::expect_used,
+    reason = "the unknown-format rejection is the fixture outcome"
+)]
+async fn unknown_delta_format_fails_closed(pool: PgPool) -> anyhow::Result<()> {
+    seed_block_times(&pool, 100, 101).await?;
+    seed_checkpoint(&pool, 1, 0, 100, CheckpointKind::Boundary, true).await?;
+    seed_delta(&pool, 1, 1, 101, 99, &[Backend::Native]).await?;
+    let reader = StateHistoryReader::new(pool, object_store().await);
+
+    let error = reader
+        .plan_targets(&TargetPlanQuery::new(
+            CHAIN_ID,
+            vec![Backend::Native],
+            BTreeSet::from([100, 101]),
+            ReadLimits::new(1_000_000, 1_000_000)?,
+        )?)
+        .await
+        .expect_err("unknown delta formats must fail closed");
+    assert!(error
+        .to_string()
+        .contains("unsupported delta payload format 99"));
+    Ok(())
+}
+
+async fn seed_checkpoint(
+    pool: &PgPool,
+    generation: u64,
+    message_seq: u64,
+    block_number: u64,
+    kind: CheckpointKind,
+    with_tokens: bool,
+) -> anyhow::Result<CheckpointManifest> {
+    seed_checkpoint_with_backends(
+        pool,
+        generation,
+        message_seq,
+        block_number,
+        kind,
+        with_tokens,
+        &[Backend::Native],
+    )
+    .await
+}
+
+async fn seed_checkpoint_with_backends(
+    pool: &PgPool,
+    generation: u64,
+    message_seq: u64,
+    block_number: u64,
+    kind: CheckpointKind,
+    with_tokens: bool,
+    backends: &[Backend],
+) -> anyhow::Result<CheckpointManifest> {
+    let checkpoint = manifest(generation, message_seq, block_number, kind, with_tokens);
+    let backend_values = backends
+        .iter()
+        .map(|backend| backend.as_str())
+        .collect::<Vec<_>>();
+    let token = checkpoint.token_reference.as_ref();
+    let id: i64 = sqlx::query_scalar(
+        "INSERT INTO state_history.checkpoints
+            (chain_id, generation, message_seq, kind, block_number, rfq_observed_at_ms,
+             backends, s3_key, archive_sha256, archive_bytes, compressed_bytes,
+             token_s3_key, token_sha256, token_count, token_bytes, status, completed_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,
+                 'complete', now())
+         RETURNING id",
+    )
+    .bind(database_i64(CHAIN_ID)?)
+    .bind(database_i64(generation)?)
+    .bind(database_i64(message_seq)?)
+    .bind(kind.as_str())
+    .bind(database_i64(block_number)?)
+    .bind(
+        backends
+            .contains(&Backend::Rfq)
+            .then(|| database_i64(block_number * 1_000))
+            .transpose()?,
+    )
+    .bind(backend_values)
+    .bind(checkpoint.s3_key.as_deref())
+    .bind(checkpoint.archive_sha256.as_deref())
+    .bind(checkpoint.archive_bytes.map(database_i64).transpose()?)
+    .bind(checkpoint.compressed_bytes.map(database_i64).transpose()?)
+    .bind(token.map(|reference| reference.s3_key.as_str()))
+    .bind(token.map(|reference| reference.sha256.as_str()))
+    .bind(
+        token
+            .map(|reference| database_i64(reference.token_count))
+            .transpose()?,
+    )
+    .bind(
+        token
+            .map(|reference| database_i64(reference.token_bytes))
+            .transpose()?,
+    )
+    .fetch_one(pool)
+    .await?;
+    Ok(CheckpointManifest {
+        id,
+        state_version: None,
+        backends: backends.to_vec(),
+        ..checkpoint
+    })
+}
+
+async fn seed_delta(
+    pool: &PgPool,
+    generation: u64,
+    message_seq: u64,
+    block_number: u64,
+    payload_format_version: i16,
+    backends: &[Backend],
+) -> anyhow::Result<()> {
+    let raw = RawValue::from_string(format!(
+        r#"{{"generation":{generation},"messageSeq":{message_seq}}}"#
+    ))?;
+    let canonical = raw.get().as_bytes();
+    let payload = zstd::stream::encode_all(canonical, 3)?;
+    let sha256 = hex::encode(sha2::Sha256::digest(canonical));
+    let delta_id: i64 = sqlx::query_scalar(
+        "INSERT INTO state_history.deltas
+            (chain_id, generation, message_seq, block_number, observed_at_ms, payload,
+             payload_sha256, payload_format_version)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+         RETURNING id",
+    )
+    .bind(database_i64(CHAIN_ID)?)
+    .bind(database_i64(generation)?)
+    .bind(database_i64(message_seq)?)
+    .bind(database_i64(block_number)?)
+    .bind(database_i64(block_number * 1_000)?)
+    .bind(payload)
+    .bind(sha256)
+    .bind(payload_format_version)
+    .fetch_one(pool)
+    .await?;
+    for backend in backends {
+        let (block_cursor, time_cursor) = match backend {
+            Backend::Native | Backend::Vm => (Some(block_number), None),
+            Backend::Rfq => (None, Some(block_number * 1_000)),
+        };
+        sqlx::query(
+            "INSERT INTO state_history.delta_backends
+                (delta_id, chain_id, backend, generation, message_seq, block_number, observed_at_ms)
+             VALUES ($1, $2, $3, $4, $5, $6, $7)",
+        )
+        .bind(delta_id)
+        .bind(database_i64(CHAIN_ID)?)
+        .bind(backend.as_str())
+        .bind(database_i64(generation)?)
+        .bind(database_i64(message_seq)?)
+        .bind(block_cursor.map(database_i64).transpose()?)
+        .bind(time_cursor.map(database_i64).transpose()?)
+        .execute(pool)
+        .await?;
+    }
+    Ok(())
+}
+
+async fn seed_gap(
+    pool: &PgPool,
+    generation: u64,
+    from_message_seq: u64,
+    to_message_seq: u64,
+    block_bounds: Option<(u64, u64)>,
+    time_bounds: Option<(u64, u64)>,
+) -> anyhow::Result<()> {
+    sqlx::query(
+        "INSERT INTO state_history.gaps
+            (chain_id, generation, from_message_seq, to_message_seq, reason,
+             from_block_number, to_block_number, from_observed_at_ms, to_observed_at_ms)
+         VALUES ($1, $2, $3, $4, 'write_failed', $5, $6, $7, $8)",
+    )
+    .bind(database_i64(CHAIN_ID)?)
+    .bind(database_i64(generation)?)
+    .bind(database_i64(from_message_seq)?)
+    .bind(database_i64(to_message_seq)?)
+    .bind(
+        block_bounds
+            .map(|bounds| database_i64(bounds.0))
+            .transpose()?,
+    )
+    .bind(
+        block_bounds
+            .map(|bounds| database_i64(bounds.1))
+            .transpose()?,
+    )
+    .bind(
+        time_bounds
+            .map(|bounds| database_i64(bounds.0))
+            .transpose()?,
+    )
+    .bind(
+        time_bounds
+            .map(|bounds| database_i64(bounds.1))
+            .transpose()?,
+    )
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+async fn seed_block_times(pool: &PgPool, start: u64, end: u64) -> anyhow::Result<()> {
+    for block_number in start..=end {
+        sqlx::query(
+            "INSERT INTO state_history.block_times
+                (chain_id, block_number, timestamp_ms, block_hash, parent_hash,
+                 source_generation, source_message_seq)
+             VALUES ($1, $2, $3, $4, $5, 1, $6)",
+        )
+        .bind(database_i64(CHAIN_ID)?)
+        .bind(database_i64(block_number)?)
+        .bind(database_i64(block_number * 1_000)?)
+        .bind(format!("hash-{block_number}"))
+        .bind(format!("hash-{}", block_number.saturating_sub(1)))
+        .bind(database_i64(block_number - start + 1)?)
+        .execute(pool)
+        .await?;
+    }
+    Ok(())
+}
+
+fn manifest(
+    generation: u64,
+    message_seq: u64,
+    block_number: u64,
+    kind: CheckpointKind,
+    with_tokens: bool,
+) -> CheckpointManifest {
+    CheckpointManifest {
+        id: 0,
+        chain_id: CHAIN_ID,
+        position: position(generation, message_seq),
+        state_version: Some(message_seq),
+        kind,
+        block_number,
+        rfq_observed_at_ms: None,
+        backends: vec![Backend::Native],
+        s3_key: Some(format!(
+            "reader/chain={CHAIN_ID}/gen={generation}/seq={message_seq}/kind={}/checkpoint.zst",
+            kind.as_str()
+        )),
+        archive_sha256: Some(format!("archive-{generation}-{message_seq}")),
+        archive_bytes: Some(1_000),
+        compressed_bytes: Some(100),
+        token_reference: with_tokens.then(|| state_history::TokenSnapshotRef {
+            s3_key: format!("reader/chain={CHAIN_ID}/tokens/token-{generation}-{message_seq}.zst"),
+            sha256: format!("token-{generation}-{message_seq}"),
+            token_count: 1,
+            token_bytes: 100,
+        }),
+        status: CheckpointStatus::Complete,
+        error: None,
+    }
+}
+
+async fn object_store() -> state_history::CheckpointObjectStore {
+    state_history::CheckpointObjectStore::from_env_config(
+        "state-history-analysis".to_owned(),
+        "reader".to_owned(),
+        "eu-central-1".to_owned(),
+        Some("http://127.0.0.1:59000".to_owned()),
+        true,
+    )
+    .await
+}
+
+const fn position(generation: u64, message_seq: u64) -> StreamPosition {
+    StreamPosition {
+        generation,
+        message_seq,
+    }
+}
+
+fn database_i64(value: u64) -> anyhow::Result<i64> {
+    i64::try_from(value).context("fixture value exceeds PostgreSQL BIGINT")
+}

--- a/docs/state_history.md
+++ b/docs/state_history.md
@@ -48,7 +48,7 @@ The uncompressed JSON envelope has this shape:
 }
 ```
 
-`TOKEN_SNAPSHOT_SCHEMA_VERSION` is the token snapshot schema constant. It is independent of `ARCHIVE_SCHEMA_VERSION`. Both constants are currently `1`.
+`TOKEN_SNAPSHOT_SCHEMA_VERSION` is the token snapshot schema constant. It is independent of `ARCHIVE_SCHEMA_VERSION` and the delta payload format. All three retained formats are currently `1`.
 
 Canonical encoding sorts tokens by address and rejects duplicate addresses. Serde emits deterministic JSON from the fixed envelope and token DTO fields. The writer computes SHA-256 over those uncompressed canonical bytes, then compresses them with Zstandard level 3. The manifest `token_bytes` column records the uncompressed canonical JSON length. `TokenSnapshotCodecError` provides the typed `Sha256Mismatch`, `UnsupportedSchemaVersion`, and `DuplicateTokenAddress` variants.
 
@@ -56,14 +56,14 @@ Token snapshots are content-addressed because an unchanged token catalog can be 
 
 ## PostgreSQL schema
 
-The migration in `crates/state-history/migrations/20260728000100_create_state_history.sql` is the source of truth for this schema.
+The append-only migrations under `crates/state-history/migrations/` are the source of truth for this schema. The initial migration creates schema version 1. `20260813000100_add_delta_payload_format_version.sql` upgrades it to version 2 without rewriting the initial migration.
 
 ### `state_history.schema_meta`
 
 | Column | Meaning |
 | --- | --- |
 | `singleton` | Primary key fixed to `TRUE`, which keeps this table to one schema metadata row. |
-| `version` | State history schema version. The current migration inserts version `1`. |
+| `version` | State history schema version. The current migration catalog requires version `2`. |
 
 ### `state_history.deltas`
 
@@ -79,7 +79,16 @@ One row represents one accepted update. `(chain_id, generation, message_seq)` is
 | `observed_at_ms` | Time the update was observed, in Unix milliseconds. |
 | `payload` | Zstandard-compressed serialized update payload. |
 | `payload_sha256` | SHA-256 digest of the uncompressed serialized payload. |
+| `payload_format_version` | Complete retained delta payload and decoder profile version. Existing and new rows default to version `1`. |
 | `created_at` | Time PostgreSQL inserted the row. |
+
+### Retained payload formats
+
+Checkpoint archives, token snapshots, and deltas dispatch through explicit stored-version matches. Unknown versions fail closed. Delta payload format 1 means the current broadcaster update envelope plus the fixed `DecoderConfig::retained_v1()` profile. That profile registers every protocol implementation a format 1 writer could emit and pins token quality to `0`; it never reads the current simulator manifest.
+
+When state history is enabled, broadcaster startup refuses `BROADCASTER_TOKEN_MIN_QUALITY` values other than `0`. Any JSON-shape, protocol-decoder, or decoder-setting change that changes retained decoding requires a new delta payload format before its writer can be enabled.
+
+Deploy reader support for format `N + 1` before any writer emits `N + 1`. Keep each decoder while matching retained rows or objects exist. This is a stored-data retention rule, not public API backward compatibility.
 
 ### `state_history.delta_backends`
 
@@ -324,11 +333,17 @@ async fn load_range(reader: &StateHistoryReader) -> anyhow::Result<()> {
 }
 ```
 
-Construct the reader with `StateHistoryReader::new(StateHistoryStore, CheckpointObjectStore)`. See `crates/state-history/src/reader.rs` for the complete API and replay plan types.
+Construct the reader with `StateHistoryReader::new(PgPool, CheckpointObjectStore)`. `StateHistoryReader<P>` accepts any service-owned `ReadConnectionProvider`, so the historical service can supply an observer or replica pool without giving the reader a primary fallback. Every range, coverage, target-planning, token-anchor, and checkpoint-pair query uses one repeatable-read, read-only transaction.
+
+`coverage` returns continuous safe block intervals and `visible_through_block` separately. Replica delay only lowers that cutoff; it never becomes a stored gap. Stored gaps retain their complete stream-position, block, and RFQ observation-time bounds. A gap without block or time cursors fails closed from the prior compatible boundary through the next compatible boundary.
+
+`plan_targets` returns observations for every unique target block and, for RFQ, each target's next block. It validates canonical parent/hash lineage across the requested span and reports unsafe lineage intervals separately from stored gaps. `resolve_checkpoint_pairs` returns adjacent complete checkpoints without crossing a boundary, while explicit pairs must resolve to exact, ordered positions in one segment. `select_token_anchor` uses the selected checkpoint's token snapshot or the newest earlier token snapshot after the same segment boundary; it never attaches a token snapshot across a boundary.
+
+Use `ReadLimits` with target planning and the bounded object fetch methods. Planning sums manifest sizes and SQL `octet_length(payload)` before selecting compressed delta bodies. Object fetches reject an oversized manifest or S3 content length before reading the body, and all Zstandard decoders use counted readers capped at the remaining decoded-byte limit.
 
 `state-history-check` is the read-only operational wrapper around this flow. It reads the observer database URL and S3 settings from the state-history environment variables, selects a closed recent Base range, requires `ensure_gap_free()`, and verifies every replay-leg checkpoint and token object. It never runs migrations or writes PostgreSQL or S3. The production image intentionally does not contain this local tool.
 
-When replaying deltas with a Tycho decoder, set its `min_token_quality` to the broadcaster's `BROADCASTER_TOKEN_MIN_QUALITY` value. The broadcaster default is `0`, while Tycho 0.341.8 defaults the decoder floor to `100`. Without matching floors, the decoder refuses mid-stream `new_tokens` below quality `100` even though the checkpoint token snapshot includes tokens admitted by the broadcaster.
+When replaying format 1 deltas, use `DecoderConfig::retained_v1()`. Its token quality is fixed at `0`; do not derive retained decoding from the live manifest or current runtime tuning.
 
 ## Operations
 
@@ -354,7 +369,7 @@ State history is inert when `STATE_HISTORY_ENABLED=false`. When it is disabled, 
 
 Token snapshots add no environment variables. They use the existing state history S3 settings. Stream token admission uses the existing `BROADCASTER_TOKEN_MIN_QUALITY` setting.
 
-`state-history-migrate` is a one-shot task. It requires `STATE_HISTORY_MIGRATION_DATABASE_URL` for the migration master and `STATE_HISTORY_WRITER_PASSWORD` for `state_history_writer`. It runs and verifies the exact embedded SQLx catalog, validates schema version 1, and converges `state_history_writer` plus the passwordless, `rds_iam`-enabled `state_history_observer`. It does not construct an S3 client or write application rows. The migration task must override the broadcaster image entrypoint with `/usr/local/bin/state-history-migrate`.
+`state-history-migrate` is a one-shot task. It requires `STATE_HISTORY_MIGRATION_DATABASE_URL` for the migration master and `STATE_HISTORY_WRITER_PASSWORD` for `state_history_writer`. It runs and verifies the exact embedded SQLx catalog, validates schema version 2, and converges `state_history_writer` plus the passwordless, `rds_iam`-enabled `state_history_observer`. It does not construct an S3 client or write application rows. The migration task must override the broadcaster image entrypoint with `/usr/local/bin/state-history-migrate`.
 
 ### `/status.state_history`
 


### PR DESCRIPTION
Extends state history with repeatable read coverage, target planning, checkpoint pair selection, token anchors, and byte limited object reads, then binds retained deltas to an explicit decoder format. This keeps storage integrity and resource bounds separate from quote reconstruction.