### PR TITLE
feat: add historical quote engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3543,12 +3543,19 @@ dependencies = [
 name = "historical-quote"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives 1.5.7",
+ "anyhow",
  "chrono",
  "num-bigint",
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "simulator-replay",
+ "state-history",
  "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tycho-simulation",
  "utoipa 5.5.0",
  "uuid",
 ]

--- a/crates/historical-quote/Cargo.toml
+++ b/crates/historical-quote/Cargo.toml
@@ -6,15 +6,35 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[features]
+default = ["engine"]
+engine = [
+    "dep:alloy-primitives",
+    "dep:anyhow",
+    "dep:simulator-replay",
+    "dep:state-history",
+    "dep:tokio-util",
+    "dep:tycho-simulation",
+]
+
 [dependencies]
+alloy-primitives = { workspace = true, optional = true }
+anyhow = { workspace = true, optional = true }
 chrono.workspace = true
 num-bigint.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
+simulator-replay = { path = "../simulator-replay", optional = true }
+state-history = { path = "../state-history", optional = true }
 thiserror.workspace = true
+tokio-util = { workspace = true, optional = true }
+tycho-simulation = { workspace = true, optional = true }
 utoipa.workspace = true
 uuid.workspace = true
+
+[dev-dependencies]
+tokio.workspace = true
 
 [lints]
 workspace = true

--- a/crates/historical-quote/src/consistency.rs
+++ b/crates/historical-quote/src/consistency.rs
@@ -1,0 +1,661 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::str::FromStr;
+use std::sync::Arc;
+
+use alloy_primitives::U256;
+use sha2::{Digest, Sha256};
+use simulator_replay::{CanonicalState, ExactPoolQuote};
+use state_history::{
+    BlockInterval, CheckpointPairQuery, CheckpointPairSelection, ExplicitCheckpointPair, ReadLimits,
+};
+use tokio_util::sync::CancellationToken;
+use tycho_simulation::tycho_common::Bytes;
+
+use crate::api::{
+    Backend, CanonicalStateSummary, ConsistencyCheckReport, ConsistencyCheckRequest,
+    ConsistencyDifference, ConsistencyPairReport, ConsistencyQuoteComparison,
+    ConsistencyQuoteOutcome, ConsistencySelection, ConsistencySelectionStatus, ConsistencySummary,
+    PairStatus, PoolSelector, QuoteComparisonRequest, QuoteFailureReason, UnsignedAmount,
+};
+use crate::quote_job::quote_failure_reason;
+use crate::replay::{
+    apply_all_pair_deltas, check_cancelled, history_backend, history_position, public_position,
+    replay_backend, restore_checkpoint,
+};
+use crate::{EngineProgress, HistoricalError, HistorySource};
+
+pub const DEFAULT_MAX_CONSISTENCY_DIFFERENCES: usize = 100;
+
+pub struct ConsistencyChecker<S> {
+    source: Arc<S>,
+    read_limits: ReadLimits,
+    max_differences: usize,
+}
+
+impl<S> ConsistencyChecker<S> {
+    pub fn new(source: Arc<S>, read_limits: ReadLimits, max_differences: usize) -> Self {
+        Self {
+            source,
+            read_limits,
+            max_differences,
+        }
+    }
+
+    pub fn with_default_limit(source: Arc<S>, read_limits: ReadLimits) -> Self {
+        Self::new(source, read_limits, DEFAULT_MAX_CONSISTENCY_DIFFERENCES)
+    }
+}
+
+impl<S: HistorySource> ConsistencyChecker<S> {
+    pub async fn execute(
+        &self,
+        request: &ConsistencyCheckRequest,
+        cancellation: &CancellationToken,
+        progress: &impl EngineProgress,
+    ) -> Result<ConsistencyCheckReport, HistoricalError> {
+        check_cancelled(cancellation)?;
+        if request.backends.contains(&Backend::Vm) {
+            return Err(HistoricalError::UnsupportedCanonicalVm);
+        }
+        let query = checkpoint_pair_query(request)?;
+        let pairs = self.source.resolve_checkpoint_pairs(query).await?;
+        if pairs.is_empty() {
+            return Ok(empty_report(request));
+        }
+
+        let mut remaining_differences = self.max_differences;
+        let mut reports = Vec::with_capacity(pairs.len());
+        for pair in pairs {
+            check_cancelled(cancellation)?;
+            let plan = self
+                .source
+                .plan_checkpoint_pair(
+                    pair,
+                    request
+                        .backends
+                        .iter()
+                        .copied()
+                        .map(history_backend)
+                        .collect(),
+                    self.read_limits,
+                )
+                .await?;
+            let report = if plan.gaps.is_empty() {
+                self.compare_pair(request, plan, cancellation, remaining_differences)
+                    .await?
+            } else {
+                gap_report(request, &plan.pair)
+            };
+            remaining_differences = remaining_differences.saturating_sub(report.differences.len());
+            reports.push(report);
+            progress.checkpoint_pair_completed();
+        }
+        let summary = summarize(&reports);
+        let mut backends = request.backends.clone();
+        backends.sort_unstable();
+        Ok(ConsistencyCheckReport {
+            request_id: request.request_id,
+            chain_id: request.chain_id,
+            backends,
+            selection: request.selection.clone(),
+            selection_status: ConsistencySelectionStatus::Compared,
+            summary,
+            pairs: reports,
+        })
+    }
+
+    async fn compare_pair(
+        &self,
+        request: &ConsistencyCheckRequest,
+        plan: state_history::CheckpointPairReplayPlan,
+        cancellation: &CancellationToken,
+        difference_limit: usize,
+    ) -> Result<ConsistencyPairReport, HistoricalError> {
+        let backends = request.backends.iter().copied().collect::<BTreeSet<_>>();
+        let direct = restore_checkpoint(
+            self.source.as_ref(),
+            &plan.pair.target,
+            &backends,
+            self.read_limits,
+            cancellation,
+        )
+        .await?;
+        let replayed = restore_checkpoint(
+            self.source.as_ref(),
+            &plan.pair.earlier,
+            &backends,
+            self.read_limits,
+            cancellation,
+        )
+        .await?;
+        let (Some(direct), Some(mut replayed)) = (direct, replayed) else {
+            return Ok(gap_report(request, &plan.pair));
+        };
+        if direct.checkpoint_application_invalid
+            || apply_all_pair_deltas(&mut replayed, &plan.deltas, &backends, cancellation).await?
+        {
+            return Err(HistoricalError::StateReconstructionFailed(
+                "checkpoint pair produced a deterministic apply anomaly".to_owned(),
+            ));
+        }
+        replayed
+            .world
+            .set_current_block(target_world_marker(&plan.pair.target, &request.backends));
+
+        let replay_backends = request
+            .backends
+            .iter()
+            .copied()
+            .map(replay_backend)
+            .collect::<Vec<_>>();
+        let direct_state = direct
+            .world
+            .pin()
+            .canonical_state(&replay_backends)
+            .map_err(canonical_error)?;
+        let replayed_state = replayed
+            .world
+            .pin()
+            .canonical_state(&replay_backends)
+            .map_err(canonical_error)?;
+        let state_matches = direct_state.as_bytes() == replayed_state.as_bytes();
+        let difference_set = canonical_differences(
+            &direct_state,
+            &replayed_state,
+            &request.backends,
+            difference_limit,
+        );
+
+        let quote_comparisons = compare_quotes(
+            &direct.world.pin(),
+            &replayed.world.pin(),
+            &request.quotes_to_compare,
+            cancellation,
+        )?;
+        let status = compared_pair_status(state_matches, &quote_comparisons);
+        let mut affected_backends = difference_set.affected_backends;
+        let mut affected_component_ids = difference_set.affected_component_ids;
+        for comparison in &quote_comparisons {
+            if comparison.status == PairStatus::Mismatch {
+                affected_backends.insert(comparison.pool.backend);
+                affected_component_ids.insert(comparison.pool.component_id.clone());
+            }
+        }
+        Ok(ConsistencyPairReport {
+            earlier_position: public_position(plan.pair.earlier.position),
+            target_position: public_position(plan.pair.target.position),
+            status,
+            direct_state: Some(canonical_summary(&direct_state)),
+            replayed_state: Some(canonical_summary(&replayed_state)),
+            affected_backends: affected_backends.into_iter().collect(),
+            affected_component_ids: affected_component_ids.into_iter().collect(),
+            quote_comparisons,
+            total_difference_count: difference_set.total_count,
+            differences: difference_set.differences,
+        })
+    }
+}
+
+fn compare_quotes(
+    direct: &simulator_replay::StatePoint,
+    replayed: &simulator_replay::StatePoint,
+    requests: &[QuoteComparisonRequest],
+    cancellation: &CancellationToken,
+) -> Result<Vec<ConsistencyQuoteComparison>, HistoricalError> {
+    let mut comparisons = Vec::new();
+    for quote in sorted_quote_requests(requests) {
+        for amount in quote.amounts_in {
+            check_cancelled(cancellation)?;
+            let direct_outcome = consistency_quote(direct, &quote.pool, &amount);
+            check_cancelled(cancellation)?;
+            let replayed_outcome = consistency_quote(replayed, &quote.pool, &amount);
+            let status = quote_status(&direct_outcome, &replayed_outcome);
+            comparisons.push(ConsistencyQuoteComparison {
+                pool: quote.pool.clone(),
+                amount_in: amount,
+                direct_outcome,
+                replayed_outcome,
+                status,
+            });
+        }
+    }
+    Ok(comparisons)
+}
+
+fn compared_pair_status(
+    state_matches: bool,
+    comparisons: &[ConsistencyQuoteComparison],
+) -> PairStatus {
+    if !state_matches
+        || comparisons
+            .iter()
+            .any(|comparison| comparison.status == PairStatus::Mismatch)
+    {
+        PairStatus::Mismatch
+    } else if comparisons
+        .iter()
+        .any(|comparison| comparison.status == PairStatus::NotComparable)
+    {
+        PairStatus::NotComparable
+    } else {
+        PairStatus::Pass
+    }
+}
+
+fn checkpoint_pair_query(
+    request: &ConsistencyCheckRequest,
+) -> Result<CheckpointPairQuery, HistoricalError> {
+    let selection = match &request.selection {
+        ConsistencySelection::CheckpointPairs { pairs } => CheckpointPairSelection::Explicit(
+            pairs
+                .iter()
+                .map(|pair| ExplicitCheckpointPair {
+                    earlier_position: history_position(pair.earlier_position),
+                    target_position: history_position(pair.target_position),
+                })
+                .collect(),
+        ),
+        ConsistencySelection::BlockRange {
+            start,
+            end_inclusive,
+        } => CheckpointPairSelection::BlockRange(
+            BlockInterval::new(*start, *end_inclusive)
+                .map_err(|error| HistoricalError::InvalidSelector(error.to_string()))?,
+        ),
+    };
+    Ok(CheckpointPairQuery::for_backends(
+        request.chain_id,
+        selection,
+        request
+            .backends
+            .iter()
+            .copied()
+            .map(history_backend)
+            .collect(),
+    ))
+}
+
+fn empty_report(request: &ConsistencyCheckRequest) -> ConsistencyCheckReport {
+    let mut backends = request.backends.clone();
+    backends.sort_unstable();
+    ConsistencyCheckReport {
+        request_id: request.request_id,
+        chain_id: request.chain_id,
+        backends,
+        selection: request.selection.clone(),
+        selection_status: ConsistencySelectionStatus::NotComparable,
+        summary: ConsistencySummary {
+            selected_checkpoint_pairs: 0,
+            compared_checkpoint_pairs: 0,
+            pass: 0,
+            mismatch: 0,
+            gap: 0,
+            not_comparable: 0,
+        },
+        pairs: Vec::new(),
+    }
+}
+
+fn gap_report(
+    request: &ConsistencyCheckRequest,
+    pair: &state_history::CheckpointPair,
+) -> ConsistencyPairReport {
+    let mut affected_backends = request.backends.clone();
+    affected_backends.sort_unstable();
+    ConsistencyPairReport {
+        earlier_position: public_position(pair.earlier.position),
+        target_position: public_position(pair.target.position),
+        status: PairStatus::Gap,
+        direct_state: None,
+        replayed_state: None,
+        affected_backends,
+        affected_component_ids: Vec::new(),
+        quote_comparisons: Vec::new(),
+        total_difference_count: 0,
+        differences: Vec::new(),
+    }
+}
+
+fn summarize(reports: &[ConsistencyPairReport]) -> ConsistencySummary {
+    let mut summary = ConsistencySummary {
+        selected_checkpoint_pairs: u64::try_from(reports.len()).unwrap_or(u64::MAX),
+        compared_checkpoint_pairs: 0,
+        pass: 0,
+        mismatch: 0,
+        gap: 0,
+        not_comparable: 0,
+    };
+    for report in reports {
+        match report.status {
+            PairStatus::Pass => {
+                summary.pass += 1;
+                summary.compared_checkpoint_pairs += 1;
+            }
+            PairStatus::Mismatch => {
+                summary.mismatch += 1;
+                summary.compared_checkpoint_pairs += 1;
+            }
+            PairStatus::Gap => summary.gap += 1,
+            PairStatus::NotComparable => {
+                summary.not_comparable += 1;
+                summary.compared_checkpoint_pairs += 1;
+            }
+        }
+    }
+    summary
+}
+
+fn sorted_quote_requests(requests: &[QuoteComparisonRequest]) -> Vec<QuoteComparisonRequest> {
+    let mut requests = requests.to_vec();
+    for request in &mut requests {
+        request.amounts_in.sort_unstable();
+    }
+    requests.sort_unstable();
+    requests
+}
+
+fn consistency_quote(
+    point: &simulator_replay::StatePoint,
+    pool: &PoolSelector,
+    amount: &UnsignedAmount,
+) -> ConsistencyQuoteOutcome {
+    let request = Bytes::from_str(&pool.token_in)
+        .and_then(|token_in| {
+            Bytes::from_str(&pool.token_out).map(|token_out| (token_in, token_out))
+        })
+        .ok()
+        .and_then(|(token_in, token_out)| {
+            U256::from_str_radix(amount.as_str(), 10)
+                .ok()
+                .map(|amount_in| ExactPoolQuote {
+                    backend: replay_backend(pool.backend),
+                    protocol: pool.protocol.clone(),
+                    component_id: pool.component_id.clone(),
+                    token_in,
+                    token_out,
+                    amount_in,
+                })
+        });
+    let Some(request) = request else {
+        return ConsistencyQuoteOutcome::QuoteFailed {
+            reason: QuoteFailureReason::SimulationFailed,
+        };
+    };
+    match point.quote(&request) {
+        Ok(amount_out) => match amount_out.to_string().parse() {
+            Ok(amount_out) => ConsistencyQuoteOutcome::Ok { amount_out },
+            Err(_) => ConsistencyQuoteOutcome::QuoteFailed {
+                reason: QuoteFailureReason::SimulationFailed,
+            },
+        },
+        Err(error) => ConsistencyQuoteOutcome::QuoteFailed {
+            reason: quote_failure_reason(&error),
+        },
+    }
+}
+
+fn quote_status(
+    direct: &ConsistencyQuoteOutcome,
+    replayed: &ConsistencyQuoteOutcome,
+) -> PairStatus {
+    match (direct, replayed) {
+        (
+            ConsistencyQuoteOutcome::Ok { amount_out: direct },
+            ConsistencyQuoteOutcome::Ok {
+                amount_out: replayed,
+            },
+        ) if direct == replayed => PairStatus::Pass,
+        (
+            ConsistencyQuoteOutcome::QuoteFailed { reason: direct },
+            ConsistencyQuoteOutcome::QuoteFailed { reason: replayed },
+        ) if direct == replayed => PairStatus::NotComparable,
+        _ => PairStatus::Mismatch,
+    }
+}
+
+fn target_world_marker(manifest: &state_history::CheckpointManifest, backends: &[Backend]) -> u64 {
+    let mut marker = 0;
+    if backends
+        .iter()
+        .any(|backend| matches!(backend, Backend::Native | Backend::Vm))
+    {
+        marker = marker.max(manifest.block_number);
+    }
+    if backends.contains(&Backend::Rfq) {
+        marker = marker.max(manifest.rfq_observed_at_ms.unwrap_or_default() / 1_000);
+    }
+    marker
+}
+
+fn canonical_error(error: simulator_replay::CanonicalStateError) -> HistoricalError {
+    match error {
+        simulator_replay::CanonicalStateError::UnsupportedBackend(_) => {
+            HistoricalError::UnsupportedCanonicalVm
+        }
+        simulator_replay::CanonicalStateError::Serialize(error) => {
+            HistoricalError::StateReconstructionFailed(error.to_string())
+        }
+    }
+}
+
+fn canonical_summary(state: &CanonicalState) -> CanonicalStateSummary {
+    CanonicalStateSummary {
+        sha256: digest(state.as_bytes()),
+        component_count: u64::try_from(state.component_count).unwrap_or(u64::MAX),
+        backend_counts: state
+            .backend_counts
+            .iter()
+            .map(|(backend, count)| {
+                (
+                    match backend {
+                        simulator_replay::ReplayBackend::Native => Backend::Native,
+                        simulator_replay::ReplayBackend::Vm => Backend::Vm,
+                        simulator_replay::ReplayBackend::Rfq => Backend::Rfq,
+                    },
+                    u64::try_from(*count).unwrap_or(u64::MAX),
+                )
+            })
+            .collect(),
+    }
+}
+
+struct DifferenceSet {
+    total_count: u64,
+    differences: Vec<ConsistencyDifference>,
+    affected_backends: BTreeSet<Backend>,
+    affected_component_ids: BTreeSet<String>,
+}
+
+fn canonical_differences(
+    direct: &CanonicalState,
+    replayed: &CanonicalState,
+    requested_backends: &[Backend],
+    limit: usize,
+) -> DifferenceSet {
+    let mut candidates = Vec::new();
+    let mut affected_backends = BTreeSet::new();
+    let mut affected_component_ids = BTreeSet::new();
+    collect_component_differences(
+        direct,
+        replayed,
+        &mut candidates,
+        &mut affected_backends,
+        &mut affected_component_ids,
+    );
+    collect_token_differences(
+        direct,
+        replayed,
+        requested_backends,
+        &mut candidates,
+        &mut affected_backends,
+    );
+    if direct.as_bytes() != replayed.as_bytes() && candidates.is_empty() {
+        for backend in requested_backends {
+            candidates.push(difference(
+                *backend,
+                None,
+                "canonical_state",
+                Some(direct.as_bytes()),
+                Some(replayed.as_bytes()),
+            ));
+            affected_backends.insert(*backend);
+        }
+    }
+    candidates.sort_by(|left, right| {
+        (
+            left.backend,
+            left.component_id.as_deref(),
+            left.field.as_str(),
+        )
+            .cmp(&(
+                right.backend,
+                right.component_id.as_deref(),
+                right.field.as_str(),
+            ))
+    });
+    let total_count = u64::try_from(candidates.len()).unwrap_or(u64::MAX);
+    candidates.truncate(limit);
+    DifferenceSet {
+        total_count,
+        differences: candidates,
+        affected_backends,
+        affected_component_ids,
+    }
+}
+
+fn collect_component_differences(
+    direct: &CanonicalState,
+    replayed: &CanonicalState,
+    candidates: &mut Vec<ConsistencyDifference>,
+    affected_backends: &mut BTreeSet<Backend>,
+    affected_component_ids: &mut BTreeSet<String>,
+) {
+    let direct_components = direct
+        .components()
+        .iter()
+        .map(|component| {
+            (
+                (
+                    public_replay_backend(component.backend),
+                    component.component_id.clone(),
+                ),
+                component,
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let replayed_components = replayed
+        .components()
+        .iter()
+        .map(|component| {
+            (
+                (
+                    public_replay_backend(component.backend),
+                    component.component_id.clone(),
+                ),
+                component,
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let component_keys = direct_components
+        .keys()
+        .chain(replayed_components.keys())
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    for (backend, component_id) in component_keys {
+        let component_difference_start = candidates.len();
+        let direct = direct_components.get(&(backend, component_id.clone()));
+        let replayed = replayed_components.get(&(backend, component_id.clone()));
+        if direct.map(|value| value.component_bytes())
+            != replayed.map(|value| value.component_bytes())
+        {
+            candidates.push(difference(
+                backend,
+                Some(component_id.clone()),
+                "component",
+                direct.map(|value| value.component_bytes()),
+                replayed.map(|value| value.component_bytes()),
+            ));
+        }
+        if direct.map(|value| value.state_bytes()) != replayed.map(|value| value.state_bytes()) {
+            candidates.push(difference(
+                backend,
+                Some(component_id.clone()),
+                "state",
+                direct.map(|value| value.state_bytes()),
+                replayed.map(|value| value.state_bytes()),
+            ));
+        }
+        if candidates.len() != component_difference_start {
+            affected_backends.insert(backend);
+            affected_component_ids.insert(component_id);
+        }
+    }
+}
+
+fn collect_token_differences(
+    direct: &CanonicalState,
+    replayed: &CanonicalState,
+    requested_backends: &[Backend],
+    candidates: &mut Vec<ConsistencyDifference>,
+    affected_backends: &mut BTreeSet<Backend>,
+) {
+    let direct_tokens = direct
+        .tokens()
+        .iter()
+        .map(|token| (token.address.clone(), token.token_bytes()))
+        .collect::<BTreeMap<_, _>>();
+    let replayed_tokens = replayed
+        .tokens()
+        .iter()
+        .map(|token| (token.address.clone(), token.token_bytes()))
+        .collect::<BTreeMap<_, _>>();
+    let token_keys = direct_tokens
+        .keys()
+        .chain(replayed_tokens.keys())
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    for address in token_keys {
+        let direct = direct_tokens.get(&address).copied();
+        let replayed = replayed_tokens.get(&address).copied();
+        if direct != replayed {
+            for backend in requested_backends {
+                candidates.push(difference(
+                    *backend,
+                    None,
+                    &format!("token:{address}"),
+                    direct,
+                    replayed,
+                ));
+                affected_backends.insert(*backend);
+            }
+        }
+    }
+}
+
+fn difference(
+    backend: Backend,
+    component_id: Option<String>,
+    field: &str,
+    direct: Option<&[u8]>,
+    replayed: Option<&[u8]>,
+) -> ConsistencyDifference {
+    ConsistencyDifference {
+        backend,
+        component_id,
+        field: field.to_owned(),
+        direct_sha256: direct.map(digest),
+        replayed_sha256: replayed.map(digest),
+    }
+}
+
+fn digest(bytes: &[u8]) -> String {
+    format!("sha256:{:x}", Sha256::digest(bytes))
+}
+
+fn public_replay_backend(backend: simulator_replay::ReplayBackend) -> Backend {
+    match backend {
+        simulator_replay::ReplayBackend::Native => Backend::Native,
+        simulator_replay::ReplayBackend::Vm => Backend::Vm,
+        simulator_replay::ReplayBackend::Rfq => Backend::Rfq,
+    }
+}

--- a/crates/historical-quote/src/coverage.rs
+++ b/crates/historical-quote/src/coverage.rs
@@ -1,0 +1,90 @@
+use std::sync::Arc;
+
+use state_history::{BlockInterval, CoverageQuery, RangeGap, RangeGapKind};
+
+use crate::api::{BlockBounds, CoverageRequest, CoverageResponse, GapCause, GapKind, KnownGap};
+use crate::replay::{history_backend, public_position};
+use crate::{HistoricalError, HistorySource};
+
+pub struct CoverageService<S> {
+    source: Arc<S>,
+}
+
+impl<S> CoverageService<S> {
+    pub fn new(source: Arc<S>) -> Self {
+        Self { source }
+    }
+}
+
+impl<S: HistorySource> CoverageService<S> {
+    pub async fn resolve(
+        &self,
+        request: &CoverageRequest,
+    ) -> Result<CoverageResponse, HistoricalError> {
+        let mut backends = request.backends.clone();
+        backends.sort_unstable();
+        let bounds = request
+            .bounds
+            .map(|bounds| BlockInterval::new(bounds.start, bounds.end_inclusive))
+            .transpose()
+            .map_err(|error| HistoricalError::InvalidSelector(error.to_string()))?;
+        let query = CoverageQuery::new(
+            request.chain_id,
+            backends.iter().copied().map(history_backend).collect(),
+            bounds,
+        )
+        .map_err(|error| HistoricalError::InvalidSelector(error.to_string()))?;
+        let snapshot = self.source.coverage(query).await?;
+        Ok(CoverageResponse {
+            api_revision: request.api_revision,
+            chain_id: request.chain_id,
+            backends,
+            visible_through_block: snapshot.visible_through_block,
+            continuous_intervals: snapshot
+                .continuous_intervals
+                .into_iter()
+                .map(|interval| BlockBounds {
+                    start: interval.start,
+                    end_inclusive: interval.end_inclusive,
+                })
+                .collect(),
+            known_gaps: snapshot
+                .known_gaps
+                .iter()
+                .map(known_gap)
+                .collect::<Result<Vec<_>, _>>()?,
+        })
+    }
+}
+
+fn known_gap(gap: &RangeGap) -> Result<KnownGap, HistoricalError> {
+    Ok(KnownGap {
+        kind: match gap.kind {
+            RangeGapKind::MissingCheckpoint => GapKind::MissingCheckpoint,
+            RangeGapKind::Recorded => GapKind::Recorded,
+            RangeGapKind::IncompleteTail => GapKind::IncompleteTail,
+        },
+        cause: (gap.kind == RangeGapKind::Recorded)
+            .then(|| gap_cause(&gap.reason))
+            .transpose()?,
+        from_position: gap.from_position.map(public_position),
+        to_position: gap.to_position.map(public_position),
+        from_block: gap.from_block,
+        to_block_inclusive: gap.to_block_inclusive,
+        from_observed_at_ms: gap.from_observed_at_ms,
+        to_observed_at_ms: gap.to_observed_at_ms,
+    })
+}
+
+fn gap_cause(reason: &str) -> Result<GapCause, HistoricalError> {
+    match reason {
+        "queue_overflow" => Ok(GapCause::QueueOverflow),
+        "write_failed" => Ok(GapCause::WriteFailed),
+        "writer_stopped" => Ok(GapCause::WriterStopped),
+        "checkpoint_failed" => Ok(GapCause::CheckpointFailed),
+        "boundary_slip" => Ok(GapCause::BoundarySlip),
+        other => Err(HistoricalError::HistoricalDataInvalid(format!(
+            "unknown recorded gap cause {other}"
+        ))),
+    }
+}

--- a/crates/historical-quote/src/error.rs
+++ b/crates/historical-quote/src/error.rs
@@ -1,0 +1,30 @@
+use anyhow::Error as AnyError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum HistoricalError {
+    #[error("historical work was cancelled")]
+    Cancelled,
+    #[error("historical state read failed during {operation}")]
+    HistoryRead {
+        operation: &'static str,
+        #[source]
+        source: AnyError,
+    },
+    #[error("retained historical data is invalid: {0}")]
+    HistoricalDataInvalid(String),
+    #[error("historical state reconstruction failed: {0}")]
+    StateReconstructionFailed(String),
+    #[error("historical request selector is invalid: {0}")]
+    InvalidSelector(String),
+    #[error("canonical VM comparison is unsupported")]
+    UnsupportedCanonicalVm,
+}
+
+impl HistoricalError {
+    pub(crate) fn history_read(operation: &'static str, source: impl Into<AnyError>) -> Self {
+        Self::HistoryRead {
+            operation,
+            source: source.into(),
+        }
+    }
+}

--- a/crates/historical-quote/src/history.rs
+++ b/crates/historical-quote/src/history.rs
@@ -1,0 +1,110 @@
+use std::future::Future;
+
+use state_history::{
+    CheckpointArchive, CheckpointManifest, CheckpointPairQuery, CheckpointPairReplayPlan,
+    CoverageQuery, CoverageSnapshot, RawTokenSnapshot, ReadConnectionProvider, ReadLimits,
+    StateHistoryReader, TargetPlan, TargetPlanQuery,
+};
+
+use crate::HistoricalError;
+
+pub trait EngineProgress: Send + Sync {
+    fn quote_comparison_completed(&self) {}
+
+    fn checkpoint_pair_completed(&self) {}
+}
+
+impl EngineProgress for () {}
+
+pub trait HistorySource: Send + Sync + 'static {
+    fn plan_targets(
+        &self,
+        query: TargetPlanQuery,
+    ) -> impl Future<Output = Result<TargetPlan, HistoricalError>> + Send;
+
+    fn coverage(
+        &self,
+        query: CoverageQuery,
+    ) -> impl Future<Output = Result<CoverageSnapshot, HistoricalError>> + Send;
+
+    fn fetch_checkpoint(
+        &self,
+        manifest: CheckpointManifest,
+        limits: ReadLimits,
+    ) -> impl Future<Output = Result<CheckpointArchive, HistoricalError>> + Send;
+
+    fn fetch_checkpoint_token_snapshot(
+        &self,
+        manifest: CheckpointManifest,
+        limits: ReadLimits,
+    ) -> impl Future<Output = Result<Option<RawTokenSnapshot>, HistoricalError>> + Send;
+
+    fn resolve_checkpoint_pairs(
+        &self,
+        query: CheckpointPairQuery,
+    ) -> impl Future<Output = Result<Vec<state_history::CheckpointPair>, HistoricalError>> + Send;
+
+    fn plan_checkpoint_pair(
+        &self,
+        pair: state_history::CheckpointPair,
+        backends: Vec<state_history::Backend>,
+        limits: ReadLimits,
+    ) -> impl Future<Output = Result<CheckpointPairReplayPlan, HistoricalError>> + Send;
+}
+
+impl<P> HistorySource for StateHistoryReader<P>
+where
+    P: ReadConnectionProvider,
+{
+    async fn plan_targets(&self, query: TargetPlanQuery) -> Result<TargetPlan, HistoricalError> {
+        StateHistoryReader::plan_targets(self, &query)
+            .await
+            .map_err(|error| HistoricalError::history_read("target planning", error))
+    }
+
+    async fn coverage(&self, query: CoverageQuery) -> Result<CoverageSnapshot, HistoricalError> {
+        StateHistoryReader::coverage(self, &query)
+            .await
+            .map_err(|error| HistoricalError::history_read("coverage resolution", error))
+    }
+
+    async fn fetch_checkpoint(
+        &self,
+        manifest: CheckpointManifest,
+        limits: ReadLimits,
+    ) -> Result<CheckpointArchive, HistoricalError> {
+        StateHistoryReader::fetch_checkpoint_with_limit(self, &manifest, limits)
+            .await
+            .map_err(|error| HistoricalError::history_read("checkpoint fetch", error))
+    }
+
+    async fn fetch_checkpoint_token_snapshot(
+        &self,
+        manifest: CheckpointManifest,
+        limits: ReadLimits,
+    ) -> Result<Option<RawTokenSnapshot>, HistoricalError> {
+        StateHistoryReader::fetch_checkpoint_token_snapshot_with_limit(self, &manifest, limits)
+            .await
+            .map_err(|error| HistoricalError::history_read("token snapshot fetch", error))
+    }
+
+    async fn resolve_checkpoint_pairs(
+        &self,
+        query: CheckpointPairQuery,
+    ) -> Result<Vec<state_history::CheckpointPair>, HistoricalError> {
+        StateHistoryReader::resolve_checkpoint_pairs(self, &query)
+            .await
+            .map_err(|error| HistoricalError::history_read("checkpoint pair resolution", error))
+    }
+
+    async fn plan_checkpoint_pair(
+        &self,
+        pair: state_history::CheckpointPair,
+        backends: Vec<state_history::Backend>,
+        limits: ReadLimits,
+    ) -> Result<CheckpointPairReplayPlan, HistoricalError> {
+        StateHistoryReader::plan_checkpoint_pair(self, &pair, backends, limits)
+            .await
+            .map_err(|error| HistoricalError::history_read("checkpoint pair planning", error))
+    }
+}

--- a/crates/historical-quote/src/lib.rs
+++ b/crates/historical-quote/src/lib.rs
@@ -2,3 +2,32 @@
 
 pub mod api;
 pub mod openapi;
+
+#[cfg(feature = "engine")]
+mod consistency;
+#[cfg(feature = "engine")]
+mod coverage;
+#[cfg(feature = "engine")]
+mod error;
+#[cfg(feature = "engine")]
+mod history;
+#[cfg(feature = "engine")]
+mod quote_job;
+#[cfg(feature = "engine")]
+mod replay;
+
+#[cfg(feature = "engine")]
+pub use consistency::ConsistencyChecker;
+#[cfg(feature = "engine")]
+pub use coverage::CoverageService;
+#[cfg(feature = "engine")]
+pub use error::HistoricalError;
+#[cfg(feature = "engine")]
+pub use history::{EngineProgress, HistorySource};
+#[cfg(feature = "engine")]
+pub use quote_job::HistoricalQuoteExecutor;
+#[cfg(feature = "engine")]
+pub use replay::{
+    HistoricalReconstructor, ReconstructedState, ReconstructedTimeline, ReconstructionRequest,
+    StateProvenance, UnavailableState,
+};

--- a/crates/historical-quote/src/quote_job.rs
+++ b/crates/historical-quote/src/quote_job.rs
@@ -1,0 +1,274 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::str::FromStr;
+
+use alloy_primitives::U256;
+use simulator_replay::{ExactPoolQuote, ReplayQuoteError};
+use tokio_util::sync::CancellationToken;
+use tycho_simulation::tycho_common::Bytes;
+
+use crate::api::{
+    normalize_quote_request, HistoricalQuoteEntry, HistoricalQuoteResult, HistoricalQuoteTarget,
+    PoolSelector, QuoteFailureReason, QuoteJobRequest, QuoteOutcome, QuoteProvenance,
+    UnavailableReason, UnsignedAmount,
+};
+use crate::replay::{
+    check_cancelled, gap_affects_interval, history_position, replay_backend,
+    HistoricalReconstructor, ReconstructedState, ReconstructedTimeline, ReconstructionRequest,
+};
+use crate::{EngineProgress, HistoricalError, HistorySource};
+
+pub struct HistoricalQuoteExecutor<S> {
+    reconstructor: HistoricalReconstructor<S>,
+    service_revision: String,
+}
+
+impl<S> HistoricalQuoteExecutor<S> {
+    pub fn new(
+        reconstructor: HistoricalReconstructor<S>,
+        service_revision: impl Into<String>,
+    ) -> Self {
+        Self {
+            reconstructor,
+            service_revision: service_revision.into(),
+        }
+    }
+}
+
+impl<S: HistorySource> HistoricalQuoteExecutor<S> {
+    pub async fn execute(
+        &self,
+        request: &QuoteJobRequest,
+        cancellation: &CancellationToken,
+        progress: &impl EngineProgress,
+    ) -> Result<HistoricalQuoteResult, HistoricalError> {
+        let normalized = normalize_quote_request(request);
+        let start_blocks = normalized.blocks.start_blocks().collect::<Vec<_>>();
+        let mut required_blocks = start_blocks.iter().copied().collect::<BTreeSet<_>>();
+        for start in &start_blocks {
+            for lag in &normalized.lags {
+                required_blocks.insert(start.checked_add(*lag).ok_or_else(|| {
+                    HistoricalError::InvalidSelector(
+                        "start block plus lag exceeds the block number range".to_owned(),
+                    )
+                })?);
+            }
+        }
+        let timeline = self
+            .reconstructor
+            .reconstruct(
+                &ReconstructionRequest {
+                    chain_id: normalized.chain_id,
+                    backends: BTreeSet::from([normalized.pool.backend]),
+                    required_blocks,
+                },
+                cancellation,
+            )
+            .await?;
+        let mut quote_cache = BTreeMap::new();
+        let mut results = Vec::with_capacity(start_blocks.len() * normalized.amounts_in.len());
+        for start_block in start_blocks {
+            for amount_in in &normalized.amounts_in {
+                check_cancelled(cancellation)?;
+                let start_outcome = quote_at(
+                    &timeline,
+                    start_block,
+                    amount_in,
+                    &normalized.pool,
+                    &self.service_revision,
+                    &mut quote_cache,
+                );
+                let start_state_available =
+                    timeline.states.get(&start_block).is_some_and(Result::is_ok);
+                let mut targets = Vec::with_capacity(normalized.lags.len());
+                for lag in &normalized.lags {
+                    check_cancelled(cancellation)?;
+                    let target_block = start_block.checked_add(*lag).ok_or_else(|| {
+                        HistoricalError::InvalidSelector(
+                            "start block plus lag exceeds the block number range".to_owned(),
+                        )
+                    })?;
+                    let outcome = if !start_state_available {
+                        unavailable_from_start(&timeline, start_block)
+                    } else if let Some(gap_refs) =
+                        relative_gap_refs(&timeline, start_block, target_block)
+                    {
+                        QuoteOutcome::Unavailable {
+                            reason: UnavailableReason::Gap,
+                            gap_refs,
+                        }
+                    } else {
+                        quote_at(
+                            &timeline,
+                            target_block,
+                            amount_in,
+                            &normalized.pool,
+                            &self.service_revision,
+                            &mut quote_cache,
+                        )
+                    };
+                    targets.push(HistoricalQuoteTarget {
+                        lag: *lag,
+                        target_block,
+                        outcome,
+                    });
+                    progress.quote_comparison_completed();
+                }
+                results.push(HistoricalQuoteEntry {
+                    start_block,
+                    amount_in: amount_in.clone(),
+                    start_outcome,
+                    targets,
+                });
+            }
+        }
+        Ok(HistoricalQuoteResult {
+            request_id: request.request_id,
+            chain_id: request.chain_id,
+            pool: request.pool.clone(),
+            visible_through_block: timeline.visible_through_block,
+            gaps: timeline.gaps,
+            results,
+        })
+    }
+}
+
+fn quote_at(
+    timeline: &ReconstructedTimeline,
+    block: u64,
+    amount_in: &UnsignedAmount,
+    pool: &PoolSelector,
+    service_revision: &str,
+    cache: &mut BTreeMap<(u64, UnsignedAmount), QuoteOutcome>,
+) -> QuoteOutcome {
+    let key = (block, amount_in.clone());
+    if let Some(outcome) = cache.get(&key) {
+        return outcome.clone();
+    }
+    let outcome = match timeline.states.get(&block) {
+        Some(Ok(state)) => quote_state(state, amount_in, pool, service_revision),
+        Some(Err(unavailable)) => QuoteOutcome::Unavailable {
+            reason: unavailable.reason,
+            gap_refs: unavailable.gap_refs.clone(),
+        },
+        None => QuoteOutcome::Unavailable {
+            reason: UnavailableReason::StateApplicationInvalid,
+            gap_refs: Vec::new(),
+        },
+    };
+    cache.insert(key, outcome.clone());
+    outcome
+}
+
+fn quote_state(
+    state: &ReconstructedState,
+    amount_in: &UnsignedAmount,
+    pool: &PoolSelector,
+    service_revision: &str,
+) -> QuoteOutcome {
+    let Ok(token_in) = Bytes::from_str(&pool.token_in) else {
+        return QuoteOutcome::QuoteFailed {
+            reason: QuoteFailureReason::DirectionUnsupported,
+        };
+    };
+    let Ok(token_out) = Bytes::from_str(&pool.token_out) else {
+        return QuoteOutcome::QuoteFailed {
+            reason: QuoteFailureReason::DirectionUnsupported,
+        };
+    };
+    let Ok(amount) = U256::from_str_radix(amount_in.as_str(), 10) else {
+        return QuoteOutcome::QuoteFailed {
+            reason: QuoteFailureReason::SimulationFailed,
+        };
+    };
+    match state.point.quote(&ExactPoolQuote {
+        backend: replay_backend(pool.backend),
+        protocol: pool.protocol.clone(),
+        component_id: pool.component_id.clone(),
+        token_in,
+        token_out,
+        amount_in: amount,
+    }) {
+        Ok(amount_out) => {
+            let Ok(amount_out) = amount_out.to_string().parse() else {
+                return QuoteOutcome::QuoteFailed {
+                    reason: QuoteFailureReason::SimulationFailed,
+                };
+            };
+            QuoteOutcome::Ok {
+                amount_out,
+                provenance: QuoteProvenance {
+                    block_hash: state.provenance.block_hash.clone(),
+                    final_position: state.provenance.final_position,
+                    anchor_checkpoint_position: state.provenance.anchor_checkpoint_position,
+                    token_snapshot_digest: state.provenance.token_snapshot_digest.clone(),
+                    service_revision: service_revision.to_owned(),
+                    rfq_observation_cursor: state.provenance.rfq_observation_cursor,
+                    rfq_observed_at: state.provenance.rfq_observed_at,
+                    rfq_observation_age_ms: state.provenance.rfq_observation_age_ms,
+                },
+            }
+        }
+        Err(error) => QuoteOutcome::QuoteFailed {
+            reason: quote_failure_reason(&error),
+        },
+    }
+}
+
+pub(crate) fn quote_failure_reason(error: &ReplayQuoteError) -> QuoteFailureReason {
+    match error {
+        ReplayQuoteError::ComponentNotFound(_) => QuoteFailureReason::ComponentNotFound,
+        ReplayQuoteError::BackendMismatch { .. }
+        | ReplayQuoteError::ProtocolMismatch { .. }
+        | ReplayQuoteError::DirectionUnsupported(_)
+        | ReplayQuoteError::TokenMissing(_) => QuoteFailureReason::DirectionUnsupported,
+        ReplayQuoteError::ZeroOutput => QuoteFailureReason::ZeroOutput,
+        ReplayQuoteError::SimulationFailed(message)
+            if message.to_ascii_lowercase().contains("insufficient") =>
+        {
+            QuoteFailureReason::InsufficientLiquidity
+        }
+        ReplayQuoteError::SimulationFailed(_)
+        | ReplayQuoteError::SimulationPanicked(_)
+        | ReplayQuoteError::AmountOverflow => QuoteFailureReason::SimulationFailed,
+    }
+}
+
+fn unavailable_from_start(timeline: &ReconstructedTimeline, start_block: u64) -> QuoteOutcome {
+    match timeline.states.get(&start_block) {
+        Some(Err(unavailable)) => QuoteOutcome::Unavailable {
+            reason: unavailable.reason,
+            gap_refs: unavailable.gap_refs.clone(),
+        },
+        _ => QuoteOutcome::Unavailable {
+            reason: UnavailableReason::StateApplicationInvalid,
+            gap_refs: Vec::new(),
+        },
+    }
+}
+
+fn relative_gap_refs(
+    timeline: &ReconstructedTimeline,
+    start_block: u64,
+    target_block: u64,
+) -> Option<Vec<String>> {
+    let start = timeline.states.get(&start_block)?.as_ref().ok()?;
+    let target = timeline.states.get(&target_block)?.as_ref().ok()?;
+    let gap_refs = timeline
+        .range_gaps
+        .iter()
+        .enumerate()
+        .filter(|(_, gap)| {
+            gap_affects_interval(
+                gap,
+                history_position(start.provenance.final_position),
+                history_position(target.provenance.final_position),
+                start_block,
+                target_block,
+                timeline.block_boundaries_ms.get(&start_block).copied(),
+                timeline.block_boundaries_ms.get(&target_block).copied(),
+            )
+        })
+        .map(|(index, _)| format!("gap-{}", index + 1))
+        .collect::<Vec<_>>();
+    (!gap_refs.is_empty()).then_some(gap_refs)
+}

--- a/crates/historical-quote/src/replay.rs
+++ b/crates/historical-quote/src/replay.rs
@@ -1,0 +1,726 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use simulator_replay::{
+    acquire_vm_world_lease, decode_token_map, DecoderConfig, ReplayBackend, ReplayDecoder,
+    ReplayWorld, StatePoint, VmWorldLease,
+};
+use state_history::{
+    Backend as HistoryBackend, BlockInterval, CheckpointManifest, RangeGap, RangeGapKind, RangeLeg,
+    ReadLimits, StoredDelta, StreamPosition as HistoryPosition, TargetPlan, TargetPlanQuery,
+};
+use tokio_util::sync::CancellationToken;
+
+use crate::api::{Backend, GapCause, GapKind, GapReference, StreamPosition, UnavailableReason};
+use crate::{HistoricalError, HistorySource};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReconstructionRequest {
+    pub chain_id: u64,
+    pub backends: BTreeSet<Backend>,
+    pub required_blocks: BTreeSet<u64>,
+}
+
+pub struct ReconstructedTimeline {
+    pub visible_through_block: u64,
+    pub states: BTreeMap<u64, Result<ReconstructedState, UnavailableState>>,
+    pub gaps: Vec<GapReference>,
+    pub estimated_decoded_bytes: u64,
+    pub(crate) range_gaps: Vec<RangeGap>,
+    pub(crate) block_boundaries_ms: BTreeMap<u64, u64>,
+    _vm_lease: Option<VmWorldLease>,
+}
+
+#[derive(Clone)]
+pub struct ReconstructedState {
+    pub point: StatePoint,
+    pub provenance: StateProvenance,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StateProvenance {
+    pub block_hash: String,
+    pub final_position: StreamPosition,
+    pub anchor_checkpoint_position: StreamPosition,
+    pub token_snapshot_digest: Option<String>,
+    pub rfq_observation_cursor: Option<StreamPosition>,
+    pub rfq_observed_at: Option<DateTime<Utc>>,
+    pub rfq_observation_age_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnavailableState {
+    pub reason: UnavailableReason,
+    pub gap_refs: Vec<String>,
+}
+
+pub struct HistoricalReconstructor<S> {
+    source: Arc<S>,
+    read_limits: ReadLimits,
+}
+
+impl<S> HistoricalReconstructor<S> {
+    pub fn new(source: Arc<S>, read_limits: ReadLimits) -> Self {
+        Self {
+            source,
+            read_limits,
+        }
+    }
+}
+
+impl<S: HistorySource> HistoricalReconstructor<S> {
+    pub async fn reconstruct(
+        &self,
+        request: &ReconstructionRequest,
+        cancellation: &CancellationToken,
+    ) -> Result<ReconstructedTimeline, HistoricalError> {
+        check_cancelled(cancellation)?;
+        let history_backends = request
+            .backends
+            .iter()
+            .copied()
+            .map(history_backend)
+            .collect::<Vec<_>>();
+        let query = TargetPlanQuery::new(
+            request.chain_id,
+            history_backends,
+            request.required_blocks.clone(),
+            self.read_limits,
+        )
+        .map_err(|error| HistoricalError::InvalidSelector(error.to_string()))?;
+        let plan = self.source.plan_targets(query).await?;
+        check_cancelled(cancellation)?;
+        let vm_lease = if request.backends.contains(&Backend::Vm) {
+            Some(acquire_vm_world_lease().await)
+        } else {
+            None
+        };
+        let mut timeline = self.reconstruct_plan(request, plan, cancellation).await?;
+        timeline._vm_lease = vm_lease;
+        Ok(timeline)
+    }
+
+    async fn reconstruct_plan(
+        &self,
+        request: &ReconstructionRequest,
+        plan: TargetPlan,
+        cancellation: &CancellationToken,
+    ) -> Result<ReconstructedTimeline, HistoricalError> {
+        let gaps = plan
+            .gaps
+            .iter()
+            .enumerate()
+            .map(|(index, gap)| public_gap(index, gap))
+            .collect::<Result<Vec<_>, _>>()?;
+        let mut states = early_unavailable_states(request, &plan);
+        let mut assigned = vec![Vec::new(); plan.legs.len()];
+        for block in &request.required_blocks {
+            if states.contains_key(block) {
+                continue;
+            }
+            if let Some(index) = leg_for_block(&plan, &request.backends, *block) {
+                assigned[index].push(*block);
+            }
+        }
+
+        for (index, leg) in plan.legs.iter().enumerate() {
+            if assigned[index].is_empty() {
+                continue;
+            }
+            for (block, state) in self
+                .reconstruct_leg(request, &plan, leg, &assigned[index], cancellation)
+                .await?
+            {
+                states.insert(block, state);
+            }
+        }
+
+        for block in &request.required_blocks {
+            states.entry(*block).or_insert_with(|| {
+                let gap_refs = matching_gap_refs(&plan.gaps, *block);
+                Err(UnavailableState {
+                    reason: if gap_refs.is_empty() {
+                        if request.backends.contains(&Backend::Rfq) {
+                            UnavailableReason::RfqObservationMissing
+                        } else {
+                            UnavailableReason::StateApplicationInvalid
+                        }
+                    } else {
+                        UnavailableReason::Gap
+                    },
+                    gap_refs,
+                })
+            });
+        }
+        Ok(ReconstructedTimeline {
+            visible_through_block: plan.visible_through_block,
+            states,
+            gaps,
+            estimated_decoded_bytes: plan.estimated_decoded_bytes,
+            range_gaps: plan.gaps,
+            block_boundaries_ms: request
+                .required_blocks
+                .iter()
+                .filter_map(|block| {
+                    block.checked_add(1).and_then(|next| {
+                        plan.block_times
+                            .get(&next)
+                            .map(|observation| (*block, observation.timestamp_ms))
+                    })
+                })
+                .collect(),
+            _vm_lease: None,
+        })
+    }
+
+    async fn reconstruct_leg(
+        &self,
+        request: &ReconstructionRequest,
+        plan: &TargetPlan,
+        leg: &RangeLeg,
+        blocks: &[u64],
+        cancellation: &CancellationToken,
+    ) -> Result<Vec<(u64, Result<ReconstructedState, UnavailableState>)>, HistoricalError> {
+        check_cancelled(cancellation)?;
+        let restored = restore_checkpoint(
+            self.source.as_ref(),
+            &leg.checkpoint,
+            &request.backends,
+            self.read_limits,
+            cancellation,
+        )
+        .await?;
+        let Some(mut restored) = restored else {
+            return Ok(blocks
+                .iter()
+                .map(|block| {
+                    (
+                        *block,
+                        Err(unavailable(UnavailableReason::TokenSnapshotMissing)),
+                    )
+                })
+                .collect());
+        };
+        let mut applied = BTreeSet::new();
+        let mut application_invalid = restored.checkpoint_application_invalid;
+        let mut blocks = blocks.to_vec();
+        blocks.sort_unstable();
+        let mut states = Vec::with_capacity(blocks.len());
+        for block in blocks {
+            check_cancelled(cancellation)?;
+            let next_block_timestamp = block
+                .checked_add(1)
+                .and_then(|next| plan.block_times.get(&next))
+                .map(|observation| observation.timestamp_ms);
+            let mut application = DeltaApplication {
+                backends: &request.backends,
+                target_block: block,
+                next_block_timestamp,
+                applied: &mut applied,
+                application_invalid: &mut application_invalid,
+                cancellation,
+            };
+            apply_deltas_through(&mut restored, &leg.deltas, &mut application).await?;
+            states.push((
+                block,
+                reconstructed_state(
+                    request,
+                    plan,
+                    &restored,
+                    block,
+                    next_block_timestamp,
+                    application_invalid,
+                )?,
+            ));
+        }
+        Ok(states)
+    }
+}
+
+pub(crate) struct RestoredWorld {
+    pub(crate) world: ReplayWorld,
+    pub(crate) decoder: ReplayDecoder,
+    pub(crate) final_position: HistoryPosition,
+    pub(crate) anchor_checkpoint_position: HistoryPosition,
+    pub(crate) anchor_block: u64,
+    pub(crate) token_snapshot_digest: Option<String>,
+    pub(crate) anchor_rfq_observed_at_ms: Option<u64>,
+    pub(crate) rfq_observed_at_ms: Option<u64>,
+    pub(crate) rfq_observation_position: Option<HistoryPosition>,
+    pub(crate) checkpoint_application_invalid: bool,
+}
+
+pub(crate) async fn restore_checkpoint<S: HistorySource>(
+    source: &S,
+    manifest: &CheckpointManifest,
+    backends: &BTreeSet<Backend>,
+    limits: ReadLimits,
+    cancellation: &CancellationToken,
+) -> Result<Option<RestoredWorld>, HistoricalError> {
+    check_cancelled(cancellation)?;
+    let needs_tokens = backends
+        .iter()
+        .any(|backend| matches!(backend, Backend::Native | Backend::Vm));
+    let (tokens, token_snapshot_digest) = if needs_tokens {
+        if manifest.token_reference.is_none() {
+            return Ok(None);
+        }
+        let snapshot = source
+            .fetch_checkpoint_token_snapshot(manifest.clone(), limits)
+            .await?
+            .ok_or_else(|| {
+                HistoricalError::HistoricalDataInvalid(
+                    "checkpoint token reference resolved without a token snapshot".to_owned(),
+                )
+            })?;
+        let tokens = decode_token_map(snapshot.chain_id, snapshot.tokens.as_ref())
+            .map_err(|error| HistoricalError::HistoricalDataInvalid(error.to_string()))?;
+        let digest = manifest
+            .token_reference
+            .as_ref()
+            .map(|reference| format!("sha256:{}", reference.sha256));
+        (tokens, digest)
+    } else {
+        (simulator_replay::TokenMap::new(), None)
+    };
+    check_cancelled(cancellation)?;
+    let archive = source.fetch_checkpoint(manifest.clone(), limits).await?;
+    let decoder = ReplayDecoder::new(DecoderConfig::retained_v1(), tokens.clone())
+        .await
+        .map_err(|error| HistoricalError::HistoricalDataInvalid(error.to_string()))?;
+    let replay_backends = backends
+        .iter()
+        .copied()
+        .map(replay_backend)
+        .collect::<Vec<_>>();
+    let decoded = decoder
+        .decode_checkpoint_payloads(&archive.payloads_json, &replay_backends)
+        .await
+        .map_err(|error| HistoricalError::HistoricalDataInvalid(error.to_string()))?;
+    let update = decoded.update.ok_or_else(|| {
+        HistoricalError::HistoricalDataInvalid(
+            "checkpoint contains no state for the selected backends".to_owned(),
+        )
+    })?;
+    let mut world = ReplayWorld::new(tokens, None);
+    let report = world.restore(update);
+    Ok(Some(RestoredWorld {
+        world,
+        decoder,
+        final_position: manifest.position,
+        anchor_checkpoint_position: manifest.position,
+        anchor_block: manifest.block_number,
+        token_snapshot_digest,
+        anchor_rfq_observed_at_ms: manifest.rfq_observed_at_ms,
+        rfq_observed_at_ms: manifest.rfq_observed_at_ms,
+        rfq_observation_position: manifest.rfq_observed_at_ms.map(|_| manifest.position),
+        checkpoint_application_invalid: report.has_anomalies(),
+    }))
+}
+
+pub(crate) async fn apply_all_pair_deltas(
+    restored: &mut RestoredWorld,
+    deltas: &[StoredDelta],
+    backends: &BTreeSet<Backend>,
+    cancellation: &CancellationToken,
+) -> Result<bool, HistoricalError> {
+    let mut invalid = restored.checkpoint_application_invalid;
+    for delta in deltas {
+        check_cancelled(cancellation)?;
+        let replay_backends = delta
+            .applicable_backends
+            .iter()
+            .filter_map(|cursor| {
+                let backend = public_backend(cursor.backend);
+                backends
+                    .contains(&backend)
+                    .then_some(replay_backend(backend))
+            })
+            .collect::<Vec<_>>();
+        if replay_backends.is_empty() {
+            continue;
+        }
+        let decoded = restored
+            .decoder
+            .decode_delta(
+                delta.payload_format_version,
+                delta.raw_payload.as_ref(),
+                &replay_backends,
+            )
+            .await
+            .map_err(|error| HistoricalError::HistoricalDataInvalid(error.to_string()))?;
+        if let Some(update) = decoded.update {
+            invalid |= restored.world.apply(update).has_anomalies();
+        }
+        if decoded.had_applicable_partition {
+            restored.final_position = delta.position;
+        }
+    }
+    Ok(invalid)
+}
+
+struct DeltaApplication<'a> {
+    backends: &'a BTreeSet<Backend>,
+    target_block: u64,
+    next_block_timestamp: Option<u64>,
+    applied: &'a mut BTreeSet<(HistoryPosition, Backend)>,
+    application_invalid: &'a mut bool,
+    cancellation: &'a CancellationToken,
+}
+
+async fn apply_deltas_through(
+    restored: &mut RestoredWorld,
+    deltas: &[StoredDelta],
+    application: &mut DeltaApplication<'_>,
+) -> Result<(), HistoricalError> {
+    for delta in deltas {
+        check_cancelled(application.cancellation)?;
+        let eligible = delta
+            .applicable_backends
+            .iter()
+            .filter_map(|cursor| {
+                let backend = public_backend(cursor.backend);
+                if !application.backends.contains(&backend)
+                    || application.applied.contains(&(delta.position, backend))
+                {
+                    return None;
+                }
+                let ready = match backend {
+                    Backend::Native | Backend::Vm => cursor
+                        .block_number
+                        .is_some_and(|block| block <= application.target_block),
+                    Backend::Rfq => application.next_block_timestamp.is_some_and(|boundary| {
+                        cursor.observed_at_ms.is_some_and(|observed| {
+                            observed < boundary
+                                && restored
+                                    .rfq_observed_at_ms
+                                    .is_none_or(|selected| observed >= selected)
+                        })
+                    }),
+                };
+                ready.then_some((backend, cursor.observed_at_ms))
+            })
+            .collect::<Vec<_>>();
+        if eligible.is_empty() {
+            continue;
+        }
+        let replay_backends = eligible
+            .iter()
+            .map(|(backend, _)| replay_backend(*backend))
+            .collect::<Vec<_>>();
+        let decoded = restored
+            .decoder
+            .decode_delta(
+                delta.payload_format_version,
+                delta.raw_payload.as_ref(),
+                &replay_backends,
+            )
+            .await
+            .map_err(|error| HistoricalError::HistoricalDataInvalid(error.to_string()))?;
+        if let Some(update) = decoded.update {
+            *application.application_invalid |= restored.world.apply(update).has_anomalies();
+        }
+        if decoded.had_applicable_partition {
+            restored.final_position = delta.position;
+            for (backend, observed_at_ms) in eligible {
+                application.applied.insert((delta.position, backend));
+                if backend == Backend::Rfq {
+                    restored.rfq_observed_at_ms = observed_at_ms;
+                    restored.rfq_observation_position = Some(delta.position);
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn reconstructed_state(
+    request: &ReconstructionRequest,
+    plan: &TargetPlan,
+    restored: &RestoredWorld,
+    block: u64,
+    next_block_timestamp: Option<u64>,
+    application_invalid: bool,
+) -> Result<Result<ReconstructedState, UnavailableState>, HistoricalError> {
+    if application_invalid {
+        return Ok(Err(unavailable(UnavailableReason::StateApplicationInvalid)));
+    }
+    let gap_refs = state_gap_refs(&plan.gaps, restored, block, next_block_timestamp);
+    if !gap_refs.is_empty() {
+        return Ok(Err(UnavailableState {
+            reason: UnavailableReason::Gap,
+            gap_refs,
+        }));
+    }
+    if request.backends.contains(&Backend::Rfq) && restored.rfq_observed_at_ms.is_none() {
+        return Ok(Err(unavailable(UnavailableReason::RfqObservationMissing)));
+    }
+    let observation = plan.block_times.get(&block).ok_or_else(|| {
+        HistoricalError::HistoricalDataInvalid(format!("block {block} lost its planned metadata"))
+    })?;
+    let block_hash = observation.block_hash.clone().ok_or_else(|| {
+        HistoricalError::HistoricalDataInvalid(format!("block {block} has no canonical hash"))
+    })?;
+    let (rfq_observed_at, rfq_observation_age_ms) = rfq_provenance(restored, next_block_timestamp)?;
+    Ok(Ok(ReconstructedState {
+        point: restored.world.pin(),
+        provenance: StateProvenance {
+            block_hash,
+            final_position: public_position(restored.final_position),
+            anchor_checkpoint_position: public_position(restored.anchor_checkpoint_position),
+            token_snapshot_digest: restored.token_snapshot_digest.clone(),
+            rfq_observation_cursor: restored.rfq_observation_position.map(public_position),
+            rfq_observed_at,
+            rfq_observation_age_ms,
+        },
+    }))
+}
+
+fn unavailable(reason: UnavailableReason) -> UnavailableState {
+    UnavailableState {
+        reason,
+        gap_refs: Vec::new(),
+    }
+}
+
+fn early_unavailable_states(
+    request: &ReconstructionRequest,
+    plan: &TargetPlan,
+) -> BTreeMap<u64, Result<ReconstructedState, UnavailableState>> {
+    let mut states = BTreeMap::new();
+    for block in &request.required_blocks {
+        let reason = if *block > plan.visible_through_block {
+            Some(UnavailableReason::ReplicaCutoff)
+        } else if plan.missing_block_times.contains(block)
+            || request.backends.contains(&Backend::Rfq)
+                && block
+                    .checked_add(1)
+                    .is_none_or(|next| plan.missing_block_times.contains(&next))
+        {
+            Some(UnavailableReason::BlockBoundaryMissing)
+        } else if plan
+            .lineage_invalid_intervals
+            .iter()
+            .any(|interval| interval_contains(*interval, *block))
+        {
+            Some(UnavailableReason::CanonicalLineageInvalid)
+        } else {
+            None
+        };
+        if let Some(reason) = reason {
+            states.insert(
+                *block,
+                Err(UnavailableState {
+                    reason,
+                    gap_refs: Vec::new(),
+                }),
+            );
+        }
+    }
+    states
+}
+
+fn leg_for_block(plan: &TargetPlan, backends: &BTreeSet<Backend>, block: u64) -> Option<usize> {
+    let next_timestamp = block
+        .checked_add(1)
+        .and_then(|next| plan.block_times.get(&next))
+        .map(|observation| observation.timestamp_ms);
+    plan.legs
+        .iter()
+        .enumerate()
+        .filter(|(_, leg)| {
+            backends.iter().all(|backend| match backend {
+                Backend::Native | Backend::Vm => leg.checkpoint.block_number <= block,
+                Backend::Rfq => leg
+                    .checkpoint
+                    .rfq_observed_at_ms
+                    .zip(next_timestamp)
+                    .is_some_and(|(observed, boundary)| observed < boundary),
+            })
+        })
+        .max_by_key(|(_, leg)| leg.checkpoint.position)
+        .map(|(index, _)| index)
+}
+
+fn state_gap_refs(
+    gaps: &[RangeGap],
+    restored: &RestoredWorld,
+    block: u64,
+    next_block_timestamp: Option<u64>,
+) -> Vec<String> {
+    gaps.iter()
+        .enumerate()
+        .filter(|(_, gap)| {
+            gap_affects_interval(
+                gap,
+                restored.anchor_checkpoint_position,
+                restored.final_position,
+                restored.anchor_block,
+                block,
+                restored.anchor_rfq_observed_at_ms,
+                next_block_timestamp,
+            )
+        })
+        .map(|(index, _)| format!("gap-{}", index + 1))
+        .collect()
+}
+
+pub(crate) fn gap_affects_interval(
+    gap: &RangeGap,
+    start_position: HistoryPosition,
+    end_position: HistoryPosition,
+    start_block: u64,
+    end_block: u64,
+    start_observed_at_ms: Option<u64>,
+    end_observed_at_ms: Option<u64>,
+) -> bool {
+    let position_overlap = gap
+        .from_position
+        .zip(gap.to_position)
+        .is_some_and(|(from, to)| to > start_position && from <= end_position);
+    let block_overlap = gap
+        .from_block
+        .zip(gap.to_block_inclusive)
+        .is_some_and(|(from, to)| to > start_block && from <= end_block);
+    let time_overlap = gap
+        .from_observed_at_ms
+        .zip(gap.to_observed_at_ms)
+        .zip(start_observed_at_ms.zip(end_observed_at_ms))
+        .is_some_and(|((from, to), (start, end))| to > start && from < end);
+    let no_public_bounds = gap.from_block.is_none()
+        && gap.to_block_inclusive.is_none()
+        && gap.from_observed_at_ms.is_none()
+        && gap.to_observed_at_ms.is_none();
+    position_overlap
+        || block_overlap
+        || time_overlap
+        || no_public_bounds
+            && gap
+                .from_position
+                .is_some_and(|from| from > start_position && from <= end_position)
+}
+
+fn matching_gap_refs(gaps: &[RangeGap], block: u64) -> Vec<String> {
+    gaps.iter()
+        .enumerate()
+        .filter(|(_, gap)| {
+            gap.from_block
+                .zip(gap.to_block_inclusive)
+                .is_some_and(|(from, to)| from <= block && block <= to)
+                || gap.kind == RangeGapKind::MissingCheckpoint
+        })
+        .map(|(index, _)| format!("gap-{}", index + 1))
+        .collect()
+}
+
+fn public_gap(index: usize, gap: &RangeGap) -> Result<GapReference, HistoricalError> {
+    Ok(GapReference {
+        reference: format!("gap-{}", index + 1),
+        kind: match gap.kind {
+            RangeGapKind::MissingCheckpoint => GapKind::MissingCheckpoint,
+            RangeGapKind::Recorded => GapKind::Recorded,
+            RangeGapKind::IncompleteTail => GapKind::IncompleteTail,
+        },
+        cause: (gap.kind == RangeGapKind::Recorded)
+            .then(|| gap_cause(&gap.reason))
+            .transpose()?,
+        from_position: gap.from_position.map(public_position),
+        to_position: gap.to_position.map(public_position),
+        from_block: gap.from_block,
+        to_block_inclusive: gap.to_block_inclusive,
+        from_observed_at_ms: gap.from_observed_at_ms,
+        to_observed_at_ms: gap.to_observed_at_ms,
+    })
+}
+
+fn gap_cause(reason: &str) -> Result<GapCause, HistoricalError> {
+    match reason {
+        "queue_overflow" => Ok(GapCause::QueueOverflow),
+        "write_failed" => Ok(GapCause::WriteFailed),
+        "writer_stopped" => Ok(GapCause::WriterStopped),
+        "checkpoint_failed" => Ok(GapCause::CheckpointFailed),
+        "boundary_slip" => Ok(GapCause::BoundarySlip),
+        other => Err(HistoricalError::HistoricalDataInvalid(format!(
+            "unknown recorded gap cause {other}"
+        ))),
+    }
+}
+
+fn rfq_provenance(
+    restored: &RestoredWorld,
+    next_block_timestamp: Option<u64>,
+) -> Result<(Option<DateTime<Utc>>, Option<u64>), HistoricalError> {
+    let Some(observed_at_ms) = restored.rfq_observed_at_ms else {
+        return Ok((None, None));
+    };
+    let observed_at =
+        DateTime::from_timestamp_millis(i64::try_from(observed_at_ms).map_err(|_| {
+            HistoricalError::HistoricalDataInvalid(
+                "RFQ observation timestamp exceeds RFC 3339 range".to_owned(),
+            )
+        })?)
+        .ok_or_else(|| {
+            HistoricalError::HistoricalDataInvalid(
+                "RFQ observation timestamp exceeds RFC 3339 range".to_owned(),
+            )
+        })?;
+    let age = next_block_timestamp
+        .and_then(|boundary| boundary.checked_sub(observed_at_ms))
+        .ok_or_else(|| {
+            HistoricalError::HistoricalDataInvalid(
+                "RFQ observation is not before the next block boundary".to_owned(),
+            )
+        })?;
+    Ok((Some(observed_at), Some(age)))
+}
+
+pub(crate) fn history_backend(backend: Backend) -> HistoryBackend {
+    match backend {
+        Backend::Native => HistoryBackend::Native,
+        Backend::Vm => HistoryBackend::Vm,
+        Backend::Rfq => HistoryBackend::Rfq,
+    }
+}
+
+pub(crate) fn public_backend(backend: HistoryBackend) -> Backend {
+    match backend {
+        HistoryBackend::Native => Backend::Native,
+        HistoryBackend::Vm => Backend::Vm,
+        HistoryBackend::Rfq => Backend::Rfq,
+    }
+}
+
+pub(crate) fn replay_backend(backend: Backend) -> ReplayBackend {
+    match backend {
+        Backend::Native => ReplayBackend::Native,
+        Backend::Vm => ReplayBackend::Vm,
+        Backend::Rfq => ReplayBackend::Rfq,
+    }
+}
+
+pub(crate) fn public_position(position: HistoryPosition) -> StreamPosition {
+    StreamPosition {
+        generation: position.generation,
+        message_seq: position.message_seq,
+    }
+}
+
+pub(crate) fn history_position(position: StreamPosition) -> HistoryPosition {
+    HistoryPosition {
+        generation: position.generation,
+        message_seq: position.message_seq,
+    }
+}
+
+fn interval_contains(interval: BlockInterval, block: u64) -> bool {
+    interval.start <= block && block <= interval.end_inclusive
+}
+
+pub(crate) fn check_cancelled(cancellation: &CancellationToken) -> Result<(), HistoricalError> {
+    if cancellation.is_cancelled() {
+        Err(HistoricalError::Cancelled)
+    } else {
+        Ok(())
+    }
+}

--- a/crates/historical-quote/tests/consistency.rs
+++ b/crates/historical-quote/tests/consistency.rs
@@ -1,0 +1,198 @@
+mod support;
+
+use std::sync::Arc;
+
+use historical_quote::api::{
+    Backend, PairStatus, PoolSelector, QuoteFailureReason, StreamPosition,
+};
+use historical_quote::{ConsistencyChecker, HistoricalError};
+use state_history::ReadLimits;
+use tokio_util::sync::CancellationToken;
+
+use support::{consistency_request, native_pool, FixtureSource};
+
+#[tokio::test]
+async fn direct_target_matches_earlier_checkpoint_plus_deltas(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let report = checker(Arc::new(FixtureSource::native_consistency(true)?), 100)
+        .execute(
+            &consistency_request(native_pool()),
+            &CancellationToken::new(),
+            &(),
+        )
+        .await?;
+
+    assert_eq!(report.pairs[0].status, PairStatus::Pass);
+    assert_eq!(report.summary.pass, 1);
+    assert_eq!(
+        report.pairs[0].quote_comparisons[0].status,
+        PairStatus::Pass
+    );
+    assert_eq!(report.pairs[0].total_difference_count, 0);
+    assert_eq!(report.pairs[0].direct_state, report.pairs[0].replayed_state);
+    Ok(())
+}
+
+#[tokio::test]
+async fn canonical_and_exact_quote_mismatches_are_reported(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let report = checker(Arc::new(FixtureSource::native_consistency(false)?), 100)
+        .execute(
+            &consistency_request(native_pool()),
+            &CancellationToken::new(),
+            &(),
+        )
+        .await?;
+
+    assert_eq!(report.pairs[0].status, PairStatus::Mismatch);
+    assert_eq!(report.summary.mismatch, 1);
+    assert_eq!(
+        report.pairs[0].quote_comparisons[0].status,
+        PairStatus::Mismatch
+    );
+    assert!(report.pairs[0].total_difference_count > 0);
+    assert_eq!(report.pairs[0].affected_backends, vec![Backend::Native]);
+    assert_eq!(
+        report.pairs[0].affected_component_ids,
+        vec![support::NATIVE_COMPONENT]
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn matching_quote_failures_are_not_comparable() -> Result<(), Box<dyn std::error::Error>> {
+    let missing_pool = PoolSelector {
+        component_id: "native:missing".to_owned(),
+        ..native_pool()
+    };
+    let report = checker(Arc::new(FixtureSource::native_consistency(true)?), 100)
+        .execute(
+            &consistency_request(missing_pool),
+            &CancellationToken::new(),
+            &(),
+        )
+        .await?;
+
+    assert_eq!(report.pairs[0].status, PairStatus::NotComparable);
+    assert_eq!(report.summary.not_comparable, 1);
+    assert!(matches!(
+        report.pairs[0].quote_comparisons[0].direct_outcome,
+        historical_quote::api::ConsistencyQuoteOutcome::QuoteFailed {
+            reason: QuoteFailureReason::ComponentNotFound
+        }
+    ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn gap_has_precedence_over_state_and_quote_comparison(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut source = FixtureSource::native_consistency(false)?;
+    let Some(pair_plan) = source.pair_plan.as_mut() else {
+        return Err("fixture pair plan must exist".into());
+    };
+    pair_plan.gaps.push(support::recorded_gap(2, 2, 101, 101));
+    let report = checker(Arc::new(source), 100)
+        .execute(
+            &consistency_request(native_pool()),
+            &CancellationToken::new(),
+            &(),
+        )
+        .await?;
+
+    assert_eq!(report.pairs[0].status, PairStatus::Gap);
+    assert_eq!(report.summary.gap, 1);
+    assert!(report.pairs[0].direct_state.is_none());
+    assert!(report.pairs[0].quote_comparisons.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn no_eligible_pair_is_a_completed_not_comparable_selection(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let report = checker(Arc::new(FixtureSource::native()?), 100)
+        .execute(
+            &consistency_request(native_pool()),
+            &CancellationToken::new(),
+            &(),
+        )
+        .await?;
+
+    assert_eq!(
+        report.selection_status,
+        historical_quote::api::ConsistencySelectionStatus::NotComparable
+    );
+    assert!(report.pairs.is_empty());
+    assert_eq!(report.summary.selected_checkpoint_pairs, 0);
+    Ok(())
+}
+
+#[tokio::test]
+async fn structured_differences_are_bounded_without_losing_total_count(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let report = checker(Arc::new(FixtureSource::native_consistency(false)?), 0)
+        .execute(
+            &consistency_request(native_pool()),
+            &CancellationToken::new(),
+            &(),
+        )
+        .await?;
+
+    assert!(report.pairs[0].total_difference_count > 0);
+    assert!(report.pairs[0].differences.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn canonical_vm_comparison_is_rejected_and_cancellation_is_observed(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let source = Arc::new(FixtureSource::native()?);
+    let mut vm_request = consistency_request(PoolSelector {
+        backend: Backend::Vm,
+        ..native_pool()
+    });
+    vm_request.backends = vec![Backend::Vm];
+    let vm_result = checker(Arc::clone(&source), 100)
+        .execute(&vm_request, &CancellationToken::new(), &())
+        .await;
+    let Err(vm_error) = vm_result else {
+        return Err("VM comparison must fail".into());
+    };
+    assert!(matches!(vm_error, HistoricalError::UnsupportedCanonicalVm));
+
+    let cancellation = CancellationToken::new();
+    cancellation.cancel();
+    let cancellation_result = checker(source, 100)
+        .execute(&consistency_request(native_pool()), &cancellation, &())
+        .await;
+    let Err(cancellation_error) = cancellation_result else {
+        return Err("cancelled check must stop".into());
+    };
+    assert!(matches!(cancellation_error, HistoricalError::Cancelled));
+    Ok(())
+}
+
+#[test]
+fn explicit_positions_remain_exact_and_ordered() -> Result<(), Box<dyn std::error::Error>> {
+    let request = consistency_request(native_pool());
+    let historical_quote::api::ConsistencySelection::CheckpointPairs { pairs } = request.selection
+    else {
+        return Err("fixture must use explicit pairs".into());
+    };
+    assert_eq!(
+        pairs[0].earlier_position,
+        StreamPosition {
+            generation: 1,
+            message_seq: 1,
+        }
+    );
+    assert_eq!(pairs[0].target_position.message_seq, 3);
+    Ok(())
+}
+
+fn checker(
+    source: Arc<FixtureSource>,
+    max_differences: usize,
+) -> ConsistencyChecker<FixtureSource> {
+    ConsistencyChecker::new(source, ReadLimits::unbounded(), max_differences)
+}

--- a/crates/historical-quote/tests/coverage.rs
+++ b/crates/historical-quote/tests/coverage.rs
@@ -1,0 +1,108 @@
+mod support;
+
+use std::sync::Arc;
+
+use historical_quote::api::{Backend, BlockBounds, CoverageRequest, GapCause, GapKind};
+use historical_quote::CoverageService;
+use state_history::{BlockInterval, CoverageSnapshot};
+
+use support::FixtureSource;
+
+#[tokio::test]
+async fn coverage_is_the_intersection_for_every_requested_backend(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut source = FixtureSource::native()?;
+    source.coverage_snapshot = CoverageSnapshot {
+        visible_through_block: 118,
+        continuous_intervals: vec![BlockInterval::new(102, 107)?, BlockInterval::new(111, 118)?],
+        known_gaps: vec![support::recorded_gap(7, 9, 108, 110)],
+    };
+    let service = CoverageService::new(Arc::new(source));
+    let response = service
+        .resolve(&CoverageRequest {
+            api_revision: 1,
+            chain_id: 8453,
+            backends: vec![Backend::Rfq, Backend::Native],
+            bounds: Some(BlockBounds {
+                start: 100,
+                end_inclusive: 120,
+            }),
+        })
+        .await?;
+
+    assert_eq!(response.backends, vec![Backend::Native, Backend::Rfq]);
+    assert_eq!(response.visible_through_block, 118);
+    assert_eq!(
+        response.continuous_intervals,
+        vec![
+            BlockBounds {
+                start: 102,
+                end_inclusive: 107,
+            },
+            BlockBounds {
+                start: 111,
+                end_inclusive: 118,
+            },
+        ]
+    );
+    assert_eq!(response.known_gaps.len(), 1);
+    assert_eq!(response.known_gaps[0].kind, GapKind::Recorded);
+    assert_eq!(response.known_gaps[0].cause, Some(GapCause::WriteFailed));
+    Ok(())
+}
+
+#[tokio::test]
+async fn replica_cutoff_is_not_reported_as_a_gap() -> Result<(), Box<dyn std::error::Error>> {
+    let mut source = FixtureSource::native()?;
+    source.coverage_snapshot = CoverageSnapshot {
+        visible_through_block: 118,
+        continuous_intervals: vec![BlockInterval::new(100, 118)?],
+        known_gaps: Vec::new(),
+    };
+    let response = CoverageService::new(Arc::new(source))
+        .resolve(&CoverageRequest {
+            api_revision: 1,
+            chain_id: 8453,
+            backends: vec![Backend::Native],
+            bounds: Some(BlockBounds {
+                start: 100,
+                end_inclusive: 120,
+            }),
+        })
+        .await?;
+
+    assert_eq!(response.visible_through_block, 118);
+    assert!(response.known_gaps.is_empty());
+    assert_eq!(response.continuous_intervals[0].end_inclusive, 118);
+    Ok(())
+}
+
+#[tokio::test]
+async fn unbounded_coverage_has_no_pool_existence_claim() -> Result<(), Box<dyn std::error::Error>>
+{
+    let response = CoverageService::new(Arc::new(FixtureSource::native()?))
+        .resolve(&CoverageRequest {
+            api_revision: 1,
+            chain_id: 8453,
+            backends: vec![Backend::Native],
+            bounds: None,
+        })
+        .await?;
+    let json = serde_json::to_value(response)?;
+
+    assert!(json.get("bounds").is_none());
+    assert!(json.get("pool").is_none());
+    assert!(json.get("componentId").is_none());
+    Ok(())
+}
+
+#[test]
+fn duplicate_backends_are_rejected_at_the_wire_boundary() {
+    let request = serde_json::from_value::<CoverageRequest>(serde_json::json!({
+        "apiRevision": 1,
+        "chainId": 8453,
+        "backends": ["native", "native"]
+    }));
+
+    assert!(request.is_err());
+}

--- a/crates/historical-quote/tests/reconstruction.rs
+++ b/crates/historical-quote/tests/reconstruction.rs
@@ -1,0 +1,284 @@
+mod support;
+
+use std::sync::Arc;
+
+use historical_quote::api::{QuoteFailureReason, QuoteOutcome, UnavailableReason};
+use historical_quote::{HistoricalQuoteExecutor, HistoricalReconstructor};
+use simulator_replay::acquire_vm_world_lease;
+use state_history::ReadLimits;
+use tokio_util::sync::CancellationToken;
+
+use support::{native_quote_request, rfq_quote_request, FixtureSource};
+
+#[tokio::test]
+async fn grouped_quotes_are_sorted_and_replay_each_leg_once(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let source = Arc::new(FixtureSource::native()?);
+    let executor = executor(Arc::clone(&source));
+    let result = executor
+        .execute(
+            &native_quote_request(100, 100),
+            &CancellationToken::new(),
+            &(),
+        )
+        .await?;
+
+    assert_eq!(source.checkpoint_fetch_count(), 1);
+    assert_eq!(source.token_fetch_count(), 1);
+    assert_eq!(result.results.len(), 2);
+    assert_eq!(result.results[0].amount_in.as_str(), "1000000");
+    assert_eq!(result.results[1].amount_in.as_str(), "2000000");
+    assert_eq!(result.results[0].targets[0].lag, 1);
+    assert_eq!(result.results[0].targets[0].target_block, 101);
+    assert_eq!(result.results[0].targets[1].lag, 2);
+    assert_eq!(result.results[0].targets[1].target_block, 102);
+    assert!(matches!(
+        result.results[0].start_outcome,
+        QuoteOutcome::Ok { .. }
+    ));
+    assert!(result.results[0]
+        .targets
+        .iter()
+        .all(|target| matches!(target.outcome, QuoteOutcome::Ok { .. })));
+    Ok(())
+}
+
+#[tokio::test]
+async fn only_target_crossing_gap_is_unavailable() -> Result<(), Box<dyn std::error::Error>> {
+    let mut source = FixtureSource::native()?;
+    source
+        .target_plan
+        .gaps
+        .push(support::recorded_gap(3, 3, 102, 102));
+    let result = executor(Arc::new(source))
+        .execute(
+            &native_quote_request(100, 100),
+            &CancellationToken::new(),
+            &(),
+        )
+        .await?;
+
+    assert!(matches!(
+        result.results[0].targets[0].outcome,
+        QuoteOutcome::Ok { .. }
+    ));
+    assert!(matches!(
+        result.results[0].targets[1].outcome,
+        QuoteOutcome::Unavailable {
+            reason: UnavailableReason::Gap,
+            ..
+        }
+    ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn position_only_gap_after_target_does_not_invalidate_target(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut source = FixtureSource::native()?;
+    source.target_plan.gaps.push(state_history::RangeGap {
+        kind: state_history::RangeGapKind::MissingCheckpoint,
+        generation: Some(1),
+        from_message_seq: Some(3),
+        to_message_seq: None,
+        from_position: Some(support::position(3)),
+        to_position: None,
+        from_block: None,
+        to_block_inclusive: None,
+        from_observed_at_ms: None,
+        to_observed_at_ms: None,
+        reason: "missing_checkpoint".to_owned(),
+    });
+    let mut request = native_quote_request(100, 100);
+    request.lags = vec![1];
+    request.amounts_in = vec![support::amount("1000000")];
+    let result = executor(Arc::new(source))
+        .execute(&request, &CancellationToken::new(), &())
+        .await?;
+
+    assert!(matches!(
+        result.results[0].targets[0].outcome,
+        QuoteOutcome::Ok { .. }
+    ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn start_quote_failure_does_not_suppress_safe_targets(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let source = Arc::new(FixtureSource::native_with_component_added_at_target()?);
+    let mut request = native_quote_request(100, 100);
+    request.lags = vec![1];
+    request.amounts_in = vec![support::amount("1000000")];
+    let result = executor(source)
+        .execute(&request, &CancellationToken::new(), &())
+        .await?;
+
+    assert!(matches!(
+        result.results[0].start_outcome,
+        QuoteOutcome::QuoteFailed {
+            reason: QuoteFailureReason::ComponentNotFound
+        }
+    ));
+    assert!(matches!(
+        result.results[0].targets[0].outcome,
+        QuoteOutcome::Ok { .. }
+    ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn rfq_uses_latest_observation_strictly_before_next_block(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut source = FixtureSource::rfq()?;
+    source.target_plan.legs[0]
+        .deltas
+        .push(support::rfq_delta(12, 5_000)?);
+    let result = executor(Arc::new(source))
+        .execute(&rfq_quote_request(), &CancellationToken::new(), &())
+        .await?;
+    let QuoteOutcome::Ok {
+        amount_out: start_amount,
+        provenance: start_provenance,
+    } = &result.results[0].start_outcome
+    else {
+        return Err("RFQ start quote must succeed".into());
+    };
+    let QuoteOutcome::Ok {
+        amount_out: target_amount,
+        provenance: target_provenance,
+    } = &result.results[0].targets[0].outcome
+    else {
+        return Err("RFQ target quote must succeed".into());
+    };
+
+    assert_eq!(start_amount.as_str(), "2000000000");
+    assert_eq!(target_amount.as_str(), "1995000000");
+    assert_eq!(
+        start_provenance.rfq_observation_cursor,
+        Some(support::public_position(10))
+    );
+    assert_eq!(
+        target_provenance.rfq_observation_cursor,
+        Some(support::public_position(12))
+    );
+    assert_eq!(target_provenance.rfq_observation_age_ms, Some(1));
+    Ok(())
+}
+
+#[tokio::test]
+async fn unavailable_cells_keep_their_distinct_reasons() -> Result<(), Box<dyn std::error::Error>> {
+    let mut source = FixtureSource::native()?;
+    source.target_plan.visible_through_block = 101;
+    source
+        .target_plan
+        .lineage_invalid_intervals
+        .push(state_history::BlockInterval::new(101, 101)?);
+    let mut request = native_quote_request(100, 100);
+    request.lags = vec![1, 2];
+    request.amounts_in = vec![support::amount("1000000")];
+    let result = executor(Arc::new(source))
+        .execute(&request, &CancellationToken::new(), &())
+        .await?;
+
+    assert!(matches!(
+        result.results[0].start_outcome,
+        QuoteOutcome::Ok { .. }
+    ));
+    assert!(matches!(
+        result.results[0].targets[0].outcome,
+        QuoteOutcome::Unavailable {
+            reason: UnavailableReason::CanonicalLineageInvalid,
+            ..
+        }
+    ));
+    assert!(matches!(
+        result.results[0].targets[1].outcome,
+        QuoteOutcome::Unavailable {
+            reason: UnavailableReason::ReplicaCutoff,
+            ..
+        }
+    ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn rfq_without_an_observation_before_the_boundary_is_unavailable(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut source = FixtureSource::rfq()?;
+    source.target_plan.legs[0].checkpoint.rfq_observed_at_ms = Some(5_000);
+    source.target_plan.legs[0].deltas.clear();
+    let result = executor(Arc::new(source))
+        .execute(&rfq_quote_request(), &CancellationToken::new(), &())
+        .await?;
+
+    assert!(matches!(
+        result.results[0].start_outcome,
+        QuoteOutcome::Unavailable {
+            reason: UnavailableReason::RfqObservationMissing,
+            ..
+        }
+    ));
+    assert!(matches!(
+        result.results[0].targets[0].outcome,
+        QuoteOutcome::Unavailable {
+            reason: UnavailableReason::RfqObservationMissing,
+            ..
+        }
+    ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn missing_token_anchor_and_apply_anomaly_fail_closed(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut missing_tokens = FixtureSource::native()?;
+    missing_tokens.target_plan.legs[0]
+        .checkpoint
+        .token_reference = None;
+    let mut request = native_quote_request(100, 100);
+    request.lags = vec![1];
+    request.amounts_in = vec![support::amount("1000000")];
+    let missing_result = executor(Arc::new(missing_tokens))
+        .execute(&request, &CancellationToken::new(), &())
+        .await?;
+    assert!(matches!(
+        missing_result.results[0].start_outcome,
+        QuoteOutcome::Unavailable {
+            reason: UnavailableReason::TokenSnapshotMissing,
+            ..
+        }
+    ));
+
+    let anomaly_result = executor(Arc::new(FixtureSource::native_with_apply_anomaly()?))
+        .execute(&request, &CancellationToken::new(), &())
+        .await?;
+    assert!(matches!(
+        anomaly_result.results[0].targets[0].outcome,
+        QuoteOutcome::Unavailable {
+            reason: UnavailableReason::StateApplicationInvalid,
+            ..
+        }
+    ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn vm_world_lease_serializes_complete_world_lifetimes(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let first = acquire_vm_world_lease().await;
+    let waiting = tokio::spawn(acquire_vm_world_lease());
+    tokio::task::yield_now().await;
+    assert!(!waiting.is_finished());
+    drop(first);
+    let second = waiting.await?;
+    drop(second);
+    Ok(())
+}
+
+fn executor(source: Arc<FixtureSource>) -> HistoricalQuoteExecutor<FixtureSource> {
+    HistoricalQuoteExecutor::new(
+        HistoricalReconstructor::new(source, ReadLimits::unbounded()),
+        "phase-4-test",
+    )
+}

--- a/crates/historical-quote/tests/support/mod.rs
+++ b/crates/historical-quote/tests/support/mod.rs
@@ -1,0 +1,540 @@
+#![expect(
+    dead_code,
+    reason = "this fixture module is shared by separate integration test binaries"
+)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::future::Future;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use historical_quote::api::{
+    Backend as PublicBackend, BlockRange, ConsistencyCheckRequest, ConsistencySelection,
+    PoolSelector, QuoteComparisonRequest, QuoteJobRequest, StreamPosition as PublicPosition,
+    UnsignedAmount,
+};
+use historical_quote::{HistoricalError, HistorySource};
+use serde_json::value::RawValue;
+use serde_json::{json, Value};
+use state_history::{
+    ArchiveMetadata, Backend, BlockInterval, BlockTimeObservation, CheckpointArchive,
+    CheckpointKind, CheckpointManifest, CheckpointPair, CheckpointPairQuery,
+    CheckpointPairReplayPlan, CheckpointStatus, CoverageQuery, CoverageSnapshot,
+    DeltaBackendCursor, RangeGap, RangeGapKind, RangeLeg, RawTokenSnapshot, ReadLimits,
+    StoredDelta, StreamPosition, TargetPlan, TargetPlanQuery, TokenSnapshotRef,
+    ARCHIVE_SCHEMA_VERSION, DELTA_PAYLOAD_FORMAT_VERSION, TOKEN_SNAPSHOT_SCHEMA_VERSION,
+};
+use uuid::Uuid;
+
+pub const NATIVE_COMPONENT: &str = "native:uniswap-v2:fixture";
+pub const TOKEN_A: &str = "0x1111111111111111111111111111111111111111";
+pub const TOKEN_B: &str = "0x2222222222222222222222222222222222222222";
+pub const RFQ_COMPONENT: &str = "rfq:bebop:WETH-USDC-fixture";
+pub const WETH: &str = "0x3333333333333333333333333333333333333333";
+pub const USDC: &str = "0x4444444444444444444444444444444444444444";
+
+const NATIVE_CHECKPOINT: &str =
+    include_str!("../../../simulator-replay/tests/fixtures/native_checkpoint_v1.json");
+const NATIVE_DELTA: &str =
+    include_str!("../../../simulator-replay/tests/fixtures/native_delta_v1.json");
+const RFQ_CHECKPOINT: &str =
+    include_str!("../../../simulator-replay/tests/fixtures/rfq_checkpoint_v1.json");
+const RFQ_DELTA: &str = include_str!("../../../simulator-replay/tests/fixtures/rfq_delta_v1.json");
+
+#[derive(Debug)]
+pub struct FixtureSource {
+    pub target_plan: TargetPlan,
+    pub coverage_snapshot: CoverageSnapshot,
+    pub archives: BTreeMap<i64, CheckpointArchive>,
+    pub token_snapshots: BTreeMap<i64, RawTokenSnapshot>,
+    pub pairs: Vec<CheckpointPair>,
+    pub pair_plan: Option<CheckpointPairReplayPlan>,
+    pub checkpoint_fetches: AtomicUsize,
+    pub token_fetches: AtomicUsize,
+}
+
+impl FixtureSource {
+    pub fn native() -> Result<Self, Box<dyn std::error::Error>> {
+        let anchor = manifest(1, 100, position(1), Backend::Native, true, None);
+        let delta = native_delta(2, 101)?;
+        let target_plan = TargetPlan {
+            visible_through_block: 103,
+            block_times: block_times(100, 104, 1_000),
+            missing_block_times: BTreeSet::new(),
+            legs: vec![RangeLeg {
+                checkpoint: anchor.clone(),
+                deltas: vec![delta.clone()],
+            }],
+            gaps: Vec::new(),
+            lineage_invalid_intervals: Vec::new(),
+            estimated_decoded_bytes: 1_024,
+        };
+        let mut archives = BTreeMap::new();
+        archives.insert(anchor.id, native_archive(&anchor, false)?);
+        let mut token_snapshots = BTreeMap::new();
+        token_snapshots.insert(anchor.id, native_tokens()?);
+        Ok(Self {
+            target_plan,
+            coverage_snapshot: CoverageSnapshot {
+                visible_through_block: 103,
+                continuous_intervals: vec![BlockInterval::new(100, 103)?],
+                known_gaps: Vec::new(),
+            },
+            archives,
+            token_snapshots,
+            pairs: Vec::new(),
+            pair_plan: None,
+            checkpoint_fetches: AtomicUsize::new(0),
+            token_fetches: AtomicUsize::new(0),
+        })
+    }
+
+    pub fn native_consistency(direct_updated: bool) -> Result<Self, Box<dyn std::error::Error>> {
+        let mut source = Self::native()?;
+        let earlier = source.target_plan.legs[0].checkpoint.clone();
+        let target = manifest(2, 101, position(3), Backend::Native, true, None);
+        source
+            .archives
+            .insert(target.id, native_archive(&target, direct_updated)?);
+        source.token_snapshots.insert(target.id, native_tokens()?);
+        let pair = CheckpointPair { earlier, target };
+        source.pairs = vec![pair.clone()];
+        source.pair_plan = Some(CheckpointPairReplayPlan {
+            pair,
+            deltas: vec![native_delta(2, 101)?],
+            gaps: Vec::new(),
+            estimated_decoded_bytes: 2_048,
+        });
+        Ok(source)
+    }
+
+    pub fn native_with_component_added_at_target() -> Result<Self, Box<dyn std::error::Error>> {
+        let mut source = Self::native()?;
+        let anchor = source.target_plan.legs[0].checkpoint.clone();
+        let checkpoint: Value = serde_json::from_str(NATIVE_CHECKPOINT)?;
+        let mut empty_partition = checkpoint["partition"].clone();
+        let state_entry = empty_partition["states"][0].clone();
+        empty_partition["states"] = json!([]);
+        source
+            .archives
+            .insert(anchor.id, archive(&anchor, "native", empty_partition));
+        let update = json!({
+            "partitions": [{
+                "backend": "native",
+                "blockNumber": 101,
+                "newPairs": [state_entry]
+            }]
+        });
+        source.target_plan.legs[0].deltas =
+            vec![delta(2, Backend::Native, Some(101), None, update)?];
+        Ok(source)
+    }
+
+    pub fn native_with_apply_anomaly() -> Result<Self, Box<dyn std::error::Error>> {
+        let mut source = Self::native()?;
+        let fixture: Value = serde_json::from_str(NATIVE_DELTA)?;
+        let mut update = fixture["update"].clone();
+        update["partitions"][0]["updatedStates"][0]["componentId"] = json!("native:missing");
+        source.target_plan.legs[0].deltas =
+            vec![delta(2, Backend::Native, Some(101), None, update)?];
+        Ok(source)
+    }
+
+    pub fn rfq() -> Result<Self, Box<dyn std::error::Error>> {
+        let anchor = manifest(10, 100, position(10), Backend::Rfq, false, Some(1_000));
+        let delta = rfq_delta(11, 5_000)?;
+        let mut block_times = BTreeMap::new();
+        for (block, timestamp) in [(100, 4_000), (101, 5_000), (102, 5_001)] {
+            block_times.insert(block, block_time(block, timestamp));
+        }
+        let target_plan = TargetPlan {
+            visible_through_block: 101,
+            block_times,
+            missing_block_times: BTreeSet::new(),
+            legs: vec![RangeLeg {
+                checkpoint: anchor.clone(),
+                deltas: vec![delta],
+            }],
+            gaps: Vec::new(),
+            lineage_invalid_intervals: Vec::new(),
+            estimated_decoded_bytes: 1_024,
+        };
+        let mut archives = BTreeMap::new();
+        archives.insert(anchor.id, rfq_archive(&anchor)?);
+        Ok(Self {
+            target_plan,
+            coverage_snapshot: CoverageSnapshot {
+                visible_through_block: 101,
+                continuous_intervals: vec![BlockInterval::new(100, 101)?],
+                known_gaps: Vec::new(),
+            },
+            archives,
+            token_snapshots: BTreeMap::new(),
+            pairs: Vec::new(),
+            pair_plan: None,
+            checkpoint_fetches: AtomicUsize::new(0),
+            token_fetches: AtomicUsize::new(0),
+        })
+    }
+
+    pub fn checkpoint_fetch_count(&self) -> usize {
+        self.checkpoint_fetches.load(Ordering::SeqCst)
+    }
+
+    pub fn token_fetch_count(&self) -> usize {
+        self.token_fetches.load(Ordering::SeqCst)
+    }
+}
+
+impl HistorySource for FixtureSource {
+    fn plan_targets(
+        &self,
+        _query: TargetPlanQuery,
+    ) -> impl Future<Output = Result<TargetPlan, HistoricalError>> + Send {
+        std::future::ready(Ok(self.target_plan.clone()))
+    }
+
+    fn coverage(
+        &self,
+        _query: CoverageQuery,
+    ) -> impl Future<Output = Result<CoverageSnapshot, HistoricalError>> + Send {
+        std::future::ready(Ok(self.coverage_snapshot.clone()))
+    }
+
+    fn fetch_checkpoint(
+        &self,
+        manifest: CheckpointManifest,
+        _limits: ReadLimits,
+    ) -> impl Future<Output = Result<CheckpointArchive, HistoricalError>> + Send {
+        self.checkpoint_fetches.fetch_add(1, Ordering::SeqCst);
+        std::future::ready(self.archives.get(&manifest.id).cloned().ok_or_else(|| {
+            HistoricalError::HistoricalDataInvalid(format!(
+                "fixture checkpoint {} is missing",
+                manifest.id
+            ))
+        }))
+    }
+
+    fn fetch_checkpoint_token_snapshot(
+        &self,
+        manifest: CheckpointManifest,
+        _limits: ReadLimits,
+    ) -> impl Future<Output = Result<Option<RawTokenSnapshot>, HistoricalError>> + Send {
+        self.token_fetches.fetch_add(1, Ordering::SeqCst);
+        std::future::ready(Ok(self.token_snapshots.get(&manifest.id).cloned()))
+    }
+
+    fn resolve_checkpoint_pairs(
+        &self,
+        _query: CheckpointPairQuery,
+    ) -> impl Future<Output = Result<Vec<CheckpointPair>, HistoricalError>> + Send {
+        std::future::ready(Ok(self.pairs.clone()))
+    }
+
+    fn plan_checkpoint_pair(
+        &self,
+        _pair: CheckpointPair,
+        _backends: Vec<Backend>,
+        _limits: ReadLimits,
+    ) -> impl Future<Output = Result<CheckpointPairReplayPlan, HistoricalError>> + Send {
+        std::future::ready(self.pair_plan.clone().ok_or_else(|| {
+            HistoricalError::HistoricalDataInvalid(
+                "fixture checkpoint pair plan is missing".to_owned(),
+            )
+        }))
+    }
+}
+
+pub fn native_quote_request(start: u64, end: u64) -> QuoteJobRequest {
+    QuoteJobRequest {
+        request_id: Uuid::new_v4(),
+        api_revision: 1,
+        timeout_ms: 10_000,
+        chain_id: 8453,
+        pool: native_pool(),
+        blocks: BlockRange {
+            start,
+            end_inclusive: end,
+            step: 1,
+        },
+        lags: vec![2, 1],
+        amounts_in: vec![amount("2000000"), amount("1000000")],
+    }
+}
+
+pub fn rfq_quote_request() -> QuoteJobRequest {
+    QuoteJobRequest {
+        request_id: Uuid::new_v4(),
+        api_revision: 1,
+        timeout_ms: 10_000,
+        chain_id: 8453,
+        pool: PoolSelector {
+            backend: PublicBackend::Rfq,
+            protocol: "rfq:bebop".to_owned(),
+            component_id: RFQ_COMPONENT.to_owned(),
+            token_in: WETH.to_owned(),
+            token_out: USDC.to_owned(),
+        },
+        blocks: BlockRange {
+            start: 100,
+            end_inclusive: 100,
+            step: 1,
+        },
+        lags: vec![1],
+        amounts_in: vec![amount("1000000000000000000")],
+    }
+}
+
+pub fn consistency_request(pool: PoolSelector) -> ConsistencyCheckRequest {
+    ConsistencyCheckRequest {
+        request_id: Uuid::new_v4(),
+        api_revision: 1,
+        timeout_ms: 10_000,
+        chain_id: 8453,
+        backends: vec![pool.backend],
+        selection: ConsistencySelection::CheckpointPairs {
+            pairs: vec![historical_quote::api::CheckpointPair {
+                earlier_position: public_position(1),
+                target_position: public_position(3),
+            }],
+        },
+        quotes_to_compare: vec![QuoteComparisonRequest {
+            pool,
+            amounts_in: vec![amount("1000000")],
+        }],
+    }
+}
+
+pub fn native_pool() -> PoolSelector {
+    PoolSelector {
+        backend: PublicBackend::Native,
+        protocol: "uniswap_v2".to_owned(),
+        component_id: NATIVE_COMPONENT.to_owned(),
+        token_in: TOKEN_A.to_owned(),
+        token_out: TOKEN_B.to_owned(),
+    }
+}
+
+pub fn amount(value: &str) -> UnsignedAmount {
+    #[expect(
+        clippy::expect_used,
+        reason = "fixture amounts are compile-time constants"
+    )]
+    value.parse().expect("fixture amount must be valid")
+}
+
+pub fn recorded_gap(from: u64, to: u64, from_block: u64, to_block: u64) -> RangeGap {
+    RangeGap {
+        kind: RangeGapKind::Recorded,
+        generation: Some(1),
+        from_message_seq: Some(from),
+        to_message_seq: Some(to),
+        from_position: Some(position(from)),
+        to_position: Some(position(to)),
+        from_block: Some(from_block),
+        to_block_inclusive: Some(to_block),
+        from_observed_at_ms: None,
+        to_observed_at_ms: None,
+        reason: "write_failed".to_owned(),
+    }
+}
+
+pub const fn position(message_seq: u64) -> StreamPosition {
+    StreamPosition {
+        generation: 1,
+        message_seq,
+    }
+}
+
+pub const fn public_position(message_seq: u64) -> PublicPosition {
+    PublicPosition {
+        generation: 1,
+        message_seq,
+    }
+}
+
+fn manifest(
+    id: i64,
+    block_number: u64,
+    position: StreamPosition,
+    backend: Backend,
+    with_tokens: bool,
+    rfq_observed_at_ms: Option<u64>,
+) -> CheckpointManifest {
+    #[expect(
+        clippy::expect_used,
+        reason = "fixture checkpoint ids are positive constants"
+    )]
+    let state_version = u64::try_from(id).expect("fixture id must be positive");
+    CheckpointManifest {
+        id,
+        chain_id: 8453,
+        position,
+        state_version: Some(state_version),
+        kind: CheckpointKind::Interval,
+        block_number,
+        rfq_observed_at_ms,
+        backends: vec![backend],
+        s3_key: Some(format!("fixture/{id}.json.zst")),
+        archive_sha256: Some(format!("archive-{id}")),
+        archive_bytes: Some(1_024),
+        compressed_bytes: Some(512),
+        token_reference: with_tokens.then(|| TokenSnapshotRef {
+            s3_key: format!("fixture/{id}-tokens.json.zst"),
+            sha256: format!("tokens-{id}"),
+            token_count: 2,
+            token_bytes: 512,
+        }),
+        status: CheckpointStatus::Complete,
+        error: None,
+    }
+}
+
+fn native_archive(
+    manifest: &CheckpointManifest,
+    updated: bool,
+) -> Result<CheckpointArchive, Box<dyn std::error::Error>> {
+    let checkpoint: Value = serde_json::from_str(NATIVE_CHECKPOINT)?;
+    let mut partition = checkpoint["partition"].clone();
+    partition["blockNumber"] = json!(manifest.block_number);
+    if updated {
+        let delta: Value = serde_json::from_str(NATIVE_DELTA)?;
+        partition["states"][0]["state"] =
+            delta["update"]["partitions"][0]["updatedStates"][0]["state"].clone();
+    }
+    Ok(archive(manifest, "native", partition))
+}
+
+fn rfq_archive(
+    manifest: &CheckpointManifest,
+) -> Result<CheckpointArchive, Box<dyn std::error::Error>> {
+    let checkpoint: Value = serde_json::from_str(RFQ_CHECKPOINT)?;
+    Ok(archive(manifest, "rfq", checkpoint["partition"].clone()))
+}
+
+fn archive(manifest: &CheckpointManifest, backend: &str, partition: Value) -> CheckpointArchive {
+    let snapshot_id = format!("snapshot-{}", manifest.id);
+    CheckpointArchive {
+        metadata: ArchiveMetadata {
+            schema_version: ARCHIVE_SCHEMA_VERSION,
+            chain_id: manifest.chain_id,
+            position: manifest.position,
+            state_version: manifest.state_version,
+            kind: manifest.kind,
+            block_number: manifest.block_number,
+            rfq_observed_at_ms: manifest.rfq_observed_at_ms,
+            backends: manifest.backends.clone(),
+        },
+        payloads_json: vec![
+            json!({
+                "kind": "snapshot_start",
+                "snapshotId": snapshot_id.clone(),
+                "chainId": manifest.chain_id,
+                "backends": [backend],
+                "totalChunks": 1
+            })
+            .to_string(),
+            json!({
+                "kind": "snapshot_chunk",
+                "snapshotId": snapshot_id.clone(),
+                "chunkIndex": 0,
+                "partitions": [partition]
+            })
+            .to_string(),
+            json!({
+                "kind": "snapshot_end",
+                "snapshotId": snapshot_id
+            })
+            .to_string(),
+        ],
+    }
+}
+
+fn native_tokens() -> Result<RawTokenSnapshot, Box<dyn std::error::Error>> {
+    let checkpoint: Value = serde_json::from_str(NATIVE_CHECKPOINT)?;
+    raw_tokens(checkpoint["tokens"].clone())
+}
+
+fn raw_tokens(tokens: Value) -> Result<RawTokenSnapshot, Box<dyn std::error::Error>> {
+    let token_count = tokens
+        .as_array()
+        .map(Vec::len)
+        .ok_or("fixture tokens must be an array")?;
+    Ok(RawTokenSnapshot {
+        schema_version: TOKEN_SNAPSHOT_SCHEMA_VERSION,
+        chain_id: 8453,
+        token_count: u64::try_from(token_count)?,
+        tokens: RawValue::from_string(tokens.to_string())?,
+    })
+}
+
+fn native_delta(
+    message_seq: u64,
+    block_number: u64,
+) -> Result<StoredDelta, Box<dyn std::error::Error>> {
+    let fixture: Value = serde_json::from_str(NATIVE_DELTA)?;
+    delta(
+        message_seq,
+        Backend::Native,
+        Some(block_number),
+        None,
+        fixture["update"].clone(),
+    )
+}
+
+pub fn rfq_delta(
+    message_seq: u64,
+    observed_at_ms: u64,
+) -> Result<StoredDelta, Box<dyn std::error::Error>> {
+    let fixture: Value = serde_json::from_str(RFQ_DELTA)?;
+    delta(
+        message_seq,
+        Backend::Rfq,
+        None,
+        Some(observed_at_ms),
+        fixture["update"].clone(),
+    )
+}
+
+fn delta(
+    message_seq: u64,
+    backend: Backend,
+    block_number: Option<u64>,
+    observed_at_ms: Option<u64>,
+    update: Value,
+) -> Result<StoredDelta, Box<dyn std::error::Error>> {
+    let raw_payload = RawValue::from_string(
+        json!({
+            "stream_id": "fixture-stream",
+            "message_seq": message_seq,
+            "kind": "update",
+            "partitions": update["partitions"].clone()
+        })
+        .to_string(),
+    )?;
+    Ok(StoredDelta {
+        position: position(message_seq),
+        observed_at_ms: observed_at_ms.unwrap_or(1_000 + message_seq),
+        payload_format_version: DELTA_PAYLOAD_FORMAT_VERSION,
+        raw_payload,
+        applicable_backends: vec![DeltaBackendCursor {
+            backend,
+            block_number,
+            observed_at_ms,
+        }],
+    })
+}
+
+fn block_times(start: u64, end: u64, base_ms: u64) -> BTreeMap<u64, BlockTimeObservation> {
+    (start..=end)
+        .map(|block| (block, block_time(block, base_ms + (block - start) * 1_000)))
+        .collect()
+}
+
+fn block_time(block: u64, timestamp_ms: u64) -> BlockTimeObservation {
+    BlockTimeObservation {
+        block_number: block,
+        timestamp_ms,
+        block_hash: Some(format!("0x{block:064x}")),
+        parent_hash: Some(format!("0x{:064x}", block.saturating_sub(1))),
+    }
+}

--- a/crates/simulator-replay/src/decoder.rs
+++ b/crates/simulator-replay/src/decoder.rs
@@ -25,16 +25,20 @@ use tycho_simulation::{
     },
     protocol::models::Update,
     tycho_client::feed::{BlockHeader, FeedMessage},
-    tycho_common::{models::token::Token, Bytes},
+    tycho_common::{
+        models::{token::Token, Chain},
+        Bytes,
+    },
 };
 
 use simulator_core::broadcaster::{
-    BroadcasterEnvelope, BroadcasterPayload, BroadcasterProtocolMessage,
-    BroadcasterSnapshotPartition, BroadcasterUpdateMessage,
+    BroadcasterEnvelope, BroadcasterPayload, BroadcasterProtocolMessage, BroadcasterSnapshotChunk,
+    BroadcasterSnapshotPartition, BroadcasterSnapshotStart, BroadcasterTokenDto,
+    BroadcasterUpdateMessage,
 };
 
 use crate::payload::{live_partition_update, snapshot_partition_update};
-use crate::{DecodedReplay, ReplayBackend};
+use crate::{DecodedReplay, RawSnapshotReassembly, ReplayBackend};
 
 pub type TokenMap = HashMap<Bytes, Token>;
 
@@ -162,6 +166,14 @@ pub enum ReplayDecodeError {
     RetainedDecoderProfileRequired(i16),
     #[error("stored delta payload is not a broadcaster update")]
     StoredDeltaIsNotUpdate,
+    #[error("checkpoint payload sequence is invalid: {0}")]
+    InvalidCheckpoint(String),
+    #[error("checkpoint is missing backend {0}")]
+    MissingCheckpointBackend(&'static str),
+    #[error("unsupported retained token chain {0}")]
+    UnsupportedTokenChain(u64),
+    #[error("failed to decode retained token snapshot: {0}")]
+    TokenSnapshot(String),
 }
 
 pub struct ReplayDecoder {
@@ -206,6 +218,103 @@ impl ReplayDecoder {
         decoder: Arc<TychoStreamDecoder<BlockHeader>>,
     ) -> Self {
         Self { config, decoder }
+    }
+
+    /// Decodes one verified checkpoint archive into a deterministic replay update.
+    pub async fn decode_checkpoint_payloads(
+        &self,
+        payloads_json: &[String],
+        selected_backends: &[ReplayBackend],
+    ) -> Result<DecodedReplay, ReplayDecodeError> {
+        let selected = selected_backends.iter().copied().collect::<HashSet<_>>();
+        if selected.is_empty() {
+            return Err(ReplayDecodeError::InvalidCheckpoint(
+                "selected backends must not be empty".to_owned(),
+            ));
+        }
+        for backend in &selected {
+            self.ensure_backend_configured(*backend)?;
+        }
+
+        let (start, chunks) = parse_checkpoint_payloads(payloads_json)?;
+        let advertised = start
+            .backends
+            .iter()
+            .copied()
+            .map(ReplayBackend::from)
+            .collect::<HashSet<_>>();
+        if let Some(missing) = selected
+            .iter()
+            .find(|backend| !advertised.contains(backend))
+        {
+            return Err(ReplayDecodeError::MissingCheckpointBackend(
+                missing.as_str(),
+            ));
+        }
+
+        self.decode_checkpoint_chunks(&start.snapshot_id, chunks, &selected)
+            .await
+    }
+
+    async fn decode_checkpoint_chunks(
+        &self,
+        snapshot_id: &str,
+        chunks: BTreeMap<u32, BroadcasterSnapshotChunk>,
+        selected: &HashSet<ReplayBackend>,
+    ) -> Result<DecodedReplay, ReplayDecodeError> {
+        let mut raw_messages = BTreeMap::<ReplayBackend, RawSnapshotReassembly>::new();
+        let mut seen_backends = HashSet::new();
+        let mut combined = None;
+        let mut block_number = 0;
+        for chunk in chunks.into_values() {
+            if chunk.snapshot_id != snapshot_id {
+                return Err(ReplayDecodeError::InvalidCheckpoint(
+                    "snapshot chunk identifier differs from snapshot start".to_owned(),
+                ));
+            }
+            for partition in chunk.partitions {
+                let backend = ReplayBackend::from(partition.backend);
+                if !selected.contains(&backend) {
+                    continue;
+                }
+                seen_backends.insert(backend);
+                block_number = block_number.max(partition.block_number);
+                if partition.messages.is_empty() {
+                    let decoded = self.decode_snapshot_partition(partition).await?;
+                    merge_update(&mut combined, decoded.update);
+                } else {
+                    let reassembly = raw_messages.entry(backend).or_default();
+                    for message in partition.messages {
+                        reassembly.push(message).map_err(|error| {
+                            ReplayDecodeError::InvalidCheckpoint(error.to_string())
+                        })?;
+                    }
+                }
+            }
+        }
+        for (backend, mut reassembly) in raw_messages {
+            let update = self
+                .decode_snapshot_messages(backend, reassembly.take_messages())
+                .await?;
+            merge_update(&mut combined, update);
+        }
+        if let Some(missing) = selected
+            .iter()
+            .find(|backend| !seen_backends.contains(backend))
+        {
+            return Err(ReplayDecodeError::MissingCheckpointBackend(
+                missing.as_str(),
+            ));
+        }
+        if let Some(update) = combined.as_mut() {
+            update.block_number_or_timestamp = block_number;
+        }
+        Ok(DecodedReplay {
+            had_applicable_partition: true,
+            block_number,
+            complete_native_block: None,
+            update: combined,
+        })
     }
 
     pub async fn decode_snapshot_partition(
@@ -380,6 +489,103 @@ impl ReplayDecoder {
             Ok(())
         }
     }
+}
+
+fn parse_checkpoint_payloads(
+    payloads_json: &[String],
+) -> Result<
+    (
+        BroadcasterSnapshotStart,
+        BTreeMap<u32, BroadcasterSnapshotChunk>,
+    ),
+    ReplayDecodeError,
+> {
+    let mut start = None;
+    let mut chunks = BTreeMap::new();
+    let mut end = None;
+    for payload_json in payloads_json {
+        let payload: BroadcasterPayload = serde_json::from_str(payload_json)
+            .map_err(|error| ReplayDecodeError::PayloadDecode(error.to_string()))?;
+        match payload {
+            BroadcasterPayload::SnapshotStart(value) if start.is_none() => start = Some(value),
+            BroadcasterPayload::SnapshotChunk(value) => {
+                if chunks.insert(value.chunk_index, value).is_some() {
+                    return Err(ReplayDecodeError::InvalidCheckpoint(
+                        "duplicate snapshot chunk index".to_owned(),
+                    ));
+                }
+            }
+            BroadcasterPayload::SnapshotEnd(value) if end.is_none() => end = Some(value),
+            _ => {
+                return Err(ReplayDecodeError::InvalidCheckpoint(
+                    "archive must contain one snapshot start, chunks, and one snapshot end"
+                        .to_owned(),
+                ));
+            }
+        }
+    }
+    let start = start
+        .ok_or_else(|| ReplayDecodeError::InvalidCheckpoint("missing snapshot start".to_owned()))?;
+    let end =
+        end.ok_or_else(|| ReplayDecodeError::InvalidCheckpoint("missing snapshot end".to_owned()))?;
+    if start.snapshot_id != end.snapshot_id {
+        return Err(ReplayDecodeError::InvalidCheckpoint(
+            "snapshot start and end identifiers differ".to_owned(),
+        ));
+    }
+    if usize::try_from(start.total_chunks).ok() != Some(chunks.len())
+        || chunks.keys().copied().ne(0..start.total_chunks)
+    {
+        return Err(ReplayDecodeError::InvalidCheckpoint(
+            "snapshot chunks are incomplete or out of range".to_owned(),
+        ));
+    }
+    Ok((start, chunks))
+}
+
+/// Decodes the canonical retained token array for a supported chain.
+pub fn decode_token_map(
+    chain_id: u64,
+    tokens: &serde_json::value::RawValue,
+) -> Result<TokenMap, ReplayDecodeError> {
+    let chain = [
+        Chain::Ethereum,
+        Chain::Starknet,
+        Chain::ZkSync,
+        Chain::Arbitrum,
+        Chain::Base,
+        Chain::Bsc,
+        Chain::Unichain,
+        Chain::Polygon,
+        Chain::Plasma,
+    ]
+    .into_iter()
+    .find(|chain| chain.id() == chain_id)
+    .ok_or(ReplayDecodeError::UnsupportedTokenChain(chain_id))?;
+    let decoded: Vec<BroadcasterTokenDto> = serde_json::from_str(tokens.get())
+        .map_err(|error| ReplayDecodeError::TokenSnapshot(error.to_string()))?;
+    let mut result = HashMap::with_capacity(decoded.len());
+    for token in decoded {
+        let token = token
+            .into_token(chain)
+            .map_err(|error| ReplayDecodeError::TokenSnapshot(error.to_string()))?;
+        if result.insert(token.address.clone(), token).is_some() {
+            return Err(ReplayDecodeError::TokenSnapshot(
+                "retained token snapshot contains a duplicate address".to_owned(),
+            ));
+        }
+    }
+    Ok(result)
+}
+
+fn merge_update(current: &mut Option<Update>, incoming: Option<Update>) {
+    let Some(incoming) = incoming else {
+        return;
+    };
+    *current = Some(match current.take() {
+        Some(existing) => existing.merge(incoming),
+        None => incoming,
+    });
 }
 
 fn register_native_decoder(

--- a/crates/simulator-replay/src/execution.rs
+++ b/crates/simulator-replay/src/execution.rs
@@ -1,7 +1,11 @@
 use std::any::Any;
+use std::future::Future;
 use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::sync::{Arc, LazyLock};
 
-use tokio::sync::oneshot;
+use tokio::sync::{oneshot, Mutex, OwnedMutexGuard};
+
+static VM_WORLD_LEASE: LazyLock<Arc<Mutex<()>>> = LazyLock::new(|| Arc::new(Mutex::new(())));
 
 #[derive(Debug, Default, Clone)]
 pub struct SimulationExecutor;
@@ -10,6 +14,24 @@ pub struct SimulationExecutor;
 pub enum SimulationExecutionError {
     WorkerPanicked(Box<dyn Any + Send + 'static>),
     ResultDropped,
+}
+
+/// Exclusive ownership of Tycho's process-wide VM state.
+pub struct VmWorldLease {
+    _guard: OwnedMutexGuard<()>,
+}
+
+/// Acquires the process-wide VM lease for one complete historical world.
+pub async fn acquire_vm_world_lease() -> VmWorldLease {
+    VmWorldLease {
+        _guard: Arc::clone(&VM_WORLD_LEASE).lock_owned().await,
+    }
+}
+
+/// Runs one complete VM-world operation while holding the process-wide lease.
+pub async fn with_vm_world<T, E>(operation: impl Future<Output = Result<T, E>>) -> Result<T, E> {
+    let _lease = acquire_vm_world_lease().await;
+    operation.await
 }
 
 impl SimulationExecutor {

--- a/crates/simulator-replay/src/lib.rs
+++ b/crates/simulator-replay/src/lib.rs
@@ -6,13 +6,17 @@ mod snapshot;
 mod state;
 
 pub use decoder::{
-    DecoderConfig, ReplayDecodeError, ReplayDecoder, TokenMap, RETAINED_DELTA_FORMAT_VERSION_V1,
-    RETAINED_TOKEN_QUALITY_V1,
+    decode_token_map, DecoderConfig, ReplayDecodeError, ReplayDecoder, TokenMap,
+    RETAINED_DELTA_FORMAT_VERSION_V1, RETAINED_TOKEN_QUALITY_V1,
 };
-pub use execution::{SimulationExecutionError, SimulationExecutor};
+pub use execution::{
+    acquire_vm_world_lease, with_vm_world, SimulationExecutionError, SimulationExecutor,
+    VmWorldLease,
+};
 pub use payload::{DecodedReplay, ReplayBackend};
 pub use quote::{simulate_amount_out, ExactPoolQuote, ReplayQuoteError};
 pub use snapshot::{RawSnapshotReassembly, SnapshotReassemblyError};
 pub use state::{
-    ApplyReport, CanonicalState, CanonicalStateError, PoolEntry, ReplayWorld, StatePoint,
+    ApplyReport, CanonicalComponentState, CanonicalState, CanonicalStateError, CanonicalTokenState,
+    PoolEntry, ReplayWorld, StatePoint,
 };

--- a/crates/simulator-replay/src/state.rs
+++ b/crates/simulator-replay/src/state.rs
@@ -123,7 +123,11 @@ impl StatePoint {
         backends: &[ReplayBackend],
     ) -> Result<CanonicalState, CanonicalStateError> {
         let selected = backends.iter().copied().collect::<BTreeSet<_>>();
+        if selected.contains(&ReplayBackend::Vm) {
+            return Err(CanonicalStateError::UnsupportedBackend(ReplayBackend::Vm));
+        }
         let mut pools = Vec::new();
+        let mut components = Vec::new();
         let mut token_addresses = BTreeSet::new();
         let mut backend_counts = BTreeMap::new();
 
@@ -136,11 +140,19 @@ impl StatePoint {
                 for token in &component.tokens {
                     token_addresses.insert(token.address.clone());
                 }
+                let component_value = canonicalize_json(serde_json::to_value(component.as_ref())?);
+                let state_value = canonicalize_json(serde_json::to_value(state.as_ref())?);
+                components.push(CanonicalComponentState {
+                    backend,
+                    component_id: component_id.clone(),
+                    component_bytes: serde_json::to_vec(&component_value)?,
+                    state_bytes: serde_json::to_vec(&state_value)?,
+                });
                 pools.push(CanonicalPool {
                     backend,
                     component_id: component_id.clone(),
-                    component: serde_json::to_value(component.as_ref())?,
-                    state: serde_json::to_value(state.as_ref())?,
+                    component: component_value,
+                    state: state_value,
                 });
                 *backend_counts.entry(backend).or_insert(0) += 1;
             }
@@ -150,20 +162,35 @@ impl StatePoint {
                 .cmp(&(right.backend, right.component_id.as_str()))
         });
 
-        let tokens = token_addresses
+        let token_values = token_addresses
             .into_iter()
             .filter_map(|address| self.state.tokens.get(&address))
-            .map(serde_json::to_value)
+            .map(|token| serde_json::to_value(token).map(canonicalize_json))
+            .collect::<Result<Vec<_>, _>>()?;
+        let tokens = token_values
+            .iter()
+            .map(|value| {
+                Ok::<_, serde_json::Error>(CanonicalTokenState {
+                    address: value
+                        .get("address")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or_default()
+                        .to_owned(),
+                    token_bytes: serde_json::to_vec(value)?,
+                })
+            })
             .collect::<Result<Vec<_>, _>>()?;
         let bytes = serde_json::to_vec(&CanonicalDocument {
             block_number: self.state.block_number,
             pools,
-            tokens,
+            tokens: token_values,
         })?;
         Ok(CanonicalState {
             bytes,
             component_count: backend_counts.values().sum(),
             backend_counts,
+            components,
+            tokens,
         })
     }
 
@@ -268,6 +295,10 @@ impl ReplayWorld {
             state: Arc::clone(&self.state),
         }
     }
+
+    pub fn set_current_block(&mut self, block_number: u64) {
+        Arc::make_mut(&mut self.state).block_number = block_number;
+    }
 }
 
 pub struct ApplyReport {
@@ -304,16 +335,58 @@ pub struct CanonicalState {
     bytes: Vec<u8>,
     pub component_count: usize,
     pub backend_counts: BTreeMap<ReplayBackend, usize>,
+    components: Vec<CanonicalComponentState>,
+    tokens: Vec<CanonicalTokenState>,
 }
 
 impl CanonicalState {
     pub fn as_bytes(&self) -> &[u8] {
         &self.bytes
     }
+
+    pub fn components(&self) -> &[CanonicalComponentState] {
+        &self.components
+    }
+
+    pub fn tokens(&self) -> &[CanonicalTokenState] {
+        &self.tokens
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CanonicalComponentState {
+    pub backend: ReplayBackend,
+    pub component_id: String,
+    component_bytes: Vec<u8>,
+    state_bytes: Vec<u8>,
+}
+
+impl CanonicalComponentState {
+    pub fn component_bytes(&self) -> &[u8] {
+        &self.component_bytes
+    }
+
+    pub fn state_bytes(&self) -> &[u8] {
+        &self.state_bytes
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CanonicalTokenState {
+    pub address: String,
+    token_bytes: Vec<u8>,
+}
+
+impl CanonicalTokenState {
+    pub fn token_bytes(&self) -> &[u8] {
+        &self.token_bytes
+    }
 }
 
 #[derive(Debug, Error)]
 pub enum CanonicalStateError {
+    #[error("canonical state comparison does not support backend {0:?}")]
+    UnsupportedBackend(ReplayBackend),
     #[error("failed to serialize canonical simulator state: {0}")]
     Serialize(#[from] serde_json::Error),
 }
@@ -333,6 +406,22 @@ struct CanonicalPool {
     component_id: String,
     component: serde_json::Value,
     state: serde_json::Value,
+}
+
+fn canonicalize_json(value: serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Array(values) => {
+            serde_json::Value::Array(values.into_iter().map(canonicalize_json).collect())
+        }
+        serde_json::Value::Object(values) => {
+            let sorted = values
+                .into_iter()
+                .map(|(key, value)| (key, canonicalize_json(value)))
+                .collect::<BTreeMap<_, _>>();
+            serde_json::Value::Object(sorted.into_iter().collect())
+        }
+        value => value,
+    }
 }
 
 #[derive(Default)]
@@ -763,6 +852,29 @@ mod tests {
         assert_eq!(report.removed_unknown_pair, 0);
         assert!(report.anomaly_samples.is_empty());
         assert!(!report.has_anomalies());
+    }
+
+    #[test]
+    fn canonical_json_sorts_nested_object_keys() -> Result<(), serde_json::Error> {
+        let mut left_nested = serde_json::Map::new();
+        left_nested.insert("z".to_owned(), serde_json::json!(1));
+        left_nested.insert("a".to_owned(), serde_json::json!(2));
+        let mut left = serde_json::Map::new();
+        left.insert("second".to_owned(), serde_json::Value::Object(left_nested));
+        left.insert("first".to_owned(), serde_json::json!(0));
+
+        let mut right_nested = serde_json::Map::new();
+        right_nested.insert("a".to_owned(), serde_json::json!(2));
+        right_nested.insert("z".to_owned(), serde_json::json!(1));
+        let mut right = serde_json::Map::new();
+        right.insert("first".to_owned(), serde_json::json!(0));
+        right.insert("second".to_owned(), serde_json::Value::Object(right_nested));
+
+        assert_eq!(
+            serde_json::to_vec(&canonicalize_json(serde_json::Value::Object(left)))?,
+            serde_json::to_vec(&canonicalize_json(serde_json::Value::Object(right)))?
+        );
+        Ok(())
     }
 
     #[test]

--- a/crates/state-history/src/reader.rs
+++ b/crates/state-history/src/reader.rs
@@ -669,7 +669,7 @@ pub(super) async fn resolve_range_in_transaction(
     rfq_bounds: Option<(u64, u64)>,
     limits: ReadLimits,
 ) -> anyhow::Result<RangeResolution> {
-    let Some(anchor) = fetch_anchor(
+    let Some(mut anchor) = fetch_anchor(
         &mut *transaction,
         request,
         rfq_bounds.map(|bounds| bounds.0),
@@ -699,6 +699,17 @@ pub(super) async fn resolve_range_in_transaction(
             estimated_decoded_bytes: 0,
         });
     };
+
+    let needs_token_snapshot = request
+        .backends
+        .iter()
+        .any(|backend| matches!(backend, Backend::Native | Backend::Vm));
+    if needs_token_snapshot && anchor.token_reference.is_none() {
+        if let Some(fallback) = checkpoints::token_fallback_in_segment(transaction, &anchor).await?
+        {
+            anchor = fallback;
+        }
+    }
 
     let boundaries = fetch_boundaries(&mut *transaction, &anchor).await?;
     let (checkpoint_compressed_bytes, checkpoint_decoded_bytes) =
@@ -3064,7 +3075,7 @@ mod tests {
 
     #[sqlx::test(migrations = "./migrations")]
     #[ignore]
-    async fn resolved_plan_surfaces_optional_token_references(pool: PgPool) -> anyhow::Result<()> {
+    async fn resolved_plan_uses_same_segment_token_fallback(pool: PgPool) -> anyhow::Result<()> {
         configure_test_aws();
         let token_reference = TokenSnapshotRef {
             s3_key: "reader/chain=8453/tokens/token-sha256.zst".to_owned(),
@@ -3106,7 +3117,7 @@ mod tests {
         assert_eq!(referenced_plan.legs.len(), 1);
         assert_eq!(
             referenced_plan.legs[0].checkpoint.token_reference,
-            Some(token_reference)
+            Some(token_reference.clone())
         );
         assert!(referenced_plan.gaps.is_empty());
         referenced_plan.ensure_gap_free()?;
@@ -3115,7 +3126,7 @@ mod tests {
             1,
             2,
             101,
-            CheckpointKind::Boundary,
+            CheckpointKind::Interval,
             r#"{"state":"unreferenced"}"#,
         )?;
         let mut connection = pool.acquire().await?;
@@ -3133,13 +3144,21 @@ mod tests {
         )
         .await?;
         drop(connection);
+        persist_delta(&pool, database_delta(1, 2, 101, false)?).await?;
 
         let unreferenced_plan = reader
             .resolve_range(&RangeRequest::new(8453, 101, 101, vec![Backend::Native])?)
             .await?;
 
         assert_eq!(unreferenced_plan.legs.len(), 1);
-        assert_eq!(unreferenced_plan.legs[0].checkpoint.token_reference, None);
+        assert_eq!(
+            unreferenced_plan.legs[0].checkpoint.position,
+            referenced_capture.position()
+        );
+        assert_eq!(
+            unreferenced_plan.legs[0].checkpoint.token_reference,
+            Some(token_reference)
+        );
         assert!(unreferenced_plan.gaps.is_empty());
         unreferenced_plan.ensure_gap_free()?;
         Ok(())

--- a/crates/state-history/src/reader/checkpoints.rs
+++ b/crates/state-history/src/reader/checkpoints.rs
@@ -2,10 +2,12 @@ use anyhow::{ensure, Context};
 use sqlx::Row;
 
 use super::{
-    begin_range_transaction, database_i64, manifest_from_row, BlockInterval,
-    ReadConnectionProvider, StateHistoryReader,
+    begin_range_transaction, database_backends, database_i64, database_u64,
+    decode_delta_row_with_limit, encoded_delta_from_row, fetch_delta_backends, gap_from_row,
+    manifest_from_row, BlockInterval, RangeGap, RangeGapKind, ReadConnectionProvider, ReadLimits,
+    StateHistoryReader, StoredDelta,
 };
-use crate::{CheckpointKind, CheckpointManifest, CheckpointStatus, StreamPosition};
+use crate::{Backend, CheckpointKind, CheckpointManifest, CheckpointStatus, StreamPosition};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TokenAnchor {
@@ -32,6 +34,7 @@ pub enum CheckpointPairSelection {
 pub struct CheckpointPairQuery {
     pub chain_id: u64,
     pub selection: CheckpointPairSelection,
+    pub backends: Vec<Backend>,
 }
 
 impl CheckpointPairQuery {
@@ -39,6 +42,21 @@ impl CheckpointPairQuery {
         Self {
             chain_id,
             selection,
+            backends: Vec::new(),
+        }
+    }
+
+    pub fn for_backends(
+        chain_id: u64,
+        selection: CheckpointPairSelection,
+        mut backends: Vec<Backend>,
+    ) -> Self {
+        backends.sort_unstable();
+        backends.dedup();
+        Self {
+            chain_id,
+            selection,
+            backends,
         }
     }
 }
@@ -47,6 +65,14 @@ impl CheckpointPairQuery {
 pub struct CheckpointPair {
     pub earlier: CheckpointManifest,
     pub target: CheckpointManifest,
+}
+
+#[derive(Debug, Clone)]
+pub struct CheckpointPairReplayPlan {
+    pub pair: CheckpointPair,
+    pub deltas: Vec<StoredDelta>,
+    pub gaps: Vec<RangeGap>,
+    pub estimated_decoded_bytes: u64,
 }
 
 impl<P: ReadConnectionProvider> StateHistoryReader<P> {
@@ -105,10 +131,17 @@ impl<P: ReadConnectionProvider> StateHistoryReader<P> {
         let mut transaction = begin_range_transaction(&mut connection).await?;
         let pairs = match &query.selection {
             CheckpointPairSelection::BlockRange(bounds) => {
-                range_checkpoint_pairs(&mut transaction, query.chain_id, *bounds).await?
+                range_checkpoint_pairs(&mut transaction, query.chain_id, *bounds, &query.backends)
+                    .await?
             }
             CheckpointPairSelection::Explicit(selections) => {
-                explicit_checkpoint_pairs(&mut transaction, query.chain_id, selections).await?
+                explicit_checkpoint_pairs(
+                    &mut transaction,
+                    query.chain_id,
+                    selections,
+                    &query.backends,
+                )
+                .await?
             }
         };
         transaction
@@ -117,6 +150,289 @@ impl<P: ReadConnectionProvider> StateHistoryReader<P> {
             .context("failed to commit checkpoint pair transaction")?;
         Ok(pairs)
     }
+
+    pub async fn plan_checkpoint_pair(
+        &self,
+        pair: &CheckpointPair,
+        mut backends: Vec<Backend>,
+        limits: ReadLimits,
+    ) -> anyhow::Result<CheckpointPairReplayPlan> {
+        ensure!(
+            !backends.is_empty(),
+            "checkpoint pair backends must not be empty"
+        );
+        ensure!(
+            pair.earlier.chain_id == pair.target.chain_id,
+            "checkpoint pair chain ids differ"
+        );
+        ensure!(
+            pair.earlier.position < pair.target.position,
+            "checkpoint pair must be ordered"
+        );
+        backends.sort_unstable();
+        backends.dedup();
+
+        let mut connection = self
+            .connections
+            .acquire()
+            .await
+            .context("failed to acquire checkpoint pair plan connection")?;
+        let mut transaction = begin_range_transaction(&mut connection).await?;
+        let earlier = exact_checkpoint(
+            &mut transaction,
+            pair.earlier.chain_id,
+            pair.earlier.position,
+        )
+        .await?
+        .context("earlier checkpoint is not retained as complete")?;
+        let target = exact_checkpoint(&mut transaction, pair.target.chain_id, pair.target.position)
+            .await?
+            .context("target checkpoint is not retained as complete")?;
+        ensure!(
+            earlier.id == pair.earlier.id && target.id == pair.target.id,
+            "checkpoint pair does not match retained checkpoint identity"
+        );
+        let segment_start =
+            segment_boundary_position(&mut transaction, target.chain_id, target.position)
+                .await?
+                .context("target checkpoint has no complete segment boundary")?;
+        ensure!(
+            earlier.position >= segment_start,
+            "checkpoint pair must stay in the same segment"
+        );
+
+        let (checkpoint_compressed_bytes, checkpoint_decoded_bytes) =
+            declared_pair_checkpoint_bytes(&earlier, &target)?;
+        limits.check_compressed(checkpoint_compressed_bytes)?;
+        limits.check_decoded(checkpoint_decoded_bytes)?;
+        let remaining_compressed_bytes = limits
+            .max_compressed_bytes
+            .saturating_sub(checkpoint_compressed_bytes);
+        let remaining_decoded_bytes = limits
+            .max_decoded_bytes
+            .saturating_sub(checkpoint_decoded_bytes);
+        let encoded_rows = fetch_pair_delta_rows(
+            &mut transaction,
+            &earlier,
+            &target,
+            &backends,
+            remaining_compressed_bytes,
+        )
+        .await?;
+        let delta_ids = encoded_rows.iter().map(|row| row.id).collect::<Vec<_>>();
+        let backend_cursors = fetch_delta_backends(&mut transaction, &delta_ids).await?;
+        let mut delta_decoded_bytes = 0_u64;
+        let mut deltas = Vec::with_capacity(encoded_rows.len());
+        for row in encoded_rows {
+            let remaining = remaining_decoded_bytes.saturating_sub(delta_decoded_bytes);
+            let (row, decoded_bytes) =
+                decode_delta_row_with_limit(row, &backend_cursors, remaining)?;
+            delta_decoded_bytes = delta_decoded_bytes
+                .checked_add(decoded_bytes)
+                .context("checkpoint pair decoded byte estimate overflowed")?;
+            deltas.push(StoredDelta {
+                position: row.position,
+                observed_at_ms: row.observed_at_ms,
+                payload_format_version: row.payload_format_version,
+                raw_payload: row.payload,
+                applicable_backends: row
+                    .backends
+                    .into_iter()
+                    .filter(|cursor| backends.binary_search(&cursor.backend).is_ok())
+                    .collect(),
+            });
+        }
+        let gaps = fetch_pair_gaps(&mut transaction, &earlier, &target).await?;
+        transaction
+            .commit()
+            .await
+            .context("failed to commit checkpoint pair plan transaction")?;
+        Ok(CheckpointPairReplayPlan {
+            pair: CheckpointPair { earlier, target },
+            deltas,
+            gaps,
+            estimated_decoded_bytes: checkpoint_decoded_bytes
+                .checked_add(delta_decoded_bytes)
+                .context("checkpoint pair decoded byte estimate overflowed")?,
+        })
+    }
+}
+
+fn declared_pair_checkpoint_bytes(
+    earlier: &CheckpointManifest,
+    target: &CheckpointManifest,
+) -> anyhow::Result<(u64, u64)> {
+    let mut compressed_bytes = 0_u64;
+    let mut decoded_bytes = 0_u64;
+    let mut token_digests = std::collections::BTreeSet::new();
+    for manifest in [earlier, target] {
+        compressed_bytes = compressed_bytes
+            .checked_add(
+                manifest
+                    .compressed_bytes
+                    .context("complete checkpoint is missing its compressed byte length")?,
+            )
+            .context("checkpoint pair compressed byte estimate overflowed")?;
+        decoded_bytes = decoded_bytes
+            .checked_add(
+                manifest
+                    .archive_bytes
+                    .context("complete checkpoint is missing its archive byte length")?,
+            )
+            .context("checkpoint pair decoded byte estimate overflowed")?;
+        if let Some(reference) = manifest
+            .token_reference
+            .as_ref()
+            .filter(|reference| token_digests.insert(reference.sha256.clone()))
+        {
+            decoded_bytes = decoded_bytes
+                .checked_add(reference.token_bytes)
+                .context("checkpoint pair token byte estimate overflowed")?;
+        }
+    }
+    Ok((compressed_bytes, decoded_bytes))
+}
+
+async fn fetch_pair_delta_rows(
+    connection: &mut sqlx::PgConnection,
+    earlier: &CheckpointManifest,
+    target: &CheckpointManifest,
+    backends: &[Backend],
+    max_compressed_bytes: u64,
+) -> anyhow::Result<Vec<super::EncodedDeltaRow>> {
+    let compressed_bytes: i64 = sqlx::query_scalar(
+        "SELECT COALESCE(sum(octet_length(d.payload)), 0)::bigint
+         FROM state_history.deltas d
+         WHERE d.chain_id = $1
+           AND (d.generation, d.message_seq) > ($2, $3)
+           AND (d.generation, d.message_seq) <= ($4, $5)
+           AND EXISTS (
+               SELECT 1 FROM state_history.delta_backends matched
+               WHERE matched.delta_id = d.id AND matched.backend = ANY($6::text[])
+           )",
+    )
+    .bind(database_i64(earlier.chain_id, "checkpoint pair chain_id")?)
+    .bind(database_i64(
+        earlier.position.generation,
+        "earlier generation",
+    )?)
+    .bind(database_i64(
+        earlier.position.message_seq,
+        "earlier message_seq",
+    )?)
+    .bind(database_i64(
+        target.position.generation,
+        "target generation",
+    )?)
+    .bind(database_i64(
+        target.position.message_seq,
+        "target message_seq",
+    )?)
+    .bind(database_backends(backends))
+    .fetch_one(&mut *connection)
+    .await
+    .context("failed to preflight checkpoint pair delta bytes")?;
+    let compressed_bytes = database_u64(compressed_bytes, "checkpoint pair delta bytes")?;
+    ensure!(
+        compressed_bytes <= max_compressed_bytes,
+        "compressed bytes {compressed_bytes} exceed limit {max_compressed_bytes}"
+    );
+
+    let rows = sqlx::query(
+        "SELECT d.id, d.generation, d.message_seq, d.observed_at_ms,
+                d.payload_format_version, d.payload, d.payload_sha256
+         FROM state_history.deltas d
+         WHERE d.chain_id = $1
+           AND (d.generation, d.message_seq) > ($2, $3)
+           AND (d.generation, d.message_seq) <= ($4, $5)
+           AND EXISTS (
+               SELECT 1 FROM state_history.delta_backends matched
+               WHERE matched.delta_id = d.id AND matched.backend = ANY($6::text[])
+           )
+         ORDER BY d.generation, d.message_seq",
+    )
+    .bind(database_i64(earlier.chain_id, "checkpoint pair chain_id")?)
+    .bind(database_i64(
+        earlier.position.generation,
+        "earlier generation",
+    )?)
+    .bind(database_i64(
+        earlier.position.message_seq,
+        "earlier message_seq",
+    )?)
+    .bind(database_i64(
+        target.position.generation,
+        "target generation",
+    )?)
+    .bind(database_i64(
+        target.position.message_seq,
+        "target message_seq",
+    )?)
+    .bind(database_backends(backends))
+    .fetch_all(connection)
+    .await
+    .context("failed to select checkpoint pair deltas")?;
+    rows.iter().map(encoded_delta_from_row).collect()
+}
+
+async fn fetch_pair_gaps(
+    connection: &mut sqlx::PgConnection,
+    earlier: &CheckpointManifest,
+    target: &CheckpointManifest,
+) -> anyhow::Result<Vec<RangeGap>> {
+    let rows = sqlx::query(
+        "SELECT generation, from_message_seq, to_message_seq, reason,
+                from_block_number, to_block_number, from_observed_at_ms, to_observed_at_ms
+         FROM state_history.gaps
+         WHERE chain_id = $1
+           AND (generation > $2 OR (generation = $2 AND to_message_seq > $3))
+           AND (generation < $4 OR (generation = $4 AND from_message_seq <= $5))
+         ORDER BY generation, from_message_seq, to_message_seq, id",
+    )
+    .bind(database_i64(earlier.chain_id, "checkpoint pair chain_id")?)
+    .bind(database_i64(
+        earlier.position.generation,
+        "earlier generation",
+    )?)
+    .bind(database_i64(
+        earlier.position.message_seq,
+        "earlier message_seq",
+    )?)
+    .bind(database_i64(
+        target.position.generation,
+        "target generation",
+    )?)
+    .bind(database_i64(
+        target.position.message_seq,
+        "target message_seq",
+    )?)
+    .fetch_all(connection)
+    .await
+    .context("failed to select checkpoint pair gaps")?;
+    rows.iter()
+        .map(|row| {
+            let gap = gap_from_row(row)?;
+            Ok(RangeGap {
+                kind: RangeGapKind::Recorded,
+                generation: Some(gap.generation),
+                from_message_seq: Some(gap.from_message_seq),
+                to_message_seq: Some(gap.to_message_seq),
+                from_position: Some(StreamPosition {
+                    generation: gap.generation,
+                    message_seq: gap.from_message_seq,
+                }),
+                to_position: Some(StreamPosition {
+                    generation: gap.generation,
+                    message_seq: gap.to_message_seq,
+                }),
+                from_block: gap.from_block_number,
+                to_block_inclusive: gap.to_block_number,
+                from_observed_at_ms: gap.from_observed_at_ms,
+                to_observed_at_ms: gap.to_observed_at_ms,
+                reason: gap.reason,
+            })
+        })
+        .collect()
 }
 
 pub(super) async fn token_fallback_in_segment(
@@ -192,6 +508,7 @@ async fn range_checkpoint_pairs(
     connection: &mut sqlx::PgConnection,
     chain_id: u64,
     bounds: BlockInterval,
+    backends: &[Backend],
 ) -> anyhow::Result<Vec<CheckpointPair>> {
     let rows = sqlx::query(
         "SELECT id, chain_id, generation, message_seq, state_version, kind, block_number,
@@ -217,12 +534,14 @@ async fn range_checkpoint_pairs(
         .map(manifest_from_row)
         .collect::<anyhow::Result<Vec<_>>>()?;
     ensure_unique_positions(&manifests)?;
-
     let mut pairs = Vec::new();
     let mut previous: Option<CheckpointManifest> = None;
     for manifest in manifests {
         if manifest.kind == CheckpointKind::Boundary {
-            previous = Some(manifest);
+            previous = checkpoint_supports(&manifest, backends).then_some(manifest);
+            continue;
+        }
+        if !checkpoint_supports(&manifest, backends) {
             continue;
         }
         if let Some(earlier) = previous.replace(manifest.clone()) {
@@ -239,6 +558,7 @@ async fn explicit_checkpoint_pairs(
     connection: &mut sqlx::PgConnection,
     chain_id: u64,
     selections: &[ExplicitCheckpointPair],
+    backends: &[Backend],
 ) -> anyhow::Result<Vec<CheckpointPair>> {
     let mut pairs = Vec::with_capacity(selections.len());
     for selection in selections {
@@ -269,9 +589,19 @@ async fn explicit_checkpoint_pairs(
             earlier.position >= segment_start,
             "explicit checkpoint pair must stay in the same segment"
         );
+        ensure!(
+            checkpoint_supports(&earlier, backends) && checkpoint_supports(&target, backends),
+            "explicit checkpoint pair does not contain every requested backend"
+        );
         pairs.push(CheckpointPair { earlier, target });
     }
     Ok(pairs)
+}
+
+fn checkpoint_supports(manifest: &CheckpointManifest, backends: &[Backend]) -> bool {
+    backends
+        .iter()
+        .all(|backend| manifest.backends.binary_search(backend).is_ok())
 }
 
 async fn exact_checkpoint(

--- a/crates/state-history/src/reader/coverage.rs
+++ b/crates/state-history/src/reader/coverage.rs
@@ -105,6 +105,7 @@ impl TargetPlanQuery {
 pub struct TargetPlan {
     pub visible_through_block: u64,
     pub block_times: BTreeMap<u64, BlockTimeObservation>,
+    pub missing_block_times: BTreeSet<u64>,
     pub legs: Vec<RangeLeg>,
     pub gaps: Vec<RangeGap>,
     pub lineage_invalid_intervals: Vec<BlockInterval>,
@@ -153,6 +154,17 @@ impl<P: ReadConnectionProvider> StateHistoryReader<P> {
             )
             .await?,
         );
+        if query.backends.binary_search(&Backend::Rfq).is_ok() {
+            unsafe_intervals.extend(
+                missing_rfq_boundary_intervals(
+                    &mut transaction,
+                    query.chain_id,
+                    retained_start,
+                    interval_end,
+                )
+                .await?,
+            );
+        }
         let continuous_intervals = if retained_start > interval_end {
             Vec::new()
         } else {
@@ -202,39 +214,38 @@ impl<P: ReadConnectionProvider> StateHistoryReader<P> {
         let mut transaction = begin_range_transaction(&mut connection).await?;
         let visible_through_block =
             visible_through_block(&mut transaction, query.chain_id, &query.backends).await?;
-        let block_times =
+        let (block_times, missing_block_times) =
             required_block_times(&mut transaction, query.chain_id, &required_blocks).await?;
         let lineage_end = required_blocks.last().copied().unwrap_or(end_block);
         let lineage_invalid_intervals =
             lineage_invalid_intervals(&mut transaction, query.chain_id, start_block, lineage_end)
                 .await?;
 
+        let Some((range_start, range_end)) = replay_target_range(query, &block_times) else {
+            transaction
+                .commit()
+                .await
+                .context("failed to commit target planning transaction")?;
+            return Ok(TargetPlan {
+                visible_through_block,
+                block_times,
+                missing_block_times,
+                legs: Vec::new(),
+                gaps: Vec::new(),
+                lineage_invalid_intervals,
+                estimated_decoded_bytes: 0,
+            });
+        };
         let mut range_request = RangeRequest::new(
             query.chain_id,
-            start_block,
-            end_block,
+            range_start,
+            range_end,
             query.backends.clone(),
         )?;
-        let rfq_bounds = if includes_rfq {
-            let start_timestamp = block_times
-                .get(&start_block)
-                .context("target start block is missing its required timestamp")?
-                .timestamp_ms;
-            let end_plus_one = end_block
-                .checked_add(1)
-                .ok_or(ModelError::RfqTargetHasNoSuccessor(end_block))?;
-            let next_timestamp = block_times
-                .get(&end_plus_one)
-                .context("target end block is missing its required next-block timestamp")?
-                .timestamp_ms;
-            let end_timestamp = next_timestamp
-                .checked_sub(1)
-                .context("target next-block timestamp must be positive")?;
+        let rfq_bounds = replay_rfq_bounds(includes_rfq, range_start, range_end, &block_times)?;
+        if let Some((start_timestamp, end_timestamp)) = rfq_bounds {
             range_request = range_request.with_rfq_bounds(start_timestamp, end_timestamp)?;
-            Some((start_timestamp, end_timestamp))
-        } else {
-            None
-        };
+        }
         let resolution = resolve_range_in_transaction(
             &mut transaction,
             &range_request,
@@ -249,6 +260,7 @@ impl<P: ReadConnectionProvider> StateHistoryReader<P> {
         Ok(TargetPlan {
             visible_through_block,
             block_times,
+            missing_block_times,
             legs: resolution.plan.legs,
             gaps: resolution.plan.gaps,
             lineage_invalid_intervals,
@@ -257,11 +269,61 @@ impl<P: ReadConnectionProvider> StateHistoryReader<P> {
     }
 }
 
+fn replay_target_range(
+    query: &TargetPlanQuery,
+    block_times: &BTreeMap<u64, BlockTimeObservation>,
+) -> Option<(u64, u64)> {
+    if query.backends.binary_search(&Backend::Rfq).is_err() {
+        return query
+            .target_blocks
+            .first()
+            .copied()
+            .zip(query.target_blocks.last().copied());
+    }
+    let mut safe = query.target_blocks.iter().copied().filter(|target| {
+        target
+            .checked_add(1)
+            .is_some_and(|next| block_times.contains_key(target) && block_times.contains_key(&next))
+    });
+    let start = safe.next()?;
+    Some((start, safe.next_back().unwrap_or(start)))
+}
+
+fn replay_rfq_bounds(
+    includes_rfq: bool,
+    range_start: u64,
+    range_end: u64,
+    block_times: &BTreeMap<u64, BlockTimeObservation>,
+) -> anyhow::Result<Option<(u64, u64)>> {
+    if !includes_rfq {
+        return Ok(None);
+    }
+    let start_plus_one = range_start
+        .checked_add(1)
+        .ok_or(ModelError::RfqTargetHasNoSuccessor(range_start))?;
+    let start_timestamp = block_times
+        .get(&start_plus_one)
+        .context("safe RFQ target is missing its next-block timestamp")?
+        .timestamp_ms
+        .checked_sub(1)
+        .context("target next-block timestamp must be positive")?;
+    let end_plus_one = range_end
+        .checked_add(1)
+        .ok_or(ModelError::RfqTargetHasNoSuccessor(range_end))?;
+    let end_timestamp = block_times
+        .get(&end_plus_one)
+        .context("safe RFQ target is missing its next-block timestamp")?
+        .timestamp_ms
+        .checked_sub(1)
+        .context("target next-block timestamp must be positive")?;
+    Ok(Some((start_timestamp, end_timestamp)))
+}
+
 async fn required_block_times(
     connection: &mut sqlx::PgConnection,
     chain_id: u64,
     required_blocks: &BTreeSet<u64>,
-) -> anyhow::Result<BTreeMap<u64, BlockTimeObservation>> {
+) -> anyhow::Result<(BTreeMap<u64, BlockTimeObservation>, BTreeSet<u64>)> {
     let database_blocks = required_blocks
         .iter()
         .map(|block| database_i64(*block, "required target block"))
@@ -291,11 +353,8 @@ async fn required_block_times(
         .iter()
         .filter(|block| !observations.contains_key(block))
         .copied()
-        .collect::<Vec<_>>();
-    if !missing.is_empty() {
-        anyhow::bail!("missing required block_times rows for blocks {missing:?}");
-    }
-    Ok(observations)
+        .collect::<BTreeSet<_>>();
+    Ok((observations, missing))
 }
 
 pub(super) async fn visible_through_block(
@@ -556,6 +615,42 @@ async fn rfq_time_gap_to_blocks(
         (None, None) => Ok(None),
         _ => anyhow::bail!("RFQ gap projection returned incomplete bounds"),
     }
+}
+
+async fn missing_rfq_boundary_intervals(
+    connection: &mut sqlx::PgConnection,
+    chain_id: u64,
+    start: u64,
+    end: u64,
+) -> anyhow::Result<Vec<BlockInterval>> {
+    if start > end {
+        return Ok(Vec::new());
+    }
+    let rows: Vec<i64> = sqlx::query_scalar(
+        "SELECT current.block_number
+         FROM state_history.block_times current
+         LEFT JOIN state_history.block_times successor
+           ON successor.chain_id = current.chain_id
+          AND successor.block_number = current.block_number + 1
+         WHERE current.chain_id = $1
+           AND current.block_number BETWEEN $2 AND $3
+           AND successor.block_number IS NULL
+         ORDER BY current.block_number",
+    )
+    .bind(database_i64(chain_id, "coverage chain_id")?)
+    .bind(database_i64(start, "coverage RFQ boundary start")?)
+    .bind(database_i64(end, "coverage RFQ boundary end")?)
+    .fetch_all(connection)
+    .await
+    .context("failed to select missing RFQ next-block boundaries")?;
+    let intervals = rows
+        .into_iter()
+        .map(|block| {
+            let block = database_u64(block, "coverage RFQ missing boundary block")?;
+            BlockInterval::new(block, block).map_err(anyhow::Error::from)
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    Ok(merge_intervals(intervals))
 }
 
 pub(super) async fn lineage_invalid_intervals(

--- a/crates/state-history/tests/history_reads.rs
+++ b/crates/state-history/tests/history_reads.rs
@@ -94,6 +94,41 @@ async fn coverage_starts_at_the_first_retained_checkpoint(pool: PgPool) -> anyho
 
 #[sqlx::test(migrations = "./migrations")]
 #[ignore = "requires the state-history integration PostgreSQL"]
+async fn rfq_coverage_excludes_block_without_next_boundary(pool: PgPool) -> anyhow::Result<()> {
+    seed_block_times(&pool, 100, 102).await?;
+    sqlx::query(
+        "DELETE FROM state_history.block_times
+         WHERE chain_id = $1 AND block_number = 101",
+    )
+    .bind(database_i64(CHAIN_ID)?)
+    .execute(&pool)
+    .await?;
+    seed_checkpoint_with_backends(
+        &pool,
+        1,
+        0,
+        100,
+        CheckpointKind::Boundary,
+        false,
+        &[Backend::Rfq],
+    )
+    .await?;
+
+    let reader = StateHistoryReader::new(pool, object_store().await);
+    let snapshot = reader
+        .coverage(&CoverageQuery::new(
+            CHAIN_ID,
+            vec![Backend::Rfq],
+            Some(BlockInterval::new(100, 101)?),
+        )?)
+        .await?;
+
+    assert!(snapshot.continuous_intervals.is_empty());
+    Ok(())
+}
+
+#[sqlx::test(migrations = "./migrations")]
+#[ignore = "requires the state-history integration PostgreSQL"]
 async fn cursorless_gap_uses_its_full_span_for_boundary_projection(
     pool: PgPool,
 ) -> anyhow::Result<()> {
@@ -152,6 +187,78 @@ async fn target_plan_returns_every_required_next_block_time(pool: PgPool) -> any
     );
     assert!(plan.lineage_invalid_intervals.is_empty());
     assert_eq!(plan.visible_through_block, 110);
+    Ok(())
+}
+
+#[sqlx::test(migrations = "./migrations")]
+#[ignore = "requires the state-history integration PostgreSQL"]
+async fn target_plan_accepts_rfq_checkpoint_before_next_block(pool: PgPool) -> anyhow::Result<()> {
+    seed_block_times(&pool, 100, 101).await?;
+    let checkpoint = seed_checkpoint_with_backends(
+        &pool,
+        1,
+        1,
+        100,
+        CheckpointKind::Boundary,
+        false,
+        &[Backend::Rfq],
+    )
+    .await?;
+    sqlx::query(
+        "UPDATE state_history.checkpoints
+         SET rfq_observed_at_ms = 100500
+         WHERE id = $1",
+    )
+    .bind(checkpoint.id)
+    .execute(&pool)
+    .await?;
+
+    let reader = StateHistoryReader::new(pool, object_store().await);
+    let plan = reader
+        .plan_targets(&TargetPlanQuery::new(
+            CHAIN_ID,
+            vec![Backend::Rfq],
+            BTreeSet::from([100]),
+            ReadLimits::new(1_000_000, 1_000_000)?,
+        )?)
+        .await?;
+
+    assert_eq!(plan.legs.len(), 1);
+    assert_eq!(plan.legs[0].checkpoint.id, checkpoint.id);
+    assert_eq!(plan.legs[0].checkpoint.rfq_observed_at_ms, Some(100_500));
+    Ok(())
+}
+
+#[sqlx::test(migrations = "./migrations")]
+#[ignore = "requires the state-history integration PostgreSQL"]
+async fn target_plan_keeps_safe_cells_when_one_block_time_is_missing(
+    pool: PgPool,
+) -> anyhow::Result<()> {
+    seed_block_times(&pool, 100, 102).await?;
+    sqlx::query(
+        "DELETE FROM state_history.block_times
+         WHERE chain_id = $1 AND block_number = 101",
+    )
+    .bind(database_i64(CHAIN_ID)?)
+    .execute(&pool)
+    .await?;
+    seed_checkpoint(&pool, 1, 0, 100, CheckpointKind::Boundary, true).await?;
+    seed_delta(&pool, 1, 1, 102, 1, &[Backend::Native]).await?;
+
+    let reader = StateHistoryReader::new(pool, object_store().await);
+    let plan = reader
+        .plan_targets(&TargetPlanQuery::new(
+            CHAIN_ID,
+            vec![Backend::Native],
+            BTreeSet::from([100, 101, 102]),
+            ReadLimits::new(1_000_000, 1_000_000)?,
+        )?)
+        .await?;
+
+    assert_eq!(plan.missing_block_times, BTreeSet::from([101]));
+    assert!(plan.block_times.contains_key(&100));
+    assert!(plan.block_times.contains_key(&102));
+    assert!(!plan.legs.is_empty());
     Ok(())
 }
 
@@ -251,6 +358,40 @@ async fn checkpoint_pairs_are_adjacent_and_never_cross_segments(
         .await
         .expect_err("an explicit pair must not cross a segment boundary");
     assert!(error.to_string().contains("same segment"));
+    Ok(())
+}
+
+#[sqlx::test(migrations = "./migrations")]
+#[ignore = "requires the state-history integration PostgreSQL"]
+async fn backend_filter_keeps_incompatible_boundaries_as_segment_breaks(
+    pool: PgPool,
+) -> anyhow::Result<()> {
+    seed_checkpoint(&pool, 1, 0, 100, CheckpointKind::Boundary, true).await?;
+    seed_checkpoint(&pool, 1, 10, 110, CheckpointKind::Interval, true).await?;
+    seed_checkpoint_with_backends(
+        &pool,
+        2,
+        0,
+        200,
+        CheckpointKind::Boundary,
+        false,
+        &[Backend::Rfq],
+    )
+    .await?;
+    seed_checkpoint(&pool, 2, 10, 210, CheckpointKind::Interval, true).await?;
+
+    let reader = StateHistoryReader::new(pool, object_store().await);
+    let pairs = reader
+        .resolve_checkpoint_pairs(&CheckpointPairQuery::for_backends(
+            CHAIN_ID,
+            CheckpointPairSelection::BlockRange(BlockInterval::new(100, 210)?),
+            vec![Backend::Native],
+        ))
+        .await?;
+
+    assert_eq!(pairs.len(), 1);
+    assert_eq!(pairs[0].earlier.position, position(1, 0));
+    assert_eq!(pairs[0].target.position, position(1, 10));
     Ok(())
 }
 


### PR DESCRIPTION
Reconstructs native and RFQ state for requested blocks, returns directed pool quotes and provenance, and implements coverage and historical consistency checks over the reader. Keeping this engine independent of HTTP makes the reconstruction rules testable without service concerns.