### PR TITLE
feat: add historical quote service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1469,6 +1469,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-rds"
+version = "1.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa1e30b6464d7af541056ede9ed0acca3202bbdbb7df8c2983cf6e78ac9ee2dc"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "aws-sdk-s3"
 version = "1.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3557,6 +3584,34 @@ dependencies = [
  "tokio-util",
  "tycho-simulation",
  "utoipa 5.5.0",
+ "uuid",
+]
+
+[[package]]
+name = "historical-quote-service"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "aws-config",
+ "aws-sdk-rds",
+ "axum 0.7.9",
+ "bytes",
+ "chrono",
+ "futures 0.3.32",
+ "hex",
+ "historical-quote",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sqlx",
+ "state-history",
+ "subtle",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tracing",
+ "tracing-subscriber 0.3.23",
  "uuid",
 ]
 
@@ -6905,6 +6960,7 @@ dependencies = [
  "anyhow",
  "aws-config",
  "aws-sdk-s3",
+ "futures 0.3.32",
  "hex",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/broadcaster-replay-client",
     "crates/state-history",
     "crates/historical-quote",
+    "crates/historical-quote-service",
     "crates/runtime",
     "crates/rpc",
     "crates/apps",
@@ -23,8 +24,10 @@ alloy-primitives = "1.5.4"
 alloy-sol-types = "1.5.2"
 anyhow = "1.0"
 aws-config = "1"
+aws-sdk-rds = "1"
 aws-sdk-s3 = "1"
 axum = "0.7"
+bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }
 csv = "1.4.0"
 dotenv = "0.15.0"
@@ -43,6 +46,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }
 sha2 = "0.10"
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "tls-rustls", "postgres", "migrate", "macros"] }
+subtle = "2"
 thiserror = "2"
 tokio = { version = "1.0", features = ["full", "test-util"] }
 tokio-stream = "0.1.18"

--- a/crates/historical-quote-service/Cargo.toml
+++ b/crates/historical-quote-service/Cargo.toml
@@ -1,31 +1,37 @@
 [package]
-name = "state-history"
+name = "historical-quote-service"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Durable simulator state history models and persistence."
-
-[features]
-test-util = []
 
 [dependencies]
 anyhow.workspace = true
 aws-config.workspace = true
-aws-sdk-s3.workspace = true
+aws-sdk-rds.workspace = true
+axum.workspace = true
+bytes.workspace = true
+chrono.workspace = true
 futures.workspace = true
 hex.workspace = true
+historical-quote = { path = "../historical-quote" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
-simulator_core = { package = "simulator-core", path = "../simulator-core" }
 sqlx.workspace = true
+state-history = { path = "../state-history" }
+subtle.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
+tower.workspace = true
 tracing.workspace = true
-zstd.workspace = true
+tracing-subscriber.workspace = true
+uuid.workspace = true
+
+[dev-dependencies]
+tower.workspace = true
 
 [lints]
 workspace = true

--- a/crates/historical-quote-service/src/app.rs
+++ b/crates/historical-quote-service/src/app.rs
@@ -1,0 +1,276 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use axum::middleware;
+use axum::routing::{get, post};
+use axum::Router;
+use historical_quote::api::{
+    Backend, CoverageRequest, CoverageResponse, DependencyHealth, DependencyState, JobFailure,
+    JobFailureCode, JobResult,
+};
+use historical_quote::{
+    ConsistencyChecker, CoverageService, HistoricalError, HistoricalQuoteExecutor,
+    HistoricalReconstructor, HistorySource,
+};
+use state_history::{ReadConnectionProvider, ReadLimits, StateHistoryReader};
+
+use crate::auth::{require_bearer, BearerTokenVerifier};
+use crate::config::ServiceConfig;
+use crate::http::handlers;
+use crate::jobs::{ExecutionContext, JobExecutionError, JobExecutor, JobRegistry, JobRequest};
+
+type ServiceFuture<'a, T> =
+    Pin<Box<dyn Future<Output = Result<T, ServiceDependencyError>> + Send + 'a>>;
+
+#[derive(Clone)]
+pub struct AppState {
+    pub config: Arc<ServiceConfig>,
+    pub registry: JobRegistry,
+    pub coverage: Arc<dyn CoverageResolver>,
+    pub status: Arc<dyn StatusProbe>,
+}
+
+pub trait CoverageResolver: Send + Sync + 'static {
+    fn resolve(&self, request: CoverageRequest) -> ServiceFuture<'_, CoverageResponse>;
+}
+
+pub trait StatusProbe: Send + Sync + 'static {
+    fn probe(&self) -> ServiceFuture<'_, StatusDependencies>;
+}
+
+#[derive(Debug, Clone)]
+pub struct StatusDependencies {
+    pub visible_through_block: Option<u64>,
+    pub database: DependencyHealth,
+    pub object_store: DependencyHealth,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("service dependency is unavailable")]
+pub struct ServiceDependencyError;
+
+pub fn router(state: AppState) -> Router {
+    let verifier = BearerTokenVerifier::new(state.config.expected_bearer_digest);
+    let protected = Router::new()
+        .route("/jobs/quote", post(handlers::submit_quote))
+        .route(
+            "/jobs/consistency-check",
+            post(handlers::submit_consistency_check),
+        )
+        .route("/jobs/:job_id", get(handlers::get_job))
+        .route("/jobs/:job_id/cancel", post(handlers::cancel_job))
+        .route("/coverage", post(handlers::coverage))
+        .route("/status", get(handlers::status))
+        .route_layer(middleware::from_fn_with_state(verifier, require_bearer));
+    Router::new()
+        .route("/ready", get(handlers::ready))
+        .merge(protected)
+        .with_state(state)
+}
+
+pub struct EngineJobExecutor<S> {
+    source: Arc<S>,
+    service_revision: String,
+    read_limits: ReadLimits,
+    max_structured_differences: usize,
+    max_consistency_pairs: usize,
+}
+
+impl<S> EngineJobExecutor<S> {
+    pub fn new(source: Arc<S>, config: &ServiceConfig) -> Result<Self, ServiceDependencyError> {
+        let read_limits = ReadLimits::new(
+            config.job_decoded_byte_reservation,
+            config.job_decoded_byte_reservation,
+        )
+        .map_err(|_| ServiceDependencyError)?;
+        Ok(Self {
+            source,
+            service_revision: config.service_revision.clone(),
+            read_limits,
+            max_structured_differences: config.max_structured_differences,
+            max_consistency_pairs: config.max_consistency_pairs,
+        })
+    }
+}
+
+impl<S> JobExecutor for EngineJobExecutor<S>
+where
+    S: HistorySource,
+{
+    fn execute(
+        &self,
+        context: ExecutionContext,
+    ) -> Pin<Box<dyn Future<Output = Result<JobResult, JobExecutionError>> + Send + 'static>> {
+        let source = Arc::clone(&self.source);
+        let service_revision = self.service_revision.clone();
+        let read_limits = self.read_limits;
+        let max_structured_differences = self.max_structured_differences;
+        let max_consistency_pairs = self.max_consistency_pairs;
+        Box::pin(async move {
+            match context.request {
+                JobRequest::HistoricalQuote(request) => {
+                    let reconstructor = HistoricalReconstructor::new(source, read_limits);
+                    let executor = HistoricalQuoteExecutor::new(reconstructor, service_revision);
+                    executor
+                        .execute(&request, &context.cancellation, &context.progress)
+                        .await
+                        .map(JobResult::HistoricalQuote)
+                        .map_err(map_engine_error)
+                }
+                JobRequest::HistoricalStateConsistencyCheck(request) => {
+                    let checker = ConsistencyChecker::with_limits(
+                        source,
+                        read_limits,
+                        max_structured_differences,
+                        max_consistency_pairs,
+                    );
+                    checker
+                        .execute(&request, &context.cancellation, &context.progress)
+                        .await
+                        .map(JobResult::HistoricalStateConsistencyCheck)
+                        .map_err(map_engine_error)
+                }
+            }
+        })
+    }
+}
+
+pub struct EngineCoverageResolver<S> {
+    service: CoverageService<S>,
+}
+
+impl<S> EngineCoverageResolver<S> {
+    #[must_use]
+    pub fn new(source: Arc<S>) -> Self {
+        Self {
+            service: CoverageService::new(source),
+        }
+    }
+}
+
+impl<S> CoverageResolver for EngineCoverageResolver<S>
+where
+    S: HistorySource,
+{
+    fn resolve(&self, request: CoverageRequest) -> ServiceFuture<'_, CoverageResponse> {
+        Box::pin(async move {
+            self.service
+                .resolve(&request)
+                .await
+                .map_err(|_| ServiceDependencyError)
+        })
+    }
+}
+
+pub struct ReaderStatusProbe<P>
+where
+    P: ReadConnectionProvider,
+{
+    reader: Arc<StateHistoryReader<P>>,
+    chain_id: u64,
+    backends: Vec<state_history::Backend>,
+}
+
+impl<P> ReaderStatusProbe<P>
+where
+    P: ReadConnectionProvider,
+{
+    #[must_use]
+    pub fn new(reader: Arc<StateHistoryReader<P>>, chain_id: u64, backends: &[Backend]) -> Self {
+        Self {
+            reader,
+            chain_id,
+            backends: backends.iter().copied().map(history_backend).collect(),
+        }
+    }
+}
+
+impl<P> StatusProbe for ReaderStatusProbe<P>
+where
+    P: ReadConnectionProvider,
+{
+    fn probe(&self) -> ServiceFuture<'_, StatusDependencies> {
+        Box::pin(async move {
+            match self
+                .reader
+                .visible_through_block(self.chain_id, &self.backends)
+                .await
+            {
+                Ok(cutoff) => Ok(StatusDependencies {
+                    visible_through_block: Some(cutoff),
+                    database: healthy_dependency(),
+                    object_store: DependencyHealth {
+                        state: DependencyState::Degraded,
+                        message: Some("object reads are checked during jobs".to_owned()),
+                    },
+                }),
+                Err(_) => Ok(StatusDependencies {
+                    visible_through_block: None,
+                    database: DependencyHealth {
+                        state: DependencyState::Unavailable,
+                        message: Some("read replica cutoff is unavailable".to_owned()),
+                    },
+                    object_store: DependencyHealth {
+                        state: DependencyState::Degraded,
+                        message: Some("object reads are checked during jobs".to_owned()),
+                    },
+                }),
+            }
+        })
+    }
+}
+
+fn healthy_dependency() -> DependencyHealth {
+    DependencyHealth {
+        state: DependencyState::Healthy,
+        message: None,
+    }
+}
+
+fn history_backend(backend: Backend) -> state_history::Backend {
+    match backend {
+        Backend::Native => state_history::Backend::Native,
+        Backend::Vm => state_history::Backend::Vm,
+        Backend::Rfq => state_history::Backend::Rfq,
+    }
+}
+
+fn map_engine_error(error: HistoricalError) -> JobExecutionError {
+    let failure = match error {
+        HistoricalError::Cancelled => return JobExecutionError::Cancelled,
+        HistoricalError::HistoryRead { .. } => JobFailure {
+            code: JobFailureCode::HistoryReadFailed,
+            message: "historical state could not be read".to_owned(),
+            retryable: true,
+            details: None,
+        },
+        HistoricalError::HistoricalDataInvalid(_) => JobFailure {
+            code: JobFailureCode::HistoricalDataInvalid,
+            message: "retained historical data is invalid".to_owned(),
+            retryable: false,
+            details: None,
+        },
+        HistoricalError::StateReconstructionFailed(_) | HistoricalError::UnsupportedCanonicalVm => {
+            JobFailure {
+                code: JobFailureCode::StateReconstructionFailed,
+                message: "historical state could not be reconstructed".to_owned(),
+                retryable: false,
+                details: None,
+            }
+        }
+        HistoricalError::CheckBudgetExceeded => JobFailure {
+            code: JobFailureCode::CheckBudgetExceeded,
+            message: "checkpoint pair limit was exceeded".to_owned(),
+            retryable: false,
+            details: None,
+        },
+        HistoricalError::InvalidSelector(_) => JobFailure {
+            code: JobFailureCode::InternalError,
+            message: "historical job could not be completed".to_owned(),
+            retryable: false,
+            details: None,
+        },
+    };
+    JobExecutionError::Failed(failure)
+}

--- a/crates/historical-quote-service/src/auth.rs
+++ b/crates/historical-quote-service/src/auth.rs
@@ -1,0 +1,82 @@
+use axum::body::Body;
+use axum::extract::{Request, State};
+use axum::http::header::AUTHORIZATION;
+use axum::http::StatusCode;
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use historical_quote::api::{ApiError, ApiErrorCode};
+use sha2::{Digest, Sha256};
+use subtle::ConstantTimeEq;
+
+#[derive(Clone)]
+pub struct BearerTokenVerifier {
+    expected_digest: [u8; 32],
+}
+
+impl BearerTokenVerifier {
+    #[must_use]
+    pub const fn new(expected_digest: [u8; 32]) -> Self {
+        Self { expected_digest }
+    }
+
+    #[must_use]
+    pub fn verify(&self, presented: &str) -> bool {
+        let candidate: [u8; 32] = Sha256::digest(presented.as_bytes()).into();
+        bool::from(candidate.ct_eq(&self.expected_digest))
+    }
+}
+
+pub async fn require_bearer(
+    State(verifier): State<BearerTokenVerifier>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    let token = request
+        .headers()
+        .get(AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(bearer_value);
+    if token.is_some_and(|token| verifier.verify(token)) {
+        return next.run(request).await;
+    }
+    (
+        StatusCode::UNAUTHORIZED,
+        axum::Json(ApiError {
+            code: ApiErrorCode::Unauthorized,
+            message: "bearer token is missing or invalid".to_owned(),
+            retryable: false,
+            details: None,
+        }),
+    )
+        .into_response()
+}
+
+fn bearer_value(value: &str) -> Option<&str> {
+    let (scheme, token) = value.split_once(' ')?;
+    (scheme.eq_ignore_ascii_case("bearer") && !token.is_empty() && !token.contains(' '))
+        .then_some(token)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verifies_only_the_token_matching_the_configured_digest() {
+        let expected_digest = Sha256::digest(b"expected-token").into();
+        let verifier = BearerTokenVerifier::new(expected_digest);
+
+        assert!(verifier.verify("expected-token"));
+        assert!(!verifier.verify("wrong-token"));
+        assert!(!verifier.verify(""));
+    }
+
+    #[test]
+    fn accepts_one_bearer_value_without_normalizing_the_secret() {
+        assert_eq!(bearer_value("Bearer exact-token"), Some("exact-token"));
+        assert_eq!(bearer_value("bearer exact-token"), Some("exact-token"));
+        assert_eq!(bearer_value("Bearer exact-token "), None);
+        assert_eq!(bearer_value("Bearer  exact-token"), None);
+        assert_eq!(bearer_value("Basic exact-token"), None);
+    }
+}

--- a/crates/historical-quote-service/src/config.rs
+++ b/crates/historical-quote-service/src/config.rs
@@ -1,0 +1,320 @@
+use std::collections::BTreeSet;
+use std::env;
+use std::net::SocketAddr;
+use std::str::FromStr;
+use std::time::Duration;
+
+use historical_quote::api::{Backend, ServiceLimits, API_REVISION};
+
+use crate::jobs::JobLimits;
+
+const DEFAULT_BIND_ADDRESS: &str = "0.0.0.0:3100";
+const DEFAULT_MAX_RUNNING_JOBS: usize = 4;
+const DEFAULT_MAX_WAITING_JOBS: usize = 16;
+const DEFAULT_MAX_TERMINAL_JOBS: usize = 20;
+const DEFAULT_TERMINAL_TTL_SECONDS: u64 = 3_600;
+const DEFAULT_DATABASE_PORT: u16 = 5_432;
+const DEFAULT_DATABASE_CONNECTIONS: usize = 4;
+const DEFAULT_DATABASE_CONNECTION_LIFETIME_SECONDS: u64 = 3_600;
+const DEFAULT_SHUTDOWN_TIMEOUT_SECONDS: u64 = 25;
+
+#[derive(Clone)]
+pub struct ServiceConfig {
+    pub bind_address: SocketAddr,
+    pub supported_chain_id: u64,
+    pub service_revision: String,
+    pub enabled_backends: Vec<Backend>,
+    pub expected_bearer_digest: [u8; 32],
+    pub scheduler: JobLimits,
+    pub max_combination_count: u64,
+    pub max_block_span: u64,
+    pub default_timeout_ms: u64,
+    pub max_timeout_ms: u64,
+    pub job_decoded_byte_reservation: u64,
+    pub max_consistency_pairs: usize,
+    pub max_quote_selectors: usize,
+    pub max_amounts_per_quote: usize,
+    pub max_structured_differences: usize,
+    pub database: ReplicaDatabaseConfig,
+    pub object_store: ObjectStoreConfig,
+    pub shutdown_timeout: Duration,
+}
+
+#[derive(Clone)]
+pub struct ReplicaDatabaseConfig {
+    pub host: String,
+    pub port: u16,
+    pub database: String,
+    pub username: String,
+    pub max_connections: usize,
+    pub max_connection_lifetime: Duration,
+}
+
+#[derive(Clone)]
+pub struct ObjectStoreConfig {
+    pub bucket: String,
+    pub prefix: String,
+    pub region: String,
+    pub endpoint_url: Option<String>,
+    pub force_path_style: bool,
+}
+
+impl ServiceConfig {
+    /// Loads the strict production configuration from the process environment.
+    ///
+    /// Workload sizes are required here because Phase 7 owns their measured
+    /// production values.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when a required value is absent, malformed, or unsafe.
+    pub fn from_env() -> Result<Self, ConfigError> {
+        let bind_address = match env::var("DSOLVER_HISTORY_BIND_ADDRESS") {
+            Ok(value) => parse_value("DSOLVER_HISTORY_BIND_ADDRESS", &value)?,
+            Err(_) => parse_value("DSOLVER_HISTORY_BIND_ADDRESS", DEFAULT_BIND_ADDRESS)?,
+        };
+        let service_revision = required("DSOLVER_HISTORY_SERVICE_REVISION")?;
+        let api_revision: u32 = parse_required("DSOLVER_HISTORY_API_REVISION")?;
+        if api_revision != API_REVISION {
+            return Err(ConfigError::Invalid(
+                "configured API revision must match the compiled revision".to_owned(),
+            ));
+        }
+        let supported_chain_id: u64 = parse_required("DSOLVER_HISTORY_CHAIN_ID")?;
+        if supported_chain_id != 8_453 {
+            return Err(ConfigError::Invalid(
+                "historical quote service supports Base chain ID 8453 only".to_owned(),
+            ));
+        }
+        let enabled_backends = parse_backends(&required("DSOLVER_HISTORY_ENABLED_BACKENDS")?)?;
+        let expected_bearer_digest = parse_digest(&required("DSOLVER_HISTORY_TOKEN_SHA256")?)?;
+        let max_running =
+            parse_optional("DSOLVER_HISTORY_MAX_RUNNING_JOBS", DEFAULT_MAX_RUNNING_JOBS)?;
+        let max_waiting =
+            parse_optional("DSOLVER_HISTORY_MAX_WAITING_JOBS", DEFAULT_MAX_WAITING_JOBS)?;
+        let decoded_byte_budget = parse_required("DSOLVER_HISTORY_DECODED_BYTE_BUDGET")?;
+        let max_terminal_jobs = parse_optional(
+            "DSOLVER_HISTORY_MAX_TERMINAL_JOBS",
+            DEFAULT_MAX_TERMINAL_JOBS,
+        )?;
+        let terminal_ttl_seconds = parse_optional(
+            "DSOLVER_HISTORY_TERMINAL_TTL_SECONDS",
+            DEFAULT_TERMINAL_TTL_SECONDS,
+        )?;
+        let default_timeout_ms = parse_required("DSOLVER_HISTORY_DEFAULT_TIMEOUT_MS")?;
+        let max_timeout_ms = parse_required("DSOLVER_HISTORY_MAX_TIMEOUT_MS")?;
+        if default_timeout_ms > max_timeout_ms {
+            return Err(ConfigError::Invalid(
+                "default timeout must not exceed maximum timeout".to_owned(),
+            ));
+        }
+        let job_decoded_byte_reservation =
+            parse_required("DSOLVER_HISTORY_JOB_DECODED_BYTE_RESERVATION")?;
+        if job_decoded_byte_reservation > decoded_byte_budget {
+            return Err(ConfigError::Invalid(
+                "job decoded-byte reservation must not exceed the global budget".to_owned(),
+            ));
+        }
+
+        let username = required("DSOLVER_HISTORY_REPLICA_DB_USER")?;
+        if username != "state_history_observer" {
+            return Err(ConfigError::Invalid(
+                "replica database user must be state_history_observer".to_owned(),
+            ));
+        }
+
+        let config = Self {
+            bind_address,
+            supported_chain_id,
+            service_revision,
+            enabled_backends,
+            expected_bearer_digest,
+            scheduler: JobLimits {
+                max_running,
+                max_waiting,
+                decoded_byte_budget,
+                max_terminal_jobs,
+                terminal_ttl: Duration::from_secs(terminal_ttl_seconds),
+            },
+            max_combination_count: parse_required("DSOLVER_HISTORY_MAX_COMBINATION_COUNT")?,
+            max_block_span: parse_required("DSOLVER_HISTORY_MAX_BLOCK_SPAN")?,
+            default_timeout_ms,
+            max_timeout_ms,
+            job_decoded_byte_reservation,
+            max_consistency_pairs: parse_required("DSOLVER_HISTORY_MAX_CONSISTENCY_PAIRS")?,
+            max_quote_selectors: parse_required("DSOLVER_HISTORY_MAX_QUOTE_SELECTORS")?,
+            max_amounts_per_quote: parse_required("DSOLVER_HISTORY_MAX_AMOUNTS_PER_QUOTE")?,
+            max_structured_differences: parse_required(
+                "DSOLVER_HISTORY_MAX_STRUCTURED_DIFFERENCES",
+            )?,
+            database: database_config(username)?,
+            object_store: object_store_config()?,
+            shutdown_timeout: Duration::from_secs(parse_optional(
+                "DSOLVER_HISTORY_SHUTDOWN_TIMEOUT_SECONDS",
+                DEFAULT_SHUTDOWN_TIMEOUT_SECONDS,
+            )?),
+        };
+        config.validate()?;
+        Ok(config)
+    }
+
+    #[must_use]
+    pub fn public_limits(&self) -> ServiceLimits {
+        ServiceLimits {
+            max_combination_count: self.max_combination_count,
+            max_block_span: self.max_block_span,
+            default_timeout_ms: self.default_timeout_ms,
+            max_timeout_ms: self.max_timeout_ms,
+            max_running_jobs: usize_to_u64(self.scheduler.max_running),
+            max_waiting_jobs: usize_to_u64(self.scheduler.max_waiting),
+            decoded_byte_budget: self.scheduler.decoded_byte_budget,
+            max_terminal_jobs: usize_to_u64(self.scheduler.max_terminal_jobs),
+            terminal_retention_seconds: self.scheduler.terminal_ttl.as_secs(),
+            max_consistency_pairs: usize_to_u64(self.max_consistency_pairs),
+            max_quote_selectors: usize_to_u64(self.max_quote_selectors),
+            max_amounts_per_quote: usize_to_u64(self.max_amounts_per_quote),
+            max_structured_differences: usize_to_u64(self.max_structured_differences),
+        }
+    }
+
+    #[must_use]
+    pub const fn api_revision(&self) -> u32 {
+        API_REVISION
+    }
+
+    fn validate(&self) -> Result<(), ConfigError> {
+        let positive = self.scheduler.max_running > 0
+            && self.scheduler.max_waiting > 0
+            && self.scheduler.decoded_byte_budget > 0
+            && self.scheduler.max_terminal_jobs > 0
+            && !self.scheduler.terminal_ttl.is_zero()
+            && self.max_combination_count > 0
+            && self.max_block_span > 0
+            && self.default_timeout_ms > 0
+            && self.max_timeout_ms > 0
+            && self.job_decoded_byte_reservation > 0
+            && self.max_consistency_pairs > 0
+            && self.max_quote_selectors > 0
+            && self.max_amounts_per_quote > 0
+            && self.max_structured_differences > 0
+            && self.database.max_connections > 0
+            && !self.database.max_connection_lifetime.is_zero()
+            && !self.shutdown_timeout.is_zero();
+        if !positive {
+            return Err(ConfigError::Invalid(
+                "service limits must be positive".to_owned(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn usize_to_u64(value: usize) -> u64 {
+    u64::try_from(value).unwrap_or(u64::MAX)
+}
+
+fn database_config(username: String) -> Result<ReplicaDatabaseConfig, ConfigError> {
+    Ok(ReplicaDatabaseConfig {
+        host: required("DSOLVER_HISTORY_REPLICA_DB_HOST")?,
+        port: parse_optional("DSOLVER_HISTORY_REPLICA_DB_PORT", DEFAULT_DATABASE_PORT)?,
+        database: required("DSOLVER_HISTORY_REPLICA_DB_NAME")?,
+        username,
+        max_connections: parse_optional(
+            "DSOLVER_HISTORY_REPLICA_DB_MAX_CONNECTIONS",
+            DEFAULT_DATABASE_CONNECTIONS,
+        )?,
+        max_connection_lifetime: Duration::from_secs(parse_optional(
+            "DSOLVER_HISTORY_REPLICA_DB_CONNECTION_LIFETIME_SECONDS",
+            DEFAULT_DATABASE_CONNECTION_LIFETIME_SECONDS,
+        )?),
+    })
+}
+
+fn object_store_config() -> Result<ObjectStoreConfig, ConfigError> {
+    Ok(ObjectStoreConfig {
+        bucket: required("DSOLVER_HISTORY_S3_BUCKET")?,
+        prefix: required("DSOLVER_HISTORY_S3_PREFIX")?,
+        region: required("AWS_REGION")?,
+        endpoint_url: env::var("DSOLVER_HISTORY_S3_ENDPOINT_URL").ok(),
+        force_path_style: parse_bool_optional("DSOLVER_HISTORY_S3_FORCE_PATH_STYLE", false)?,
+    })
+}
+
+fn required(name: &'static str) -> Result<String, ConfigError> {
+    let value = env::var(name).map_err(|_| ConfigError::Missing(name))?;
+    if value.is_empty() {
+        return Err(ConfigError::Malformed(name));
+    }
+    Ok(value)
+}
+
+fn parse_required<T>(name: &'static str) -> Result<T, ConfigError>
+where
+    T: FromStr,
+{
+    parse_value(name, &required(name)?)
+}
+
+fn parse_optional<T>(name: &'static str, default: T) -> Result<T, ConfigError>
+where
+    T: FromStr,
+{
+    match env::var(name) {
+        Ok(value) => parse_value(name, &value),
+        Err(_) => Ok(default),
+    }
+}
+
+fn parse_value<T>(name: &'static str, value: &str) -> Result<T, ConfigError>
+where
+    T: FromStr,
+{
+    value.parse().map_err(|_| ConfigError::Malformed(name))
+}
+
+fn parse_bool_optional(name: &'static str, default: bool) -> Result<bool, ConfigError> {
+    parse_optional(name, default)
+}
+
+fn parse_backends(value: &str) -> Result<Vec<Backend>, ConfigError> {
+    let mut backends = Vec::new();
+    let mut distinct = BTreeSet::new();
+    for raw in value.split(',') {
+        let backend = match raw.trim() {
+            "native" => Backend::Native,
+            "vm" => Backend::Vm,
+            "rfq" => Backend::Rfq,
+            _ => return Err(ConfigError::Malformed("DSOLVER_HISTORY_ENABLED_BACKENDS")),
+        };
+        if !distinct.insert(backend) {
+            return Err(ConfigError::Invalid(
+                "enabled backends must be duplicate-free".to_owned(),
+            ));
+        }
+        backends.push(backend);
+    }
+    if backends.is_empty() {
+        return Err(ConfigError::Invalid(
+            "at least one backend must be enabled".to_owned(),
+        ));
+    }
+    Ok(backends)
+}
+
+fn parse_digest(value: &str) -> Result<[u8; 32], ConfigError> {
+    let decoded =
+        hex::decode(value).map_err(|_| ConfigError::Malformed("DSOLVER_HISTORY_TOKEN_SHA256"))?;
+    decoded
+        .try_into()
+        .map_err(|_| ConfigError::Malformed("DSOLVER_HISTORY_TOKEN_SHA256"))
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    #[error("required configuration is missing: {0}")]
+    Missing(&'static str),
+    #[error("configuration value is malformed: {0}")]
+    Malformed(&'static str),
+    #[error("configuration is invalid: {0}")]
+    Invalid(String),
+}

--- a/crates/historical-quote-service/src/database.rs
+++ b/crates/historical-quote-service/src/database.rs
@@ -1,0 +1,472 @@
+use std::future::Future;
+use std::ops::{Deref, DerefMut};
+use std::pin::Pin;
+use std::sync::{Arc, Mutex, Weak};
+use std::time::{Duration, Instant};
+
+use aws_sdk_rds::auth_token::{AuthTokenGenerator, Config as AuthTokenConfig};
+use sqlx::postgres::{PgConnectOptions, PgSslMode};
+use sqlx::{ConnectOptions, Connection, PgConnection};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+use crate::config::ReplicaDatabaseConfig;
+
+type DatabaseFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, DatabaseError>> + Send + 'a>>;
+
+pub trait IamTokenProvider: Send + Sync + 'static {
+    fn generate(&self) -> DatabaseFuture<'_, SecretToken>;
+}
+
+pub trait PhysicalConnectionFactory: Send + Sync + 'static {
+    type Connection: Send + 'static;
+
+    fn open(&self, token: SecretToken) -> DatabaseFuture<'_, Self::Connection>;
+
+    fn ping<'a>(&'a self, connection: &'a mut Self::Connection) -> DatabaseFuture<'a, ()>;
+}
+
+pub struct SecretToken(String);
+
+impl SecretToken {
+    fn expose(&self) -> &str {
+        &self.0
+    }
+}
+
+pub struct RdsIamTokenProvider {
+    generator: AuthTokenGenerator,
+    sdk_config: aws_config::SdkConfig,
+}
+
+impl RdsIamTokenProvider {
+    /// Creates the signer for the exact replica endpoint and observer user.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the signing configuration is invalid.
+    pub fn new(
+        config: &ReplicaDatabaseConfig,
+        sdk_config: aws_config::SdkConfig,
+    ) -> Result<Self, DatabaseError> {
+        let signer_config = AuthTokenConfig::builder()
+            .hostname(config.host.clone())
+            .port(u64::from(config.port))
+            .username(config.username.clone())
+            .build()
+            .map_err(|_| DatabaseError::Configuration)?;
+        Ok(Self {
+            generator: AuthTokenGenerator::new(signer_config),
+            sdk_config,
+        })
+    }
+}
+
+impl IamTokenProvider for RdsIamTokenProvider {
+    fn generate(&self) -> DatabaseFuture<'_, SecretToken> {
+        Box::pin(async move {
+            let token = self
+                .generator
+                .auth_token(&self.sdk_config)
+                .await
+                .map_err(|_| DatabaseError::Credential)?;
+            Ok(SecretToken(token.as_str().to_owned()))
+        })
+    }
+}
+
+pub struct PostgresConnectionFactory {
+    base_options: PgConnectOptions,
+}
+
+impl PostgresConnectionFactory {
+    #[must_use]
+    pub fn new(config: &ReplicaDatabaseConfig) -> Self {
+        let base_options = PgConnectOptions::new()
+            .host(&config.host)
+            .port(config.port)
+            .username(&config.username)
+            .database(&config.database)
+            .ssl_mode(PgSslMode::VerifyFull)
+            .disable_statement_logging();
+        Self { base_options }
+    }
+}
+
+impl PhysicalConnectionFactory for PostgresConnectionFactory {
+    type Connection = PgConnection;
+
+    fn open(&self, token: SecretToken) -> DatabaseFuture<'_, Self::Connection> {
+        Box::pin(async move {
+            let options = self.base_options.clone().password(token.expose());
+            PgConnection::connect_with(&options)
+                .await
+                .map_err(|_| DatabaseError::Connect)
+        })
+    }
+
+    fn ping<'a>(&'a self, connection: &'a mut Self::Connection) -> DatabaseFuture<'a, ()> {
+        Box::pin(async move { connection.ping().await.map_err(|_| DatabaseError::Health) })
+    }
+}
+
+pub struct IamConnectionPool<T, F>
+where
+    T: IamTokenProvider,
+    F: PhysicalConnectionFactory,
+{
+    inner: Arc<PoolInner<T, F>>,
+}
+
+impl<T, F> Clone for IamConnectionPool<T, F>
+where
+    T: IamTokenProvider,
+    F: PhysicalConnectionFactory,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+struct PoolInner<T, F>
+where
+    T: IamTokenProvider,
+    F: PhysicalConnectionFactory,
+{
+    token_provider: T,
+    connection_factory: F,
+    permits: Arc<Semaphore>,
+    idle: Mutex<Vec<IdleConnection<F::Connection>>>,
+    max_lifetime: Duration,
+}
+
+struct IdleConnection<C> {
+    connection: C,
+    opened_at: Instant,
+}
+
+pub struct ConnectionLease<T, F>
+where
+    T: IamTokenProvider,
+    F: PhysicalConnectionFactory,
+{
+    connection: Option<F::Connection>,
+    opened_at: Instant,
+    permit: Option<OwnedSemaphorePermit>,
+    pool: Weak<PoolInner<T, F>>,
+}
+
+impl<T, F> IamConnectionPool<T, F>
+where
+    T: IamTokenProvider,
+    F: PhysicalConnectionFactory,
+{
+    /// Creates a small pool that signs only when it opens a physical connection.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the connection count or lifetime is zero.
+    pub fn new(
+        token_provider: T,
+        connection_factory: F,
+        max_connections: usize,
+        max_lifetime: Duration,
+    ) -> Result<Self, DatabaseError> {
+        if max_connections == 0 || max_lifetime.is_zero() {
+            return Err(DatabaseError::Configuration);
+        }
+        Ok(Self {
+            inner: Arc::new(PoolInner {
+                token_provider,
+                connection_factory,
+                permits: Arc::new(Semaphore::new(max_connections)),
+                idle: Mutex::new(Vec::new()),
+                max_lifetime,
+            }),
+        })
+    }
+
+    /// Acquires a healthy connection or opens one with a fresh IAM token.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when credential generation, connection establishment,
+    /// or pool coordination fails.
+    pub async fn acquire(&self) -> Result<ConnectionLease<T, F>, DatabaseError> {
+        let permit = Arc::clone(&self.inner.permits)
+            .acquire_owned()
+            .await
+            .map_err(|_| DatabaseError::Closed)?;
+        loop {
+            if let Some(mut idle) = self.take_idle()? {
+                if idle.opened_at.elapsed() >= self.inner.max_lifetime {
+                    continue;
+                }
+                if self
+                    .inner
+                    .connection_factory
+                    .ping(&mut idle.connection)
+                    .await
+                    .is_ok()
+                {
+                    tracing::trace!(
+                        credential_label = "state_history_observer",
+                        "reusing healthy replica connection"
+                    );
+                    return Ok(ConnectionLease {
+                        connection: Some(idle.connection),
+                        opened_at: idle.opened_at,
+                        permit: Some(permit),
+                        pool: Arc::downgrade(&self.inner),
+                    });
+                }
+                continue;
+            }
+
+            tracing::debug!(
+                credential_label = "state_history_observer",
+                "opening replica connection with a fresh IAM credential"
+            );
+            let token = self.inner.token_provider.generate().await?;
+            let connection = self.inner.connection_factory.open(token).await?;
+            return Ok(ConnectionLease {
+                connection: Some(connection),
+                opened_at: Instant::now(),
+                permit: Some(permit),
+                pool: Arc::downgrade(&self.inner),
+            });
+        }
+    }
+
+    fn take_idle(&self) -> Result<Option<IdleConnection<F::Connection>>, DatabaseError> {
+        self.inner
+            .idle
+            .lock()
+            .map_err(|_| DatabaseError::Closed)
+            .map(|mut idle| idle.pop())
+    }
+}
+
+impl<T, F> Deref for ConnectionLease<T, F>
+where
+    T: IamTokenProvider,
+    F: PhysicalConnectionFactory,
+{
+    type Target = F::Connection;
+
+    #[expect(
+        clippy::expect_used,
+        reason = "a live lease always owns its connection"
+    )]
+    fn deref(&self) -> &Self::Target {
+        self.connection.as_ref().expect("connection lease is empty")
+    }
+}
+
+impl<T, F> DerefMut for ConnectionLease<T, F>
+where
+    T: IamTokenProvider,
+    F: PhysicalConnectionFactory,
+{
+    #[expect(
+        clippy::expect_used,
+        reason = "a live lease always owns its connection"
+    )]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.connection.as_mut().expect("connection lease is empty")
+    }
+}
+
+impl<T, F> Drop for ConnectionLease<T, F>
+where
+    T: IamTokenProvider,
+    F: PhysicalConnectionFactory,
+{
+    fn drop(&mut self) {
+        let (Some(connection), Some(permit), Some(pool)) = (
+            self.connection.take(),
+            self.permit.take(),
+            self.pool.upgrade(),
+        ) else {
+            return;
+        };
+        if self.opened_at.elapsed() >= pool.max_lifetime {
+            return;
+        }
+        if let Ok(mut idle) = pool.idle.lock() {
+            idle.push(IdleConnection {
+                connection,
+                opened_at: self.opened_at,
+            });
+        };
+        drop(permit);
+    }
+}
+
+impl<T, F> state_history::ReadConnectionProvider for IamConnectionPool<T, F>
+where
+    T: IamTokenProvider,
+    F: PhysicalConnectionFactory<Connection = PgConnection>,
+{
+    type Connection<'a>
+        = ConnectionLease<T, F>
+    where
+        Self: 'a;
+
+    async fn acquire(&self) -> Result<Self::Connection<'_>, sqlx::Error> {
+        IamConnectionPool::acquire(self)
+            .await
+            .map_err(|error| sqlx::Error::Configuration(Box::new(error)))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum DatabaseError {
+    #[error("database configuration is invalid")]
+    Configuration,
+    #[error("database login credential could not be generated")]
+    Credential,
+    #[error("database connection could not be opened")]
+    Connect,
+    #[error("database connection health check failed")]
+    Health,
+    #[error("database connection pool is closed")]
+    Closed,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct FakeTokenProvider {
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl IamTokenProvider for FakeTokenProvider {
+        fn generate(&self) -> DatabaseFuture<'_, SecretToken> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            Box::pin(async { Ok(SecretToken("signed-token".to_owned())) })
+        }
+    }
+
+    #[derive(Clone)]
+    struct FakeConnectionFactory {
+        opens: Arc<AtomicUsize>,
+        pings: Arc<AtomicUsize>,
+    }
+
+    struct FakeConnection {
+        healthy: Arc<AtomicBool>,
+    }
+
+    impl PhysicalConnectionFactory for FakeConnectionFactory {
+        type Connection = FakeConnection;
+
+        fn open(&self, _token: SecretToken) -> DatabaseFuture<'_, Self::Connection> {
+            self.opens.fetch_add(1, Ordering::Relaxed);
+            Box::pin(async {
+                Ok(FakeConnection {
+                    healthy: Arc::new(AtomicBool::new(true)),
+                })
+            })
+        }
+
+        fn ping<'a>(&'a self, connection: &'a mut Self::Connection) -> DatabaseFuture<'a, ()> {
+            self.pings.fetch_add(1, Ordering::Relaxed);
+            Box::pin(async move {
+                if connection.healthy.load(Ordering::Relaxed) {
+                    Ok(())
+                } else {
+                    Err(DatabaseError::Health)
+                }
+            })
+        }
+    }
+
+    #[tokio::test]
+    #[expect(clippy::unwrap_used, reason = "the fake pool must acquire connections")]
+    async fn signs_each_physical_open_and_reuses_a_healthy_connection() {
+        let token_calls = Arc::new(AtomicUsize::new(0));
+        let opens = Arc::new(AtomicUsize::new(0));
+        let pings = Arc::new(AtomicUsize::new(0));
+        let pool = IamConnectionPool::new(
+            FakeTokenProvider {
+                calls: Arc::clone(&token_calls),
+            },
+            FakeConnectionFactory {
+                opens: Arc::clone(&opens),
+                pings: Arc::clone(&pings),
+            },
+            2,
+            Duration::from_secs(60),
+        )
+        .unwrap();
+
+        drop(pool.acquire().await.unwrap());
+        drop(pool.acquire().await.unwrap());
+        assert_eq!(token_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(opens.load(Ordering::Relaxed), 1);
+        assert_eq!(pings.load(Ordering::Relaxed), 1);
+
+        let first = pool.acquire().await.unwrap();
+        let second = pool.acquire().await.unwrap();
+        assert_eq!(token_calls.load(Ordering::Relaxed), 2);
+        assert_eq!(opens.load(Ordering::Relaxed), 2);
+        drop((first, second));
+    }
+
+    #[tokio::test]
+    #[expect(clippy::unwrap_used, reason = "the fake pool must acquire connections")]
+    async fn failed_health_check_opens_with_a_new_token() {
+        let token_calls = Arc::new(AtomicUsize::new(0));
+        let pool = IamConnectionPool::new(
+            FakeTokenProvider {
+                calls: Arc::clone(&token_calls),
+            },
+            FakeConnectionFactory {
+                opens: Arc::new(AtomicUsize::new(0)),
+                pings: Arc::new(AtomicUsize::new(0)),
+            },
+            1,
+            Duration::from_secs(60),
+        )
+        .unwrap();
+        let connection = pool.acquire().await.unwrap();
+        connection.healthy.store(false, Ordering::Relaxed);
+        drop(connection);
+
+        drop(pool.acquire().await.unwrap());
+        assert_eq!(token_calls.load(Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test]
+    #[expect(clippy::unwrap_used, reason = "the fake pool must acquire connections")]
+    async fn waiting_acquire_reuses_a_connection_after_the_lease_returns() {
+        let token_calls = Arc::new(AtomicUsize::new(0));
+        let pool = IamConnectionPool::new(
+            FakeTokenProvider {
+                calls: Arc::clone(&token_calls),
+            },
+            FakeConnectionFactory {
+                opens: Arc::new(AtomicUsize::new(0)),
+                pings: Arc::new(AtomicUsize::new(0)),
+            },
+            1,
+            Duration::from_secs(60),
+        )
+        .unwrap();
+        let first = pool.acquire().await.unwrap();
+        let waiting_pool = pool.clone();
+        let waiter = tokio::spawn(async move { waiting_pool.acquire().await.unwrap() });
+        tokio::task::yield_now().await;
+        assert!(!waiter.is_finished());
+
+        drop(first);
+        drop(waiter.await.unwrap());
+        assert_eq!(token_calls.load(Ordering::Relaxed), 1);
+    }
+}

--- a/crates/historical-quote-service/src/http/error.rs
+++ b/crates/historical-quote-service/src/http/error.rs
@@ -1,0 +1,111 @@
+use axum::http::header::RETRY_AFTER;
+use axum::http::{HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Response};
+use historical_quote::api::{ApiError, ApiErrorCode};
+use serde_json::Value;
+
+pub struct HttpError {
+    status: StatusCode,
+    body: Box<ApiError>,
+    retry_after_seconds: Option<u64>,
+}
+
+impl HttpError {
+    pub fn invalid(message: impl Into<String>, details: Option<Value>) -> Self {
+        Self::new(
+            StatusCode::BAD_REQUEST,
+            ApiErrorCode::InvalidRequest,
+            message,
+            false,
+            details,
+        )
+    }
+
+    pub fn job_not_found() -> Self {
+        Self::new(
+            StatusCode::NOT_FOUND,
+            ApiErrorCode::JobNotFound,
+            "job was not found",
+            false,
+            None,
+        )
+    }
+
+    pub fn request_id_conflict() -> Self {
+        Self::new(
+            StatusCode::CONFLICT,
+            ApiErrorCode::RequestIdConflict,
+            "requestId is retained with different request content",
+            false,
+            None,
+        )
+    }
+
+    pub fn comparison_budget(details: Value) -> Self {
+        Self::new(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            ApiErrorCode::ComparisonBudgetExceeded,
+            "quote comparison budget was exceeded",
+            false,
+            Some(details),
+        )
+    }
+
+    pub fn queue_full(retry_after_seconds: u64) -> Self {
+        Self::new(
+            StatusCode::TOO_MANY_REQUESTS,
+            ApiErrorCode::QueueFull,
+            "job queue is full",
+            true,
+            None,
+        )
+        .with_retry_after(retry_after_seconds)
+    }
+
+    pub fn unavailable(retry_after_seconds: u64) -> Self {
+        Self::new(
+            StatusCode::SERVICE_UNAVAILABLE,
+            ApiErrorCode::ServiceUnavailable,
+            "service cannot safely accept this request",
+            true,
+            None,
+        )
+        .with_retry_after(retry_after_seconds)
+    }
+
+    fn new(
+        status: StatusCode,
+        code: ApiErrorCode,
+        message: impl Into<String>,
+        retryable: bool,
+        details: Option<Value>,
+    ) -> Self {
+        Self {
+            status,
+            body: Box::new(ApiError {
+                code,
+                message: message.into(),
+                retryable,
+                details,
+            }),
+            retry_after_seconds: None,
+        }
+    }
+
+    fn with_retry_after(mut self, seconds: u64) -> Self {
+        self.retry_after_seconds = Some(seconds);
+        self
+    }
+}
+
+impl IntoResponse for HttpError {
+    fn into_response(self) -> Response {
+        let mut response = (self.status, axum::Json(*self.body)).into_response();
+        if let Some(seconds) = self.retry_after_seconds {
+            if let Ok(value) = HeaderValue::from_str(&seconds.to_string()) {
+                response.headers_mut().insert(RETRY_AFTER, value);
+            }
+        }
+        response
+    }
+}

--- a/crates/historical-quote-service/src/http/handlers.rs
+++ b/crates/historical-quote-service/src/http/handlers.rs
@@ -1,0 +1,355 @@
+use axum::extract::rejection::JsonRejection;
+use axum::extract::{Path, State};
+use axum::http::header::{CONTENT_TYPE, LOCATION, RETRY_AFTER};
+use axum::http::{HeaderMap, HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use historical_quote::api::{
+    Backend, ComparisonBudgetDetails, ConsistencyCheckRequest, ConsistencySelection,
+    CoverageRequest, DependencyHealth, DependencyState, QuoteJobRequest, ReadyResponse,
+    StatusResponse, API_REVISION,
+};
+use uuid::Uuid;
+
+use crate::app::{AppState, StatusDependencies};
+use crate::http::error::HttpError;
+use crate::jobs::{
+    terminal_response_body, CancelOutcome, JobRequest, PollOutcome, ScheduledJob, SubmitOutcome,
+};
+
+const RETRY_AFTER_SECONDS: u64 = 2;
+const REVISION_HEADER: &str = "x-dsolver-history-api-revision";
+
+pub async fn submit_quote(
+    State(state): State<AppState>,
+    request: Result<Json<QuoteJobRequest>, JsonRejection>,
+) -> Result<Response, HttpError> {
+    let request = request
+        .map_err(|_| HttpError::invalid("request body is invalid", None))?
+        .0;
+    validate_quote(&state, &request)?;
+    let request_id = request.request_id;
+    let dimensions = quote_dimensions(&request)?;
+    let outcome = state
+        .registry
+        .submit(ScheduledJob::new(
+            JobRequest::HistoricalQuote(request),
+            state.config.job_decoded_byte_reservation,
+        ))
+        .await;
+    tracing::info!(
+        %request_id,
+        start_block_count = dimensions.start_block_count,
+        lag_count = dimensions.lag_count,
+        input_amount_count = dimensions.input_amount_count,
+        combination_count = dimensions.combination_count,
+        "historical quote job submission resolved"
+    );
+    submission_response(outcome)
+}
+
+pub async fn submit_consistency_check(
+    State(state): State<AppState>,
+    request: Result<Json<ConsistencyCheckRequest>, JsonRejection>,
+) -> Result<Response, HttpError> {
+    let request = request
+        .map_err(|_| HttpError::invalid("request body is invalid", None))?
+        .0;
+    validate_consistency(&state, &request)?;
+    let request_id = request.request_id;
+    let outcome = state
+        .registry
+        .submit(ScheduledJob::new(
+            JobRequest::HistoricalStateConsistencyCheck(request),
+            state.config.job_decoded_byte_reservation,
+        ))
+        .await;
+    tracing::info!(%request_id, "historical state consistency check submission resolved");
+    submission_response(outcome)
+}
+
+pub async fn get_job(
+    State(state): State<AppState>,
+    Path(job_id): Path<String>,
+    headers: HeaderMap,
+) -> Result<Response, HttpError> {
+    require_revision_header(&headers)?;
+    let job_id = parse_job_id(&job_id)?;
+    match state.registry.poll(job_id).await {
+        PollOutcome::Pending(envelope) => {
+            let mut response = Json(envelope).into_response();
+            insert_integer_header(&mut response, RETRY_AFTER, RETRY_AFTER_SECONDS);
+            Ok(response)
+        }
+        PollOutcome::Terminal(delivery) => {
+            let mut response = Response::new(terminal_response_body(delivery));
+            response
+                .headers_mut()
+                .insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+            Ok(response)
+        }
+        PollOutcome::NotFound => Err(HttpError::job_not_found()),
+    }
+}
+
+pub async fn cancel_job(
+    State(state): State<AppState>,
+    Path(job_id): Path<String>,
+    headers: HeaderMap,
+) -> Result<Response, HttpError> {
+    require_revision_header(&headers)?;
+    let job_id = parse_job_id(&job_id)?;
+    match state.registry.cancel(job_id).await {
+        CancelOutcome::Found(envelope) => Ok(Json(envelope).into_response()),
+        CancelOutcome::NotFound => Err(HttpError::job_not_found()),
+    }
+}
+
+pub async fn coverage(
+    State(state): State<AppState>,
+    request: Result<Json<CoverageRequest>, JsonRejection>,
+) -> Result<Response, HttpError> {
+    let request = request
+        .map_err(|_| HttpError::invalid("request body is invalid", None))?
+        .0;
+    validate_backends(&state, &request.backends)?;
+    state
+        .coverage
+        .resolve(request)
+        .await
+        .map(Json)
+        .map(IntoResponse::into_response)
+        .map_err(|_| HttpError::unavailable(RETRY_AFTER_SECONDS))
+}
+
+pub async fn ready(State(state): State<AppState>) -> Response {
+    let ready = state.registry.is_ready().await;
+    let status = if ready {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+    (status, Json(ReadyResponse { ready })).into_response()
+}
+
+pub async fn status(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<Response, HttpError> {
+    require_revision_header(&headers)?;
+    let scheduler = state.registry.snapshot().await;
+    let dependencies = state
+        .status
+        .probe()
+        .await
+        .unwrap_or_else(|_| unavailable_dependencies());
+    Ok(Json(StatusResponse {
+        service_revision: state.config.service_revision.clone(),
+        api_revision: API_REVISION,
+        supported_chain_id: state.config.supported_chain_id,
+        enabled_backends: state.config.enabled_backends.clone(),
+        visible_through_block: dependencies.visible_through_block,
+        database: dependencies.database,
+        object_store: dependencies.object_store,
+        jobs: scheduler.counts,
+        reserved_decoded_bytes: scheduler.reserved_decoded_bytes,
+        limits: state.config.public_limits(),
+        draining: scheduler.draining,
+    })
+    .into_response())
+}
+
+fn validate_quote(state: &AppState, request: &QuoteJobRequest) -> Result<(), HttpError> {
+    validate_timeout(state, request.timeout_ms)?;
+    validate_backends(state, &[request.pool.backend])?;
+    let span = request.blocks.end_inclusive - request.blocks.start;
+    if span > state.config.max_block_span {
+        return Err(HttpError::invalid(
+            "requested block span exceeds the configured maximum",
+            Some(serde_json::json!({"field": "blocks"})),
+        ));
+    }
+    for lag in &request.lags {
+        if request.blocks.end_inclusive.checked_add(*lag).is_none() {
+            return Err(HttpError::invalid(
+                "target block exceeds the block number range",
+                Some(serde_json::json!({"field": "lags"})),
+            ));
+        }
+    }
+    let dimensions = quote_dimensions(request)?;
+    if dimensions.combination_count > state.config.max_combination_count {
+        let details = ComparisonBudgetDetails {
+            start_block_count: dimensions.start_block_count,
+            lag_count: dimensions.lag_count,
+            input_amount_count: dimensions.input_amount_count,
+            combination_count: dimensions.combination_count,
+            max_combination_count: state.config.max_combination_count,
+        };
+        return Err(HttpError::comparison_budget(
+            serde_json::to_value(details).unwrap_or(serde_json::Value::Null),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_consistency(
+    state: &AppState,
+    request: &ConsistencyCheckRequest,
+) -> Result<(), HttpError> {
+    validate_timeout(state, request.timeout_ms)?;
+    validate_backends(state, &request.backends)?;
+    match &request.selection {
+        ConsistencySelection::CheckpointPairs { pairs } => {
+            if pairs.len() > state.config.max_consistency_pairs {
+                return Err(HttpError::invalid(
+                    "checkpoint pair count exceeds the configured maximum",
+                    Some(serde_json::json!({"field": "selection.pairs"})),
+                ));
+            }
+        }
+        ConsistencySelection::BlockRange {
+            start,
+            end_inclusive,
+        } => {
+            if end_inclusive - start > state.config.max_block_span {
+                return Err(HttpError::invalid(
+                    "requested block span exceeds the configured maximum",
+                    Some(serde_json::json!({"field": "selection"})),
+                ));
+            }
+        }
+    }
+    if request.quotes_to_compare.len() > state.config.max_quote_selectors {
+        return Err(HttpError::invalid(
+            "quote selector count exceeds the configured maximum",
+            Some(serde_json::json!({"field": "quotesToCompare"})),
+        ));
+    }
+    if request
+        .quotes_to_compare
+        .iter()
+        .any(|quote| quote.amounts_in.len() > state.config.max_amounts_per_quote)
+    {
+        return Err(HttpError::invalid(
+            "quote input amount count exceeds the configured maximum",
+            Some(serde_json::json!({"field": "quotesToCompare.amountsIn"})),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_timeout(state: &AppState, timeout_ms: u64) -> Result<(), HttpError> {
+    if timeout_ms > state.config.max_timeout_ms {
+        return Err(HttpError::invalid(
+            "timeoutMs exceeds the configured maximum",
+            Some(serde_json::json!({"field": "timeoutMs"})),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_backends(state: &AppState, backends: &[Backend]) -> Result<(), HttpError> {
+    if backends
+        .iter()
+        .any(|backend| !state.config.enabled_backends.contains(backend))
+    {
+        return Err(HttpError::invalid(
+            "requested backend is not enabled",
+            Some(serde_json::json!({"field": "backends"})),
+        ));
+    }
+    Ok(())
+}
+
+fn quote_dimensions(request: &QuoteJobRequest) -> Result<QuoteDimensions, HttpError> {
+    let start_block_count = u64::try_from(request.blocks.start_blocks().count())
+        .map_err(|_| HttpError::invalid("requested block count is too large", None))?;
+    let lag_count = u64::try_from(request.lags.len())
+        .map_err(|_| HttpError::invalid("lag count is too large", None))?;
+    let input_amount_count = u64::try_from(request.amounts_in.len())
+        .map_err(|_| HttpError::invalid("input amount count is too large", None))?;
+    let combination_count = start_block_count
+        .checked_mul(lag_count)
+        .and_then(|count| count.checked_mul(input_amount_count))
+        .ok_or_else(|| HttpError::invalid("quote comparison count is too large", None))?;
+    Ok(QuoteDimensions {
+        start_block_count,
+        lag_count,
+        input_amount_count,
+        combination_count,
+    })
+}
+
+fn submission_response(outcome: SubmitOutcome) -> Result<Response, HttpError> {
+    let (status, submission) = match outcome {
+        SubmitOutcome::Accepted(submission) => (StatusCode::ACCEPTED, submission),
+        SubmitOutcome::Reused(submission) => (StatusCode::OK, submission),
+        SubmitOutcome::RequestIdConflict => return Err(HttpError::request_id_conflict()),
+        SubmitOutcome::QueueFull => return Err(HttpError::queue_full(RETRY_AFTER_SECONDS)),
+        SubmitOutcome::ServiceUnavailable | SubmitOutcome::InternalError => {
+            return Err(HttpError::unavailable(RETRY_AFTER_SECONDS));
+        }
+    };
+    tracing::info!(
+        job_id = %submission.job_id,
+        request_id = %submission.request_id,
+        job_type = ?submission.job_type,
+        state = ?submission.state,
+        reused = submission.reused,
+        "historical job submission accepted"
+    );
+    let location = format!("/jobs/{}", submission.job_id);
+    let mut response = (status, Json(submission)).into_response();
+    if let Ok(value) = HeaderValue::from_str(&location) {
+        response.headers_mut().insert(LOCATION, value);
+    }
+    insert_integer_header(&mut response, RETRY_AFTER, RETRY_AFTER_SECONDS);
+    Ok(response)
+}
+
+fn require_revision_header(headers: &HeaderMap) -> Result<(), HttpError> {
+    let matches = headers
+        .get(REVISION_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value == API_REVISION.to_string());
+    if matches {
+        Ok(())
+    } else {
+        Err(HttpError::invalid(
+            "X-DSolver-History-API-Revision must match the service revision",
+            Some(serde_json::json!({"field": "X-DSolver-History-API-Revision"})),
+        ))
+    }
+}
+
+fn parse_job_id(value: &str) -> Result<Uuid, HttpError> {
+    Uuid::parse_str(value).map_err(|_| HttpError::job_not_found())
+}
+
+fn insert_integer_header(response: &mut Response, name: axum::http::HeaderName, value: u64) {
+    if let Ok(value) = HeaderValue::from_str(&value.to_string()) {
+        response.headers_mut().insert(name, value);
+    }
+}
+
+fn unavailable_dependencies() -> StatusDependencies {
+    StatusDependencies {
+        visible_through_block: None,
+        database: DependencyHealth {
+            state: DependencyState::Unavailable,
+            message: Some("read replica status is unavailable".to_owned()),
+        },
+        object_store: DependencyHealth {
+            state: DependencyState::Unavailable,
+            message: Some("object-store status is unavailable".to_owned()),
+        },
+    }
+}
+
+struct QuoteDimensions {
+    start_block_count: u64,
+    lag_count: u64,
+    input_amount_count: u64,
+    combination_count: u64,
+}

--- a/crates/historical-quote-service/src/http/mod.rs
+++ b/crates/historical-quote-service/src/http/mod.rs
@@ -1,0 +1,2 @@
+pub mod error;
+pub mod handlers;

--- a/crates/historical-quote-service/src/jobs/mod.rs
+++ b/crates/historical-quote-service/src/jobs/mod.rs
@@ -1,0 +1,228 @@
+mod registry;
+mod result_body;
+mod worker;
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use historical_quote::api::{
+    normalize_consistency_request, normalize_quote_request, ConsistencyCheckProgress,
+    ConsistencyCheckRequest, ConsistencySelection, HistoricalQuoteProgress, JobFailure, JobResult,
+    JobType, QuoteJobRequest,
+};
+use historical_quote::EngineProgress;
+use uuid::Uuid;
+
+pub use registry::{
+    CancelOutcome, JobRegistry, JobSnapshot, PollOutcome, SubmitOutcome, TerminalDelivery,
+};
+pub use result_body::terminal_response_body;
+pub use worker::JobRunner;
+
+#[derive(Debug, Clone)]
+pub struct JobLimits {
+    pub max_running: usize,
+    pub max_waiting: usize,
+    pub decoded_byte_budget: u64,
+    pub max_terminal_jobs: usize,
+    pub terminal_ttl: Duration,
+}
+
+impl Default for JobLimits {
+    fn default() -> Self {
+        Self {
+            max_running: 4,
+            max_waiting: 16,
+            decoded_byte_budget: u64::MAX,
+            max_terminal_jobs: 20,
+            terminal_ttl: Duration::from_secs(3_600),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum JobRequest {
+    HistoricalQuote(QuoteJobRequest),
+    HistoricalStateConsistencyCheck(ConsistencyCheckRequest),
+}
+
+impl JobRequest {
+    #[must_use]
+    pub fn request_id(&self) -> Uuid {
+        match self {
+            Self::HistoricalQuote(request) => request.request_id,
+            Self::HistoricalStateConsistencyCheck(request) => request.request_id,
+        }
+    }
+
+    #[must_use]
+    pub const fn job_type(&self) -> JobType {
+        match self {
+            Self::HistoricalQuote(_) => JobType::HistoricalQuote,
+            Self::HistoricalStateConsistencyCheck(_) => JobType::HistoricalStateConsistencyCheck,
+        }
+    }
+
+    #[must_use]
+    pub fn timeout_ms(&self) -> u64 {
+        match self {
+            Self::HistoricalQuote(request) => request.timeout_ms,
+            Self::HistoricalStateConsistencyCheck(request) => request.timeout_ms,
+        }
+    }
+
+    pub(crate) fn fingerprint(&self) -> Result<[u8; 32], serde_json::Error> {
+        match self {
+            Self::HistoricalQuote(request) => normalize_quote_request(request).fingerprint(),
+            Self::HistoricalStateConsistencyCheck(request) => {
+                normalize_consistency_request(request).fingerprint()
+            }
+        }
+    }
+
+    pub(crate) fn progress(&self) -> Arc<ProgressCounters> {
+        match self {
+            Self::HistoricalQuote(request) => Arc::new(ProgressCounters::quote(
+                request
+                    .blocks
+                    .start_blocks()
+                    .count()
+                    .saturating_mul(request.lags.len())
+                    .saturating_mul(request.amounts_in.len()),
+            )),
+            Self::HistoricalStateConsistencyCheck(request) => {
+                let total = match &request.selection {
+                    ConsistencySelection::CheckpointPairs { pairs } => pairs.len(),
+                    ConsistencySelection::BlockRange { .. } => 0,
+                };
+                Arc::new(ProgressCounters::consistency(total))
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ScheduledJob {
+    pub request: JobRequest,
+    pub estimated_decoded_bytes: u64,
+}
+
+impl ScheduledJob {
+    #[must_use]
+    pub const fn new(request: JobRequest, estimated_decoded_bytes: u64) -> Self {
+        Self {
+            request,
+            estimated_decoded_bytes,
+        }
+    }
+}
+
+pub struct ExecutionContext {
+    pub job_id: Uuid,
+    pub request: JobRequest,
+    pub cancellation: tokio_util::sync::CancellationToken,
+    pub progress: ProgressReporter,
+}
+
+pub trait JobExecutor: Send + Sync + 'static {
+    fn execute(
+        &self,
+        context: ExecutionContext,
+    ) -> Pin<Box<dyn Future<Output = Result<JobResult, JobExecutionError>> + Send + 'static>>;
+}
+
+#[derive(Debug)]
+pub enum JobExecutionError {
+    Cancelled,
+    Failed(JobFailure),
+}
+
+#[derive(Clone)]
+pub struct ProgressReporter {
+    counters: Arc<ProgressCounters>,
+}
+
+impl ProgressReporter {
+    pub(crate) fn new(counters: Arc<ProgressCounters>) -> Self {
+        Self { counters }
+    }
+}
+
+impl EngineProgress for ProgressReporter {
+    fn quote_comparison_completed(&self) {
+        self.counters.completed.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn checkpoint_pair_total(&self, total: u64) {
+        self.counters.total.store(total, Ordering::Relaxed);
+    }
+
+    fn checkpoint_pair_completed(&self) {
+        self.counters.completed.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ProgressKind {
+    Quote,
+    Consistency,
+}
+
+pub(crate) struct ProgressCounters {
+    kind: ProgressKind,
+    completed: AtomicU64,
+    total: AtomicU64,
+}
+
+impl ProgressCounters {
+    fn quote(total: usize) -> Self {
+        Self::new(ProgressKind::Quote, total)
+    }
+
+    fn consistency(total: usize) -> Self {
+        Self::new(ProgressKind::Consistency, total)
+    }
+
+    fn new(kind: ProgressKind, total: usize) -> Self {
+        Self {
+            kind,
+            completed: AtomicU64::new(0),
+            total: AtomicU64::new(u64::try_from(total).unwrap_or(u64::MAX)),
+        }
+    }
+
+    pub(crate) fn snapshot(&self, completed_job: bool) -> historical_quote::api::JobProgress {
+        let total = self.total.load(Ordering::Relaxed);
+        let completed = self.completed.load(Ordering::Relaxed).min(total);
+        let percent = if completed_job {
+            100
+        } else {
+            completed
+                .saturating_mul(100)
+                .checked_div(total)
+                .and_then(|percent| u8::try_from(percent).ok())
+                .unwrap_or(0)
+        };
+        match self.kind {
+            ProgressKind::Quote => {
+                historical_quote::api::JobProgress::HistoricalQuote(HistoricalQuoteProgress {
+                    completed_comparisons: if completed_job { total } else { completed },
+                    total_comparisons: total,
+                    percent_complete: percent,
+                })
+            }
+            ProgressKind::Consistency => {
+                historical_quote::api::JobProgress::HistoricalStateConsistencyCheck(
+                    ConsistencyCheckProgress {
+                        completed_checkpoint_pairs: if completed_job { total } else { completed },
+                        total_checkpoint_pairs: total,
+                        percent_complete: percent,
+                    },
+                )
+            }
+        }
+    }
+}

--- a/crates/historical-quote-service/src/jobs/registry.rs
+++ b/crates/historical-quote-service/src/jobs/registry.rs
@@ -1,0 +1,651 @@
+use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
+
+use bytes::Bytes;
+use chrono::{DateTime, Utc};
+use historical_quote::api::{
+    JobCounts, JobEnvelope, JobFailure, JobFailureCode, JobResult, JobState, JobSubmission, JobType,
+};
+use tokio::sync::{Mutex, Notify};
+use tokio::time::Instant;
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+use super::{JobLimits, JobRequest, ProgressCounters, ProgressReporter, ScheduledJob};
+
+#[derive(Clone)]
+pub struct JobRegistry {
+    inner: Arc<RegistryInner>,
+}
+
+struct RegistryInner {
+    limits: JobLimits,
+    state: Mutex<RegistryState>,
+    notify: Notify,
+}
+
+#[derive(Default)]
+struct RegistryState {
+    records: HashMap<Uuid, JobRecord>,
+    request_ids: HashMap<Uuid, RequestMapping>,
+    queue: VecDeque<Uuid>,
+    running: usize,
+    reserved_decoded_bytes: u64,
+    admission_open: bool,
+    draining: bool,
+    next_terminal_order: u64,
+}
+
+struct RequestMapping {
+    job_id: Uuid,
+}
+
+struct JobRecord {
+    job_id: Uuid,
+    request_id: Uuid,
+    fingerprint: [u8; 32],
+    request: JobRequest,
+    job_type: JobType,
+    state: JobState,
+    submitted_at: DateTime<Utc>,
+    deadline_at: DateTime<Utc>,
+    deadline_instant: Instant,
+    started_at: Option<DateTime<Utc>>,
+    finished_at: Option<DateTime<Utc>>,
+    finished_instant: Option<Instant>,
+    terminal_order: Option<u64>,
+    estimated_decoded_bytes: u64,
+    progress: Arc<ProgressCounters>,
+    cancellation: CancellationToken,
+    cancellation_requested: bool,
+    result: Option<JobResult>,
+    failure: Option<JobFailure>,
+    terminal_body: Option<Bytes>,
+    terminal_delivery_in_progress: bool,
+}
+
+#[derive(Debug, Clone)]
+pub enum SubmitOutcome {
+    Accepted(JobSubmission),
+    Reused(JobSubmission),
+    RequestIdConflict,
+    QueueFull,
+    ServiceUnavailable,
+    InternalError,
+}
+
+impl SubmitOutcome {
+    #[must_use]
+    pub fn job_id(&self) -> Option<Uuid> {
+        match self {
+            Self::Accepted(submission) | Self::Reused(submission) => Some(submission.job_id),
+            Self::RequestIdConflict
+            | Self::QueueFull
+            | Self::ServiceUnavailable
+            | Self::InternalError => None,
+        }
+    }
+}
+
+pub enum PollOutcome {
+    Pending(Box<JobEnvelope>),
+    Terminal(TerminalDelivery),
+    NotFound,
+}
+
+pub enum CancelOutcome {
+    Found(Box<JobEnvelope>),
+    NotFound,
+}
+
+pub struct TerminalDelivery {
+    registry: JobRegistry,
+    job_id: Uuid,
+    bytes: Bytes,
+}
+
+impl TerminalDelivery {
+    #[must_use]
+    pub fn bytes(&self) -> Bytes {
+        self.bytes.clone()
+    }
+
+    #[must_use]
+    pub fn job_id(&self) -> Uuid {
+        self.job_id
+    }
+
+    pub async fn commit(self) {
+        self.registry.consume(self.job_id).await;
+    }
+
+    pub async fn release(self) {
+        self.registry.release_delivery(self.job_id).await;
+    }
+
+    pub(crate) fn into_parts(self) -> (JobRegistry, Uuid, Bytes) {
+        (self.registry, self.job_id, self.bytes)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct JobSnapshot {
+    pub counts: JobCounts,
+    pub reserved_decoded_bytes: u64,
+    pub draining: bool,
+}
+
+pub(crate) struct RunnableJob {
+    pub job_id: Uuid,
+    pub job_type: JobType,
+    pub request: JobRequest,
+    pub deadline: Instant,
+    pub reserved_decoded_bytes: u64,
+    pub cancellation: CancellationToken,
+    pub progress: ProgressReporter,
+}
+
+pub(crate) struct ScheduleBatch {
+    pub jobs: Vec<RunnableJob>,
+    pub next_deadline: Option<Instant>,
+    pub stopped: bool,
+}
+
+pub(crate) enum FinishedJob {
+    Completed(JobResult),
+    Failed(JobFailure),
+    Cancelled,
+}
+
+impl JobRegistry {
+    #[must_use]
+    pub fn new(limits: JobLimits) -> Self {
+        let state = RegistryState {
+            admission_open: true,
+            ..RegistryState::default()
+        };
+        Self {
+            inner: Arc::new(RegistryInner {
+                limits,
+                state: Mutex::new(state),
+                notify: Notify::new(),
+            }),
+        }
+    }
+
+    pub async fn submit(&self, job: ScheduledJob) -> SubmitOutcome {
+        let Ok(fingerprint) = job.request.fingerprint() else {
+            return SubmitOutcome::InternalError;
+        };
+        let mut state = self.inner.state.lock().await;
+        prune_expired(&mut state, &self.inner.limits, Instant::now());
+        let request_id = job.request.request_id();
+        if let Some(mapping) = state.request_ids.get(&request_id) {
+            let Some(record) = state.records.get(&mapping.job_id) else {
+                return SubmitOutcome::InternalError;
+            };
+            if record.fingerprint != fingerprint {
+                return SubmitOutcome::RequestIdConflict;
+            }
+            return SubmitOutcome::Reused(record.submission(true, &state.queue));
+        }
+        if !state.admission_open
+            || job.estimated_decoded_bytes == 0
+            || job.estimated_decoded_bytes > self.inner.limits.decoded_byte_budget
+        {
+            return SubmitOutcome::ServiceUnavailable;
+        }
+        if state.queue.len() >= self.inner.limits.max_waiting {
+            return SubmitOutcome::QueueFull;
+        }
+
+        let submitted_at = Utc::now();
+        let submitted_instant = Instant::now();
+        let timeout = std::time::Duration::from_millis(job.request.timeout_ms());
+        let Ok(deadline_delta) = chrono::Duration::from_std(timeout) else {
+            return SubmitOutcome::ServiceUnavailable;
+        };
+        let Some(deadline_at) = submitted_at.checked_add_signed(deadline_delta) else {
+            return SubmitOutcome::ServiceUnavailable;
+        };
+        let Some(deadline_instant) = submitted_instant.checked_add(timeout) else {
+            return SubmitOutcome::ServiceUnavailable;
+        };
+        let job_id = Uuid::new_v4();
+        let record = JobRecord {
+            job_id,
+            request_id,
+            fingerprint,
+            job_type: job.request.job_type(),
+            progress: job.request.progress(),
+            request: job.request,
+            state: JobState::Queued,
+            submitted_at,
+            deadline_at,
+            deadline_instant,
+            started_at: None,
+            finished_at: None,
+            finished_instant: None,
+            terminal_order: None,
+            estimated_decoded_bytes: job.estimated_decoded_bytes,
+            cancellation: CancellationToken::new(),
+            cancellation_requested: false,
+            result: None,
+            failure: None,
+            terminal_body: None,
+            terminal_delivery_in_progress: false,
+        };
+        state
+            .request_ids
+            .insert(request_id, RequestMapping { job_id });
+        state.queue.push_back(job_id);
+        state.records.insert(job_id, record);
+        let Some(submission) = state
+            .records
+            .get(&job_id)
+            .map(|record| record.submission(false, &state.queue))
+        else {
+            return SubmitOutcome::InternalError;
+        };
+        drop(state);
+        self.inner.notify.notify_one();
+        SubmitOutcome::Accepted(submission)
+    }
+
+    pub async fn inspect(&self, job_id: Uuid) -> Option<JobEnvelope> {
+        let mut state = self.inner.state.lock().await;
+        prune_expired(&mut state, &self.inner.limits, Instant::now());
+        state
+            .records
+            .get(&job_id)
+            .map(|record| record.envelope(false, &state.queue))
+    }
+
+    pub async fn poll(&self, job_id: Uuid) -> PollOutcome {
+        let mut state = self.inner.state.lock().await;
+        prune_expired(&mut state, &self.inner.limits, Instant::now());
+        let queue = state.queue.clone();
+        let Some(record) = state.records.get_mut(&job_id) else {
+            return PollOutcome::NotFound;
+        };
+        if !is_terminal(record.state) {
+            return PollOutcome::Pending(Box::new(record.envelope(false, &queue)));
+        }
+        if record.terminal_delivery_in_progress {
+            return PollOutcome::NotFound;
+        }
+        let Some(bytes) = record.terminal_body.clone() else {
+            return PollOutcome::NotFound;
+        };
+        record.terminal_delivery_in_progress = true;
+        PollOutcome::Terminal(TerminalDelivery {
+            registry: self.clone(),
+            job_id,
+            bytes,
+        })
+    }
+
+    pub async fn cancel(&self, job_id: Uuid) -> CancelOutcome {
+        let mut state = self.inner.state.lock().await;
+        prune_expired(&mut state, &self.inner.limits, Instant::now());
+        let Some(current_state) = state.records.get(&job_id).map(|record| record.state) else {
+            return CancelOutcome::NotFound;
+        };
+        if current_state == JobState::Queued {
+            state.queue.retain(|queued| *queued != job_id);
+            finish_locked(
+                &mut state,
+                &self.inner.limits,
+                job_id,
+                FinishedJob::Cancelled,
+            );
+        } else if current_state == JobState::Running {
+            if let Some(record) = state.records.get_mut(&job_id) {
+                record.cancellation_requested = true;
+                record.cancellation.cancel();
+            }
+        }
+        let envelope = state
+            .records
+            .get(&job_id)
+            .map(|record| record.envelope(false, &state.queue));
+        drop(state);
+        self.inner.notify.notify_one();
+        envelope.map_or(CancelOutcome::NotFound, |envelope| {
+            CancelOutcome::Found(Box::new(envelope))
+        })
+    }
+
+    pub async fn snapshot(&self) -> JobSnapshot {
+        let mut state = self.inner.state.lock().await;
+        prune_expired(&mut state, &self.inner.limits, Instant::now());
+        snapshot_locked(&state)
+    }
+
+    pub async fn begin_shutdown(&self) {
+        let mut state = self.inner.state.lock().await;
+        state.admission_open = false;
+        state.draining = true;
+        let queued = state.queue.drain(..).collect::<Vec<_>>();
+        for job_id in queued {
+            finish_locked(
+                &mut state,
+                &self.inner.limits,
+                job_id,
+                FinishedJob::Cancelled,
+            );
+        }
+        for record in state.records.values_mut() {
+            if record.state == JobState::Running {
+                record.cancellation_requested = true;
+                record.cancellation.cancel();
+            }
+        }
+        drop(state);
+        self.inner.notify.notify_waiters();
+    }
+
+    #[must_use]
+    pub async fn is_ready(&self) -> bool {
+        let state = self.inner.state.lock().await;
+        state.admission_open && !state.draining
+    }
+
+    pub(crate) async fn schedule(&self) -> ScheduleBatch {
+        let mut state = self.inner.state.lock().await;
+        let now = Instant::now();
+        expire_queued_deadlines(&mut state, &self.inner.limits, now);
+        prune_expired(&mut state, &self.inner.limits, now);
+        let mut jobs = Vec::new();
+        while state.running < self.inner.limits.max_running {
+            let Some(job_id) = state.queue.front().copied() else {
+                break;
+            };
+            let Some(record) = state.records.get(&job_id) else {
+                state.queue.pop_front();
+                continue;
+            };
+            let estimated_decoded_bytes = record.estimated_decoded_bytes;
+            let Some(reserved) = state
+                .reserved_decoded_bytes
+                .checked_add(estimated_decoded_bytes)
+            else {
+                break;
+            };
+            if reserved > self.inner.limits.decoded_byte_budget {
+                break;
+            }
+            state.queue.pop_front();
+            state.running += 1;
+            state.reserved_decoded_bytes = reserved;
+            let Some(record) = state.records.get_mut(&job_id) else {
+                state.running = state.running.saturating_sub(1);
+                state.reserved_decoded_bytes = state
+                    .reserved_decoded_bytes
+                    .saturating_sub(estimated_decoded_bytes);
+                continue;
+            };
+            record.state = JobState::Running;
+            record.started_at = Some(Utc::now());
+            jobs.push(RunnableJob {
+                job_id,
+                job_type: record.job_type,
+                request: record.request.clone(),
+                deadline: record.deadline_instant,
+                reserved_decoded_bytes: estimated_decoded_bytes,
+                cancellation: record.cancellation.clone(),
+                progress: ProgressReporter::new(Arc::clone(&record.progress)),
+            });
+        }
+        let next_deadline = state
+            .queue
+            .iter()
+            .filter_map(|job_id| {
+                state
+                    .records
+                    .get(job_id)
+                    .map(|record| record.deadline_instant)
+            })
+            .min();
+        let stopped = state.draining && state.running == 0;
+        ScheduleBatch {
+            jobs,
+            next_deadline,
+            stopped,
+        }
+    }
+
+    pub(crate) async fn finish(&self, job_id: Uuid, outcome: FinishedJob) {
+        let mut state = self.inner.state.lock().await;
+        finish_locked(&mut state, &self.inner.limits, job_id, outcome);
+        drop(state);
+        self.inner.notify.notify_one();
+    }
+
+    pub(crate) async fn notified(&self) {
+        self.inner.notify.notified().await;
+    }
+
+    pub(crate) async fn consume(&self, job_id: Uuid) {
+        let mut state = self.inner.state.lock().await;
+        if state
+            .records
+            .get(&job_id)
+            .is_some_and(|record| record.terminal_delivery_in_progress)
+        {
+            remove_job(&mut state, job_id);
+        }
+    }
+
+    pub(crate) async fn release_delivery(&self, job_id: Uuid) {
+        let mut state = self.inner.state.lock().await;
+        if let Some(record) = state.records.get_mut(&job_id) {
+            record.terminal_delivery_in_progress = false;
+        }
+    }
+}
+
+impl JobRecord {
+    fn submission(&self, reused: bool, queue: &VecDeque<Uuid>) -> JobSubmission {
+        JobSubmission {
+            job_id: self.job_id,
+            request_id: self.request_id,
+            job_type: self.job_type,
+            state: self.state,
+            submitted_at: self.submitted_at,
+            deadline_at: self.deadline_at,
+            started_at: self.started_at,
+            finished_at: self.finished_at,
+            queue_position: queue_position(queue, self.job_id),
+            cancellation_requested: self.cancellation_requested,
+            progress: self.progress.snapshot(self.state == JobState::Completed),
+            reused,
+        }
+    }
+
+    fn envelope(&self, include_terminal: bool, queue: &VecDeque<Uuid>) -> JobEnvelope {
+        JobEnvelope {
+            job_id: self.job_id,
+            request_id: self.request_id,
+            job_type: self.job_type,
+            state: self.state,
+            submitted_at: self.submitted_at,
+            deadline_at: self.deadline_at,
+            started_at: self.started_at,
+            finished_at: self.finished_at,
+            queue_position: queue_position(queue, self.job_id),
+            cancellation_requested: self.cancellation_requested,
+            progress: self.progress.snapshot(self.state == JobState::Completed),
+            result: include_terminal.then(|| self.result.clone()).flatten(),
+            failure: include_terminal.then(|| self.failure.clone()).flatten(),
+        }
+    }
+}
+
+fn finish_locked(
+    state: &mut RegistryState,
+    limits: &JobLimits,
+    job_id: Uuid,
+    outcome: FinishedJob,
+) {
+    let Some(record) = state.records.get_mut(&job_id) else {
+        return;
+    };
+    if is_terminal(record.state) {
+        return;
+    }
+    if record.state == JobState::Running {
+        state.running = state.running.saturating_sub(1);
+        state.reserved_decoded_bytes = state
+            .reserved_decoded_bytes
+            .saturating_sub(record.estimated_decoded_bytes);
+    }
+    let state_value = match outcome {
+        FinishedJob::Completed(result) => {
+            record.result = Some(result);
+            JobState::Completed
+        }
+        FinishedJob::Failed(failure) => {
+            record.failure = Some(failure);
+            JobState::Failed
+        }
+        FinishedJob::Cancelled => JobState::Cancelled,
+    };
+    record.state = state_value;
+    let finished_at = Utc::now();
+    let finished_instant = Instant::now();
+    record.finished_at = Some(finished_at);
+    record.finished_instant = Some(finished_instant);
+    record.terminal_order = Some(state.next_terminal_order);
+    state.next_terminal_order = state.next_terminal_order.saturating_add(1);
+    let envelope = record.envelope(true, &state.queue);
+    match serde_json::to_vec(&envelope) {
+        Ok(bytes) => record.terminal_body = Some(Bytes::from(bytes)),
+        Err(_) => {
+            record.state = JobState::Failed;
+            record.result = None;
+            record.failure = Some(internal_failure());
+            if let Ok(bytes) = serde_json::to_vec(&record.envelope(true, &state.queue)) {
+                record.terminal_body = Some(Bytes::from(bytes));
+            }
+        }
+    }
+    enforce_terminal_limit(state, limits.max_terminal_jobs);
+}
+
+fn expire_queued_deadlines(state: &mut RegistryState, limits: &JobLimits, now: Instant) {
+    let expired = state
+        .queue
+        .iter()
+        .filter_map(|job_id| {
+            state
+                .records
+                .get(job_id)
+                .filter(|record| record.deadline_instant <= now)
+                .map(|_| *job_id)
+        })
+        .collect::<Vec<_>>();
+    for job_id in expired {
+        state.queue.retain(|queued| *queued != job_id);
+        finish_locked(
+            state,
+            limits,
+            job_id,
+            FinishedJob::Failed(JobFailure {
+                code: JobFailureCode::DeadlineExceeded,
+                message: "job deadline exceeded".to_owned(),
+                retryable: false,
+                details: None,
+            }),
+        );
+    }
+}
+
+fn prune_expired(state: &mut RegistryState, limits: &JobLimits, now: Instant) {
+    let expired = state
+        .records
+        .iter()
+        .filter_map(|(job_id, record)| {
+            record
+                .finished_instant
+                .filter(|finished| *finished + limits.terminal_ttl <= now)
+                .map(|_| *job_id)
+        })
+        .collect::<Vec<_>>();
+    for job_id in expired {
+        remove_job(state, job_id);
+    }
+}
+
+fn enforce_terminal_limit(state: &mut RegistryState, limit: usize) {
+    while state
+        .records
+        .values()
+        .filter(|record| is_terminal(record.state))
+        .count()
+        > limit
+    {
+        let oldest = state
+            .records
+            .values()
+            .filter(|record| is_terminal(record.state))
+            .min_by_key(|record| record.terminal_order)
+            .map(|record| record.job_id);
+        let Some(job_id) = oldest else {
+            break;
+        };
+        remove_job(state, job_id);
+    }
+}
+
+fn remove_job(state: &mut RegistryState, job_id: Uuid) {
+    if let Some(record) = state.records.remove(&job_id) {
+        state.request_ids.remove(&record.request_id);
+    }
+    state.queue.retain(|queued| *queued != job_id);
+}
+
+fn snapshot_locked(state: &RegistryState) -> JobSnapshot {
+    let queued = u64::try_from(state.queue.len()).unwrap_or(u64::MAX);
+    let running = u64::try_from(state.running).unwrap_or(u64::MAX);
+    let retained_terminal = u64::try_from(
+        state
+            .records
+            .values()
+            .filter(|record| is_terminal(record.state))
+            .count(),
+    )
+    .unwrap_or(u64::MAX);
+    JobSnapshot {
+        counts: JobCounts {
+            queued,
+            running,
+            retained_terminal,
+        },
+        reserved_decoded_bytes: state.reserved_decoded_bytes,
+        draining: state.draining,
+    }
+}
+
+fn queue_position(queue: &VecDeque<Uuid>, job_id: Uuid) -> Option<u64> {
+    queue
+        .iter()
+        .position(|queued| *queued == job_id)
+        .and_then(|position| u64::try_from(position + 1).ok())
+}
+
+fn is_terminal(state: JobState) -> bool {
+    matches!(
+        state,
+        JobState::Completed | JobState::Failed | JobState::Cancelled
+    )
+}
+
+fn internal_failure() -> JobFailure {
+    JobFailure {
+        code: JobFailureCode::InternalError,
+        message: "job result could not be prepared".to_owned(),
+        retryable: false,
+        details: None,
+    }
+}

--- a/crates/historical-quote-service/src/jobs/result_body.rs
+++ b/crates/historical-quote-service/src/jobs/result_body.rs
@@ -1,0 +1,88 @@
+use std::convert::Infallible;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use axum::body::Body;
+use bytes::Bytes;
+use futures::Stream;
+
+use super::{JobRegistry, TerminalDelivery};
+
+pub fn terminal_response_body(delivery: TerminalDelivery) -> Body {
+    let (registry, job_id, bytes) = delivery.into_parts();
+    Body::from_stream(DeliveryStream {
+        state: DeliveryState::Data(Some(bytes)),
+        guard: DeliveryGuard::new(registry, job_id),
+    })
+}
+
+struct DeliveryStream {
+    state: DeliveryState,
+    guard: DeliveryGuard,
+}
+
+enum DeliveryState {
+    Data(Option<Bytes>),
+    Commit(Pin<Box<dyn Future<Output = ()> + Send>>),
+    Done,
+}
+
+impl Stream for DeliveryStream {
+    type Item = Result<Bytes, Infallible>;
+
+    fn poll_next(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        loop {
+            match &mut self.state {
+                DeliveryState::Data(bytes) => {
+                    if let Some(bytes) = bytes.take() {
+                        return Poll::Ready(Some(Ok(bytes)));
+                    }
+                    let registry = self.guard.registry.clone();
+                    let job_id = self.guard.job_id;
+                    self.state = DeliveryState::Commit(Box::pin(async move {
+                        registry.consume(job_id).await;
+                    }));
+                }
+                DeliveryState::Commit(future) => match future.as_mut().poll(context) {
+                    Poll::Pending => return Poll::Pending,
+                    Poll::Ready(()) => {
+                        self.guard.committed = true;
+                        self.state = DeliveryState::Done;
+                        return Poll::Ready(None);
+                    }
+                },
+                DeliveryState::Done => return Poll::Ready(None),
+            }
+        }
+    }
+}
+
+struct DeliveryGuard {
+    registry: JobRegistry,
+    job_id: uuid::Uuid,
+    committed: bool,
+}
+
+impl DeliveryGuard {
+    const fn new(registry: JobRegistry, job_id: uuid::Uuid) -> Self {
+        Self {
+            registry,
+            job_id,
+            committed: false,
+        }
+    }
+}
+
+impl Drop for DeliveryGuard {
+    fn drop(&mut self) {
+        if self.committed {
+            return;
+        }
+        let registry = self.registry.clone();
+        let job_id = self.job_id;
+        tokio::spawn(async move {
+            registry.release_delivery(job_id).await;
+        });
+    }
+}

--- a/crates/historical-quote-service/src/jobs/worker.rs
+++ b/crates/historical-quote-service/src/jobs/worker.rs
@@ -1,0 +1,101 @@
+use std::sync::Arc;
+
+use historical_quote::api::{JobFailure, JobFailureCode};
+
+use super::registry::{FinishedJob, RunnableJob};
+use super::{ExecutionContext, JobExecutionError, JobExecutor, JobRegistry};
+
+pub struct JobRunner<E> {
+    registry: JobRegistry,
+    executor: Arc<E>,
+}
+
+impl<E> JobRunner<E>
+where
+    E: JobExecutor,
+{
+    #[must_use]
+    pub fn new(registry: JobRegistry, executor: Arc<E>) -> Self {
+        Self { registry, executor }
+    }
+
+    pub async fn run(self) {
+        loop {
+            let batch = self.registry.schedule().await;
+            for job in batch.jobs {
+                let registry = self.registry.clone();
+                let executor = Arc::clone(&self.executor);
+                tokio::spawn(run_one(registry, executor, job));
+            }
+            if batch.stopped {
+                return;
+            }
+            if let Some(deadline) = batch.next_deadline {
+                tokio::select! {
+                    () = self.registry.notified() => {}
+                    () = tokio::time::sleep_until(deadline) => {}
+                }
+            } else {
+                self.registry.notified().await;
+            }
+        }
+    }
+
+    pub async fn begin_shutdown(&self) {
+        self.registry.begin_shutdown().await;
+    }
+}
+
+async fn run_one<E>(registry: JobRegistry, executor: Arc<E>, job: RunnableJob)
+where
+    E: JobExecutor,
+{
+    let started = std::time::Instant::now();
+    tracing::info!(
+        job_id = %job.job_id,
+        job_type = ?job.job_type,
+        reserved_decoded_bytes = job.reserved_decoded_bytes,
+        "historical job started"
+    );
+    let cancellation = job.cancellation.clone();
+    let execution = executor.execute(ExecutionContext {
+        job_id: job.job_id,
+        request: job.request,
+        cancellation: cancellation.clone(),
+        progress: job.progress,
+    });
+    tokio::pin!(execution);
+    let outcome = tokio::select! {
+        biased;
+        () = tokio::time::sleep_until(job.deadline) => {
+            cancellation.cancel();
+            FinishedJob::Failed(JobFailure {
+                code: JobFailureCode::DeadlineExceeded,
+                message: "job deadline exceeded".to_owned(),
+                retryable: false,
+                details: None,
+            })
+        }
+        () = cancellation.cancelled() => FinishedJob::Cancelled,
+        result = &mut execution => match result {
+            Ok(result) => FinishedJob::Completed(result),
+            Err(JobExecutionError::Cancelled) => FinishedJob::Cancelled,
+            Err(JobExecutionError::Failed(failure)) => FinishedJob::Failed(failure),
+        },
+    };
+    let (state, failure_code) = match &outcome {
+        FinishedJob::Completed(_) => ("completed", None),
+        FinishedJob::Failed(failure) => ("failed", Some(failure.code)),
+        FinishedJob::Cancelled => ("cancelled", None),
+    };
+    tracing::info!(
+        job_id = %job.job_id,
+        job_type = ?job.job_type,
+        state,
+        failure_code = ?failure_code,
+        elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
+        reserved_decoded_bytes = job.reserved_decoded_bytes,
+        "historical job finished"
+    );
+    registry.finish(job.job_id, outcome).await;
+}

--- a/crates/historical-quote-service/src/lib.rs
+++ b/crates/historical-quote-service/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod app;
+pub mod auth;
+pub mod config;
+pub mod database;
+pub mod http;
+pub mod jobs;
+pub mod shutdown;

--- a/crates/historical-quote-service/src/main.rs
+++ b/crates/historical-quote-service/src/main.rs
@@ -1,0 +1,105 @@
+use std::sync::Arc;
+
+use anyhow::Context;
+use historical_quote_service::app::{
+    router, AppState, EngineCoverageResolver, EngineJobExecutor, ReaderStatusProbe,
+};
+use historical_quote_service::config::ServiceConfig;
+use historical_quote_service::database::{
+    IamConnectionPool, PostgresConnectionFactory, RdsIamTokenProvider,
+};
+use historical_quote_service::jobs::{JobRegistry, JobRunner};
+use historical_quote_service::shutdown;
+use state_history::{CheckpointObjectStore, StateHistoryReader};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .json()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init()
+        .map_err(|_| anyhow::anyhow!("failed to initialize structured logging"))?;
+    let config = Arc::new(ServiceConfig::from_env()?);
+    let sdk_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .region(aws_config::Region::new(config.object_store.region.clone()))
+        .load()
+        .await;
+    let token_provider = RdsIamTokenProvider::new(&config.database, sdk_config)?;
+    let connection_factory = PostgresConnectionFactory::new(&config.database);
+    let connections = IamConnectionPool::new(
+        token_provider,
+        connection_factory,
+        config.database.max_connections,
+        config.database.max_connection_lifetime,
+    )?;
+    let objects = CheckpointObjectStore::from_env_config(
+        config.object_store.bucket.clone(),
+        config.object_store.prefix.clone(),
+        config.object_store.region.clone(),
+        config.object_store.endpoint_url.clone(),
+        config.object_store.force_path_style,
+    )
+    .await;
+    let reader = Arc::new(StateHistoryReader::new(connections, objects));
+    let executor = Arc::new(
+        EngineJobExecutor::new(Arc::clone(&reader), &config)
+            .map_err(|_| anyhow::anyhow!("historical engine configuration is invalid"))?,
+    );
+    let registry = JobRegistry::new(config.scheduler.clone());
+    let runner = JobRunner::new(registry.clone(), executor);
+    let mut runner_task = tokio::spawn(runner.run());
+    let app = router(AppState {
+        config: Arc::clone(&config),
+        registry: registry.clone(),
+        coverage: Arc::new(EngineCoverageResolver::new(Arc::clone(&reader))),
+        status: Arc::new(ReaderStatusProbe::new(
+            reader,
+            config.supported_chain_id,
+            &config.enabled_backends,
+        )),
+    });
+    let listener = tokio::net::TcpListener::bind(config.bind_address)
+        .await
+        .context("failed to bind historical quote service")?;
+    let (stop_server, wait_for_stop) = tokio::sync::oneshot::channel();
+    let mut server_task = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                let _ = wait_for_stop.await;
+            })
+            .await
+    });
+    let early_server_result = tokio::select! {
+        result = &mut server_task => Some(result),
+        () = shutdown::signal() => None,
+    };
+    registry.begin_shutdown().await;
+    let deadline = tokio::time::Instant::now()
+        .checked_add(config.shutdown_timeout)
+        .ok_or_else(|| anyhow::anyhow!("shutdown timeout is too large"))?;
+    let server_result = match early_server_result {
+        Some(result) => Some(result),
+        None => {
+            let _ = stop_server.send(());
+            match tokio::time::timeout_at(deadline, &mut server_task).await {
+                Ok(result) => Some(result),
+                Err(_) => {
+                    tracing::warn!("HTTP shutdown exceeded the configured deadline");
+                    server_task.abort();
+                    None
+                }
+            }
+        }
+    };
+    if tokio::time::timeout_at(deadline, &mut runner_task)
+        .await
+        .is_err()
+    {
+        tracing::warn!("job shutdown exceeded the configured deadline");
+        runner_task.abort();
+    }
+    if let Some(result) = server_result {
+        result.context("historical quote server task stopped")??;
+    }
+    Ok(())
+}

--- a/crates/historical-quote-service/src/shutdown.rs
+++ b/crates/historical-quote-service/src/shutdown.rs
@@ -1,0 +1,19 @@
+pub async fn signal() {
+    #[cfg(unix)]
+    {
+        if let Ok(mut terminate) =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+        {
+            tokio::select! {
+                result = tokio::signal::ctrl_c() => {
+                    let _ = result;
+                }
+                signal = terminate.recv() => {
+                    let _ = signal;
+                }
+            }
+            return;
+        }
+    }
+    let _ = tokio::signal::ctrl_c().await;
+}

--- a/crates/historical-quote-service/tests/http.rs
+++ b/crates/historical-quote-service/tests/http.rs
@@ -1,0 +1,485 @@
+#![expect(
+    clippy::expect_used,
+    clippy::panic,
+    reason = "integration tests should fail immediately when a fixture or assertion is invalid"
+)]
+
+use std::future::Future;
+use std::net::{Ipv4Addr, SocketAddr};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::body::{to_bytes, Body};
+use axum::http::header::{AUTHORIZATION, CONTENT_TYPE};
+use axum::http::{Request, StatusCode};
+use historical_quote::api::{
+    Backend, CoverageRequest, CoverageResponse, DependencyHealth, DependencyState,
+    HistoricalQuoteResult, JobResult,
+};
+use historical_quote::EngineProgress;
+use historical_quote_service::app::{
+    router, AppState, CoverageResolver, ServiceDependencyError, StatusDependencies, StatusProbe,
+};
+use historical_quote_service::config::{ObjectStoreConfig, ReplicaDatabaseConfig, ServiceConfig};
+use historical_quote_service::jobs::{
+    ExecutionContext, JobExecutionError, JobExecutor, JobLimits, JobRegistry, JobRequest, JobRunner,
+};
+use sha2::{Digest, Sha256};
+use tower::ServiceExt;
+use uuid::Uuid;
+
+mod support;
+
+use support::{consistency_request, quote_request, ControlledExecutor};
+
+const TOKEN: &str = "test-token";
+const REVISION_HEADER: &str = "x-dsolver-history-api-revision";
+
+#[tokio::test]
+async fn only_ready_is_open_and_bodyless_routes_require_exact_revision() {
+    let (app, registry) = test_app(Arc::new(ImmediateExecutor));
+    assert_eq!(
+        send(&app, request("GET", "/ready", None, false, false))
+            .await
+            .status(),
+        StatusCode::OK
+    );
+    assert_eq!(
+        send(&app, request("GET", "/status", None, false, false))
+            .await
+            .status(),
+        StatusCode::UNAUTHORIZED
+    );
+    assert_eq!(
+        send(&app, request("GET", "/status", None, true, false))
+            .await
+            .status(),
+        StatusCode::BAD_REQUEST
+    );
+    assert_eq!(
+        send(&app, request("GET", "/status", None, true, true))
+            .await
+            .status(),
+        StatusCode::OK
+    );
+    registry.begin_shutdown().await;
+}
+
+#[tokio::test]
+async fn quote_submission_reuses_retained_work_and_consumes_terminal_result_once() {
+    let (app, registry) = test_app(Arc::new(ImmediateExecutor));
+    let request_id = Uuid::new_v4();
+    let body = serde_json::to_value(quote_request(request_id, 60_000))
+        .expect("quote request must serialize");
+    let submitted = send(
+        &app,
+        request("POST", "/jobs/quote", Some(&body), true, false),
+    )
+    .await;
+    assert_eq!(submitted.status(), StatusCode::ACCEPTED);
+    assert_eq!(submitted.headers()["retry-after"], "2");
+    let location = submitted.headers()["location"]
+        .to_str()
+        .expect("location must be text")
+        .to_owned();
+
+    wait_terminal(&registry, &location).await;
+    let reused = send(
+        &app,
+        request("POST", "/jobs/quote", Some(&body), true, false),
+    )
+    .await;
+    assert_eq!(reused.status(), StatusCode::OK);
+    let reused_body = json_body(reused).await;
+    assert_eq!(reused_body["reused"], true);
+    assert!(reused_body.get("result").is_none());
+
+    let terminal = send(&app, request("GET", &location, None, true, true)).await;
+    assert_eq!(terminal.status(), StatusCode::OK);
+    let terminal_body = json_body(terminal).await;
+    assert_eq!(terminal_body["state"], "completed");
+    assert!(terminal_body.get("result").is_some());
+    assert_eq!(
+        send(&app, request("GET", &location, None, true, true))
+            .await
+            .status(),
+        StatusCode::NOT_FOUND
+    );
+    registry.begin_shutdown().await;
+}
+
+#[tokio::test]
+async fn admission_errors_use_safe_shapes_and_budget_details() {
+    let (app, registry) = test_app(Arc::new(ImmediateExecutor));
+    let request_id = Uuid::new_v4();
+    let mut body = serde_json::to_value(quote_request(request_id, 60_000))
+        .expect("quote request must serialize");
+    body["blocks"]["endInclusive"] = serde_json::json!(200);
+    let response = send(
+        &app,
+        request("POST", "/jobs/quote", Some(&body), true, false),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let error = json_body(response).await;
+    assert_eq!(error["code"], "comparison_budget_exceeded");
+    assert_eq!(error["details"]["startBlockCount"], 101);
+    assert!(error.get("stack").is_none());
+
+    let malformed = send(
+        &app,
+        Request::builder()
+            .method("POST")
+            .uri("/jobs/quote")
+            .header(AUTHORIZATION, format!("Bearer {TOKEN}"))
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from("{not-json"))
+            .expect("request must build"),
+    )
+    .await;
+    assert_eq!(malformed.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        json_body(malformed).await["message"],
+        "request body is invalid"
+    );
+    registry.begin_shutdown().await;
+}
+
+#[tokio::test]
+async fn cancellation_is_retry_safe_and_does_not_consume_the_terminal_envelope() {
+    let executor = Arc::new(ControlledExecutor::default());
+    let (app, registry) = test_app(executor.clone());
+    let body = serde_json::to_value(quote_request(Uuid::new_v4(), 60_000))
+        .expect("quote request must serialize");
+    let submitted = send(
+        &app,
+        request("POST", "/jobs/quote", Some(&body), true, false),
+    )
+    .await;
+    let location = submitted.headers()["location"]
+        .to_str()
+        .expect("location must be text")
+        .to_owned();
+    let started = executor.next_started().await;
+    assert!(!started.job_id.is_nil());
+    started.progress.quote_comparison_completed();
+    let cancel_path = format!("{location}/cancel");
+    let running = send(&app, request("POST", &cancel_path, None, true, true)).await;
+    assert_eq!(running.status(), StatusCode::OK);
+    assert_eq!(json_body(running).await["cancellationRequested"], true);
+    wait_terminal(&registry, &location).await;
+
+    let cancelled = send(&app, request("POST", &cancel_path, None, true, true)).await;
+    assert_eq!(cancelled.status(), StatusCode::OK);
+    assert_eq!(json_body(cancelled).await["state"], "cancelled");
+    let poll = send(&app, request("GET", &location, None, true, true)).await;
+    assert_eq!(poll.status(), StatusCode::OK);
+    assert_eq!(json_body(poll).await["state"], "cancelled");
+    registry.begin_shutdown().await;
+}
+
+#[tokio::test]
+async fn incomplete_terminal_body_delivery_releases_the_lease() {
+    let executor = Arc::new(ControlledExecutor::default());
+    let (app, registry) = test_app(executor.clone());
+    let body = serde_json::to_value(quote_request(Uuid::new_v4(), 60_000))
+        .expect("quote request must serialize");
+    let submitted = send(
+        &app,
+        request("POST", "/jobs/quote", Some(&body), true, false),
+    )
+    .await;
+    let location = submitted.headers()["location"]
+        .to_str()
+        .expect("location must be text")
+        .to_owned();
+    executor.next_started().await.complete_quote();
+    wait_terminal(&registry, &location).await;
+
+    let selected = send(&app, request("GET", &location, None, true, true)).await;
+    assert_eq!(selected.status(), StatusCode::OK);
+    drop(selected);
+    tokio::task::yield_now().await;
+    let retried = send(&app, request("GET", &location, None, true, true)).await;
+    assert_eq!(retried.status(), StatusCode::OK);
+    assert_eq!(json_body(retried).await["state"], "completed");
+    registry.begin_shutdown().await;
+}
+
+#[tokio::test]
+async fn consistency_submission_uses_the_shared_job_lifecycle() {
+    let executor = Arc::new(ControlledExecutor::default());
+    let (app, registry) = test_app(executor.clone());
+    let consistency = consistency_request(Uuid::new_v4(), 60_000);
+    let body = serde_json::to_value(consistency).expect("consistency request must serialize");
+    let submitted = send(
+        &app,
+        request("POST", "/jobs/consistency-check", Some(&body), true, false),
+    )
+    .await;
+    assert_eq!(submitted.status(), StatusCode::ACCEPTED);
+    assert_eq!(
+        json_body(submitted).await["jobType"],
+        "historicalStateConsistencyCheck"
+    );
+    let started = executor.next_started().await;
+    assert!(!started.job_id.is_nil());
+    registry.begin_shutdown().await;
+}
+
+#[tokio::test]
+async fn full_queue_stays_ready_and_drain_turns_readiness_off() {
+    let executor = Arc::new(ControlledExecutor::default());
+    let (app, registry) = test_app_with_limits(
+        executor.clone(),
+        JobLimits {
+            max_running: 1,
+            max_waiting: 1,
+            ..JobLimits::default()
+        },
+    );
+    for _ in 0..2 {
+        let body = serde_json::to_value(quote_request(Uuid::new_v4(), 60_000))
+            .expect("quote request must serialize");
+        assert!(matches!(
+            send(
+                &app,
+                request("POST", "/jobs/quote", Some(&body), true, false)
+            )
+            .await
+            .status(),
+            StatusCode::ACCEPTED
+        ));
+        if executor.try_next_started().is_none() {
+            tokio::task::yield_now().await;
+        }
+    }
+    assert_eq!(
+        send(&app, request("GET", "/ready", None, false, false))
+            .await
+            .status(),
+        StatusCode::OK
+    );
+    registry.begin_shutdown().await;
+    assert_eq!(
+        send(&app, request("GET", "/ready", None, false, false))
+            .await
+            .status(),
+        StatusCode::SERVICE_UNAVAILABLE
+    );
+}
+
+#[tokio::test]
+async fn protected_status_and_coverage_return_bounded_safe_data() {
+    let (app, registry) = test_app(Arc::new(ImmediateExecutor));
+    let status = send(&app, request("GET", "/status", None, true, true)).await;
+    let status = json_body(status).await;
+    assert_eq!(status["apiRevision"], 1);
+    assert_eq!(status["visibleThroughBlock"], 123);
+    assert_eq!(status["limits"]["maxRunningJobs"], 4);
+    assert!(status.get("databaseHost").is_none());
+
+    let coverage_request = serde_json::json!({
+        "apiRevision": 1,
+        "chainId": 8453,
+        "backends": ["native"]
+    });
+    let coverage = send(
+        &app,
+        request("POST", "/coverage", Some(&coverage_request), true, false),
+    )
+    .await;
+    assert_eq!(coverage.status(), StatusCode::OK);
+    assert_eq!(json_body(coverage).await["visibleThroughBlock"], 123);
+    registry.begin_shutdown().await;
+}
+
+fn test_app<E>(executor: Arc<E>) -> (axum::Router, JobRegistry)
+where
+    E: JobExecutor,
+{
+    test_app_with_limits(executor, JobLimits::default())
+}
+
+fn test_app_with_limits<E>(executor: Arc<E>, limits: JobLimits) -> (axum::Router, JobRegistry)
+where
+    E: JobExecutor,
+{
+    let mut config = test_config();
+    config.scheduler = limits.clone();
+    let registry = JobRegistry::new(limits);
+    let runner = JobRunner::new(registry.clone(), executor);
+    tokio::spawn(runner.run());
+    let app = router(AppState {
+        config: Arc::new(config),
+        registry: registry.clone(),
+        coverage: Arc::new(StaticCoverage),
+        status: Arc::new(StaticStatus),
+    });
+    (app, registry)
+}
+
+fn test_config() -> ServiceConfig {
+    ServiceConfig {
+        bind_address: SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
+        supported_chain_id: 8_453,
+        service_revision: "test-revision".to_owned(),
+        enabled_backends: vec![Backend::Native, Backend::Rfq],
+        expected_bearer_digest: Sha256::digest(TOKEN.as_bytes()).into(),
+        scheduler: JobLimits::default(),
+        max_combination_count: 100,
+        max_block_span: 10_000,
+        default_timeout_ms: 60_000,
+        max_timeout_ms: 300_000,
+        job_decoded_byte_reservation: 1,
+        max_consistency_pairs: 10,
+        max_quote_selectors: 10,
+        max_amounts_per_quote: 10,
+        max_structured_differences: 100,
+        database: ReplicaDatabaseConfig {
+            host: "replica.invalid".to_owned(),
+            port: 5_432,
+            database: "state_history".to_owned(),
+            username: "state_history_observer".to_owned(),
+            max_connections: 1,
+            max_connection_lifetime: Duration::from_secs(60),
+        },
+        object_store: ObjectStoreConfig {
+            bucket: "history".to_owned(),
+            prefix: "state".to_owned(),
+            region: "eu-central-1".to_owned(),
+            endpoint_url: None,
+            force_path_style: false,
+        },
+        shutdown_timeout: Duration::from_secs(1),
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ImmediateExecutor;
+
+impl JobExecutor for ImmediateExecutor {
+    fn execute(
+        &self,
+        context: ExecutionContext,
+    ) -> Pin<Box<dyn Future<Output = Result<JobResult, JobExecutionError>> + Send + 'static>> {
+        Box::pin(async move {
+            match context.request {
+                JobRequest::HistoricalQuote(request) => {
+                    let result: HistoricalQuoteResult = serde_json::from_value(serde_json::json!({
+                        "requestId": request.request_id,
+                        "chainId": 8453,
+                        "pool": request.pool,
+                        "visibleThroughBlock": 123,
+                        "gaps": [],
+                        "results": []
+                    }))
+                    .expect("quote result fixture must be valid");
+                    Ok(JobResult::HistoricalQuote(result))
+                }
+                JobRequest::HistoricalStateConsistencyCheck(_) => Err(JobExecutionError::Cancelled),
+            }
+        })
+    }
+}
+
+struct StaticCoverage;
+
+impl CoverageResolver for StaticCoverage {
+    fn resolve(
+        &self,
+        request: CoverageRequest,
+    ) -> Pin<Box<dyn Future<Output = Result<CoverageResponse, ServiceDependencyError>> + Send + '_>>
+    {
+        Box::pin(async move {
+            Ok(CoverageResponse {
+                api_revision: request.api_revision,
+                chain_id: request.chain_id,
+                backends: request.backends,
+                visible_through_block: 123,
+                continuous_intervals: Vec::new(),
+                known_gaps: Vec::new(),
+            })
+        })
+    }
+}
+
+struct StaticStatus;
+
+impl StatusProbe for StaticStatus {
+    fn probe(
+        &self,
+    ) -> Pin<Box<dyn Future<Output = Result<StatusDependencies, ServiceDependencyError>> + Send + '_>>
+    {
+        Box::pin(async {
+            Ok(StatusDependencies {
+                visible_through_block: Some(123),
+                database: DependencyHealth {
+                    state: DependencyState::Healthy,
+                    message: None,
+                },
+                object_store: DependencyHealth {
+                    state: DependencyState::Healthy,
+                    message: None,
+                },
+            })
+        })
+    }
+}
+
+fn request(
+    method: &str,
+    uri: &str,
+    body: Option<&serde_json::Value>,
+    authenticated: bool,
+    revision: bool,
+) -> Request<Body> {
+    let mut builder = Request::builder().method(method).uri(uri);
+    if authenticated {
+        builder = builder.header(AUTHORIZATION, format!("Bearer {TOKEN}"));
+    }
+    if revision {
+        builder = builder.header(REVISION_HEADER, "1");
+    }
+    let payload = if let Some(body) = body {
+        builder = builder.header(CONTENT_TYPE, "application/json");
+        Body::from(serde_json::to_vec(body).expect("request body must serialize"))
+    } else {
+        Body::empty()
+    };
+    builder.body(payload).expect("request must build")
+}
+
+async fn send(app: &axum::Router, request: Request<Body>) -> axum::response::Response {
+    app.clone()
+        .oneshot(request)
+        .await
+        .expect("router must respond")
+}
+
+async fn json_body(response: axum::response::Response) -> serde_json::Value {
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("response body must be readable");
+    serde_json::from_slice(&bytes).expect("response body must be JSON")
+}
+
+async fn wait_terminal(registry: &JobRegistry, location: &str) {
+    let job_id = Uuid::parse_str(location.trim_start_matches("/jobs/"))
+        .expect("location must contain a UUID");
+    for _ in 0..20 {
+        if registry.inspect(job_id).await.is_some_and(|job| {
+            matches!(
+                job.state,
+                historical_quote::api::JobState::Completed
+                    | historical_quote::api::JobState::Cancelled
+                    | historical_quote::api::JobState::Failed
+            )
+        }) {
+            return;
+        }
+        tokio::task::yield_now().await;
+    }
+    panic!("job did not become terminal");
+}

--- a/crates/historical-quote-service/tests/jobs.rs
+++ b/crates/historical-quote-service/tests/jobs.rs
@@ -1,0 +1,436 @@
+#![expect(
+    clippy::expect_used,
+    clippy::panic,
+    reason = "integration tests should fail immediately when a fixture or assertion is invalid"
+)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use historical_quote::api::{JobProgress, JobState, JobType};
+use historical_quote::EngineProgress;
+use historical_quote_service::jobs::{
+    JobLimits, JobRegistry, JobRequest, JobRunner, PollOutcome, ScheduledJob, SubmitOutcome,
+};
+use uuid::Uuid;
+
+mod support;
+
+use support::{consistency_request, quote_request, ControlledExecutor};
+
+trait SubmitOutcomeExt {
+    fn accepted_job_id(&self) -> Uuid;
+}
+
+impl SubmitOutcomeExt for SubmitOutcome {
+    fn accepted_job_id(&self) -> Uuid {
+        match self {
+            SubmitOutcome::Accepted(submission) => submission.job_id,
+            other => panic!("expected accepted job, got {other:?}"),
+        }
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn byte_budget_preserves_fifo_head_blocking_and_one_based_positions() {
+    let executor = Arc::new(ControlledExecutor::default());
+    let registry = JobRegistry::new(JobLimits {
+        max_running: 2,
+        max_waiting: 16,
+        decoded_byte_budget: 100,
+        max_terminal_jobs: 20,
+        terminal_ttl: Duration::from_secs(3_600),
+    });
+    let runner = JobRunner::new(registry.clone(), executor.clone());
+    let run_task = tokio::spawn(runner.run());
+
+    let first = registry
+        .submit(ScheduledJob::new(
+            JobRequest::HistoricalQuote(quote_request(Uuid::new_v4(), 60_000)),
+            80,
+        ))
+        .await
+        .accepted_job_id();
+    let first_started = executor.next_started().await;
+    assert_eq!(first_started.job_id, first);
+
+    let head = registry
+        .submit(ScheduledJob::new(
+            JobRequest::HistoricalQuote(quote_request(Uuid::new_v4(), 60_000)),
+            30,
+        ))
+        .await
+        .accepted_job_id();
+    let younger = registry
+        .submit(ScheduledJob::new(
+            JobRequest::HistoricalQuote(quote_request(Uuid::new_v4(), 60_000)),
+            10,
+        ))
+        .await
+        .accepted_job_id();
+    tokio::task::yield_now().await;
+
+    let head_snapshot = registry.inspect(head).await.expect("head job must exist");
+    let younger_snapshot = registry
+        .inspect(younger)
+        .await
+        .expect("younger job must exist");
+    assert_eq!(head_snapshot.state, JobState::Queued);
+    assert_eq!(head_snapshot.queue_position, Some(1));
+    assert_eq!(younger_snapshot.state, JobState::Queued);
+    assert_eq!(younger_snapshot.queue_position, Some(2));
+    assert!(executor.try_next_started().is_none());
+
+    first_started.complete_quote();
+    let second = executor.next_started().await;
+    let third = executor.next_started().await;
+    assert_eq!((second.job_id, third.job_id), (head, younger));
+
+    registry.begin_shutdown().await;
+    run_task.await.expect("runner task must stop");
+}
+
+#[tokio::test(start_paused = true)]
+async fn retained_request_id_reuses_same_content_and_conflicts_on_change() {
+    let registry = JobRegistry::new(JobLimits::default());
+    let request_id = Uuid::new_v4();
+    let original = ScheduledJob::new(
+        JobRequest::HistoricalQuote(quote_request(request_id, 60_000)),
+        1,
+    );
+    let first = registry.submit(original.clone()).await.accepted_job_id();
+
+    let reused = registry.submit(original).await;
+    assert!(matches!(reused, SubmitOutcome::Reused(_)));
+    assert_eq!(reused.job_id(), Some(first));
+
+    let conflict = registry
+        .submit(ScheduledJob::new(
+            JobRequest::HistoricalQuote(quote_request(request_id, 30_000)),
+            1,
+        ))
+        .await;
+    assert!(matches!(conflict, SubmitOutcome::RequestIdConflict));
+}
+
+#[tokio::test(start_paused = true)]
+async fn queue_time_counts_toward_the_deadline() {
+    let executor = Arc::new(ControlledExecutor::default());
+    let registry = JobRegistry::new(JobLimits {
+        max_running: 1,
+        ..JobLimits::default()
+    });
+    let runner = JobRunner::new(registry.clone(), executor.clone());
+    let run_task = tokio::spawn(runner.run());
+
+    registry
+        .submit(ScheduledJob::new(
+            JobRequest::HistoricalQuote(quote_request(Uuid::new_v4(), 60_000)),
+            1,
+        ))
+        .await;
+    let _blocking = executor.next_started().await;
+    let queued = registry
+        .submit(ScheduledJob::new(
+            JobRequest::HistoricalQuote(quote_request(Uuid::new_v4(), 1_000)),
+            1,
+        ))
+        .await
+        .accepted_job_id();
+
+    tokio::time::advance(Duration::from_secs(1)).await;
+    tokio::task::yield_now().await;
+    assert_eq!(
+        registry
+            .inspect(queued)
+            .await
+            .expect("queued job must exist")
+            .state,
+        JobState::Failed
+    );
+
+    registry.begin_shutdown().await;
+    run_task.await.expect("runner task must stop");
+}
+
+#[tokio::test(start_paused = true)]
+async fn terminal_delivery_is_leased_and_retryable_until_committed() {
+    let executor = Arc::new(ControlledExecutor::default());
+    let registry = JobRegistry::new(JobLimits::default());
+    let runner = JobRunner::new(registry.clone(), executor.clone());
+    let run_task = tokio::spawn(runner.run());
+    let request_id = Uuid::new_v4();
+    let job_id = registry
+        .submit(ScheduledJob::new(
+            JobRequest::HistoricalQuote(quote_request(request_id, 60_000)),
+            1,
+        ))
+        .await
+        .accepted_job_id();
+    executor.next_started().await.complete_quote();
+    tokio::task::yield_now().await;
+
+    let PollOutcome::Terminal(first_delivery) = registry.poll(job_id).await else {
+        panic!("first terminal poll must acquire delivery");
+    };
+    assert!(matches!(registry.poll(job_id).await, PollOutcome::NotFound));
+    first_delivery.release().await;
+
+    let PollOutcome::Terminal(second_delivery) = registry.poll(job_id).await else {
+        panic!("released delivery must be retryable");
+    };
+    second_delivery.commit().await;
+    assert!(matches!(registry.poll(job_id).await, PollOutcome::NotFound));
+    let replacement = registry
+        .submit(ScheduledJob::new(
+            JobRequest::HistoricalQuote(quote_request(request_id, 60_000)),
+            1,
+        ))
+        .await;
+    assert!(matches!(replacement, SubmitOutcome::Accepted(_)));
+
+    registry.begin_shutdown().await;
+    run_task.await.expect("runner task must stop");
+}
+
+#[tokio::test(start_paused = true)]
+async fn both_job_types_share_capacity_and_shutdown_cancels_them() {
+    let executor = Arc::new(ControlledExecutor::default());
+    let registry = JobRegistry::new(JobLimits {
+        max_running: 1,
+        ..JobLimits::default()
+    });
+    let runner = JobRunner::new(registry.clone(), executor.clone());
+    let run_task = tokio::spawn(runner.run());
+    let quote = registry
+        .submit(ScheduledJob::new(
+            JobRequest::HistoricalQuote(quote_request(Uuid::new_v4(), 60_000)),
+            1,
+        ))
+        .await
+        .accepted_job_id();
+    let _running = executor.next_started().await;
+    let check = registry
+        .submit(ScheduledJob::new(
+            JobRequest::HistoricalStateConsistencyCheck(consistency_request(
+                Uuid::new_v4(),
+                60_000,
+            )),
+            1,
+        ))
+        .await
+        .accepted_job_id();
+    assert_eq!(
+        registry
+            .inspect(quote)
+            .await
+            .expect("quote must exist")
+            .job_type,
+        JobType::HistoricalQuote
+    );
+    assert_eq!(
+        registry
+            .inspect(check)
+            .await
+            .expect("check must exist")
+            .job_type,
+        JobType::HistoricalStateConsistencyCheck
+    );
+
+    registry.begin_shutdown().await;
+    run_task.await.expect("runner task must stop");
+    assert_eq!(
+        registry
+            .inspect(quote)
+            .await
+            .expect("quote must remain retained")
+            .state,
+        JobState::Cancelled
+    );
+    assert_eq!(
+        registry
+            .inspect(check)
+            .await
+            .expect("check must remain retained")
+            .state,
+        JobState::Cancelled
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn default_concurrency_is_four_and_waiting_capacity_is_bounded() {
+    let executor = Arc::new(ControlledExecutor::default());
+    let registry = JobRegistry::new(JobLimits {
+        max_waiting: 1,
+        ..JobLimits::default()
+    });
+    let runner = JobRunner::new(registry.clone(), executor.clone());
+    let run_task = tokio::spawn(runner.run());
+
+    let mut running = Vec::new();
+    for _ in 0..4 {
+        registry
+            .submit(ScheduledJob::new(
+                JobRequest::HistoricalQuote(quote_request(Uuid::new_v4(), 60_000)),
+                1,
+            ))
+            .await;
+        running.push(executor.next_started().await);
+    }
+    let waiting = registry
+        .submit(ScheduledJob::new(
+            JobRequest::HistoricalQuote(quote_request(Uuid::new_v4(), 60_000)),
+            1,
+        ))
+        .await
+        .accepted_job_id();
+    let rejected = registry
+        .submit(ScheduledJob::new(
+            JobRequest::HistoricalQuote(quote_request(Uuid::new_v4(), 60_000)),
+            1,
+        ))
+        .await;
+    assert!(matches!(rejected, SubmitOutcome::QueueFull));
+    assert_eq!(
+        registry
+            .inspect(waiting)
+            .await
+            .expect("waiting job must exist")
+            .queue_position,
+        Some(1)
+    );
+
+    registry.begin_shutdown().await;
+    drop(running);
+    run_task.await.expect("runner task must stop");
+}
+
+#[tokio::test(start_paused = true)]
+async fn queued_and_running_cancellation_preserve_partial_progress() {
+    let executor = Arc::new(ControlledExecutor::default());
+    let registry = JobRegistry::new(JobLimits {
+        max_running: 1,
+        ..JobLimits::default()
+    });
+    let runner = JobRunner::new(registry.clone(), executor.clone());
+    let run_task = tokio::spawn(runner.run());
+    let running_id = registry
+        .submit(ScheduledJob::new(
+            JobRequest::HistoricalQuote(quote_request(Uuid::new_v4(), 60_000)),
+            1,
+        ))
+        .await
+        .accepted_job_id();
+    let running = executor.next_started().await;
+    running.progress.quote_comparison_completed();
+    let queued_id = registry
+        .submit(ScheduledJob::new(
+            JobRequest::HistoricalQuote(quote_request(Uuid::new_v4(), 60_000)),
+            1,
+        ))
+        .await
+        .accepted_job_id();
+
+    let _ = registry.cancel(queued_id).await;
+    assert_eq!(
+        registry
+            .inspect(queued_id)
+            .await
+            .expect("queued job must be retained")
+            .state,
+        JobState::Cancelled
+    );
+    assert_eq!(
+        registry
+            .inspect(queued_id)
+            .await
+            .expect("queued job must be retained")
+            .queue_position,
+        None
+    );
+    let _ = registry.cancel(running_id).await;
+    tokio::task::yield_now().await;
+    let running = registry
+        .inspect(running_id)
+        .await
+        .expect("running job must be retained");
+    assert_eq!(running.state, JobState::Cancelled);
+    let JobProgress::HistoricalQuote(progress) = running.progress else {
+        panic!("quote job must report quote progress");
+    };
+    assert_eq!(progress.completed_comparisons, 1);
+
+    registry.begin_shutdown().await;
+    run_task.await.expect("runner task must stop");
+}
+
+#[tokio::test(start_paused = true)]
+async fn running_deadline_cancels_work_and_keeps_partial_progress() {
+    let executor = Arc::new(ControlledExecutor::default());
+    let registry = JobRegistry::new(JobLimits::default());
+    let runner = JobRunner::new(registry.clone(), executor.clone());
+    let run_task = tokio::spawn(runner.run());
+    let job_id = registry
+        .submit(ScheduledJob::new(
+            JobRequest::HistoricalQuote(quote_request(Uuid::new_v4(), 1_000)),
+            1,
+        ))
+        .await
+        .accepted_job_id();
+    let running = executor.next_started().await;
+    running.progress.quote_comparison_completed();
+
+    tokio::time::advance(Duration::from_secs(1)).await;
+    tokio::task::yield_now().await;
+    let failed = registry
+        .inspect(job_id)
+        .await
+        .expect("failed job must be retained");
+    assert_eq!(failed.state, JobState::Failed);
+    assert!(failed.failure.is_none());
+    let JobProgress::HistoricalQuote(progress) = failed.progress else {
+        panic!("quote job must report quote progress");
+    };
+    assert_eq!(progress.completed_comparisons, 1);
+
+    registry.begin_shutdown().await;
+    run_task.await.expect("runner task must stop");
+}
+
+#[tokio::test(start_paused = true)]
+async fn terminal_retention_evicts_on_replacement_and_expires_unfetched_results() {
+    let executor = Arc::new(ControlledExecutor::default());
+    let registry = JobRegistry::new(JobLimits {
+        max_running: 1,
+        max_terminal_jobs: 2,
+        terminal_ttl: Duration::from_secs(3_600),
+        ..JobLimits::default()
+    });
+    let runner = JobRunner::new(registry.clone(), executor.clone());
+    let run_task = tokio::spawn(runner.run());
+    let mut completed = Vec::new();
+    for _ in 0..3 {
+        let job_id = registry
+            .submit(ScheduledJob::new(
+                JobRequest::HistoricalQuote(quote_request(Uuid::new_v4(), 60_000)),
+                1,
+            ))
+            .await
+            .accepted_job_id();
+        executor.next_started().await.complete_quote();
+        tokio::task::yield_now().await;
+        completed.push(job_id);
+        if completed.len() == 2 {
+            assert!(registry.inspect(completed[0]).await.is_some());
+        }
+    }
+    assert!(registry.inspect(completed[0]).await.is_none());
+    assert!(registry.inspect(completed[1]).await.is_some());
+    assert!(registry.inspect(completed[2]).await.is_some());
+
+    tokio::time::advance(Duration::from_secs(3_600)).await;
+    assert!(registry.inspect(completed[1]).await.is_none());
+    assert!(registry.inspect(completed[2]).await.is_none());
+    registry.begin_shutdown().await;
+    run_task.await.expect("runner task must stop");
+}

--- a/crates/historical-quote-service/tests/support/mod.rs
+++ b/crates/historical-quote-service/tests/support/mod.rs
@@ -1,0 +1,138 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use historical_quote::api::{
+    ConsistencyCheckRequest, HistoricalQuoteResult, JobResult, QuoteJobRequest,
+};
+use historical_quote_service::jobs::{
+    ExecutionContext, JobExecutionError, JobExecutor, JobRequest, ProgressReporter,
+};
+use tokio::sync::{mpsc, oneshot, Mutex};
+use uuid::Uuid;
+
+pub fn quote_request(request_id: Uuid, timeout_ms: u64) -> QuoteJobRequest {
+    serde_json::from_value(serde_json::json!({
+        "requestId": request_id,
+        "apiRevision": 1,
+        "timeoutMs": timeout_ms,
+        "chainId": 8453,
+        "pool": {
+            "backend": "native",
+            "protocol": "uniswap_v3",
+            "componentId": "pool-1",
+            "tokenIn": "0x01",
+            "tokenOut": "0x02"
+        },
+        "blocks": {"start": 100, "endInclusive": 100, "step": 1},
+        "lags": [1],
+        "amountsIn": ["1"]
+    }))
+    .expect("quote request fixture must be valid")
+}
+
+pub fn consistency_request(request_id: Uuid, timeout_ms: u64) -> ConsistencyCheckRequest {
+    serde_json::from_value(serde_json::json!({
+        "requestId": request_id,
+        "apiRevision": 1,
+        "timeoutMs": timeout_ms,
+        "chainId": 8453,
+        "backends": ["native"],
+        "selection": {
+            "type": "checkpointPairs",
+            "pairs": [{
+                "earlierPosition": {"generation": 1, "messageSeq": 1},
+                "targetPosition": {"generation": 1, "messageSeq": 2}
+            }]
+        },
+        "quotesToCompare": [{
+            "pool": {
+                "backend": "native",
+                "protocol": "uniswap_v3",
+                "componentId": "pool-1",
+                "tokenIn": "0x01",
+                "tokenOut": "0x02"
+            },
+            "amountsIn": ["1"]
+        }]
+    }))
+    .expect("consistency request fixture must be valid")
+}
+
+type ExecutionResult = Result<JobResult, JobExecutionError>;
+
+pub struct StartedJob {
+    pub job_id: Uuid,
+    pub progress: ProgressReporter,
+    request: JobRequest,
+    finish: oneshot::Sender<ExecutionResult>,
+}
+
+impl StartedJob {
+    pub fn complete_quote(self) {
+        let JobRequest::HistoricalQuote(request) = self.request else {
+            panic!("started job must be a quote");
+        };
+        let result: HistoricalQuoteResult = serde_json::from_value(serde_json::json!({
+            "requestId": request.request_id,
+            "chainId": 8453,
+            "pool": request.pool,
+            "visibleThroughBlock": 101,
+            "gaps": [],
+            "results": []
+        }))
+        .expect("quote result fixture must be valid");
+        self.finish
+            .send(Ok(JobResult::HistoricalQuote(result)))
+            .expect("job runner must still await the result");
+    }
+}
+
+#[derive(Clone)]
+pub struct ControlledExecutor {
+    started_tx: mpsc::UnboundedSender<StartedJob>,
+    started_rx: Arc<Mutex<mpsc::UnboundedReceiver<StartedJob>>>,
+}
+
+impl Default for ControlledExecutor {
+    fn default() -> Self {
+        let (started_tx, started_rx) = mpsc::unbounded_channel();
+        Self {
+            started_tx,
+            started_rx: Arc::new(Mutex::new(started_rx)),
+        }
+    }
+}
+
+impl ControlledExecutor {
+    pub async fn next_started(&self) -> StartedJob {
+        self.started_rx
+            .lock()
+            .await
+            .recv()
+            .await
+            .expect("executor must report a started job")
+    }
+
+    pub fn try_next_started(&self) -> Option<StartedJob> {
+        self.started_rx.try_lock().ok()?.try_recv().ok()
+    }
+}
+
+impl JobExecutor for ControlledExecutor {
+    fn execute(
+        &self,
+        context: ExecutionContext,
+    ) -> Pin<Box<dyn Future<Output = ExecutionResult> + Send + 'static>> {
+        let (finish, result) = oneshot::channel();
+        self.started_tx
+            .send(StartedJob {
+                job_id: context.job_id,
+                progress: context.progress,
+                request: context.request,
+                finish,
+            })
+            .expect("test receiver must remain open");
+        Box::pin(async move { result.await.unwrap_or(Err(JobExecutionError::Cancelled)) })
+    }
+}

--- a/crates/historical-quote/src/consistency.rs
+++ b/crates/historical-quote/src/consistency.rs
@@ -30,6 +30,7 @@ pub struct ConsistencyChecker<S> {
     source: Arc<S>,
     read_limits: ReadLimits,
     max_differences: usize,
+    max_pairs: usize,
 }
 
 impl<S> ConsistencyChecker<S> {
@@ -38,6 +39,21 @@ impl<S> ConsistencyChecker<S> {
             source,
             read_limits,
             max_differences,
+            max_pairs: usize::MAX,
+        }
+    }
+
+    pub fn with_limits(
+        source: Arc<S>,
+        read_limits: ReadLimits,
+        max_differences: usize,
+        max_pairs: usize,
+    ) -> Self {
+        Self {
+            source,
+            read_limits,
+            max_differences,
+            max_pairs,
         }
     }
 
@@ -57,8 +73,14 @@ impl<S: HistorySource> ConsistencyChecker<S> {
         if request.backends.contains(&Backend::Vm) {
             return Err(HistoricalError::UnsupportedCanonicalVm);
         }
-        let query = checkpoint_pair_query(request)?;
+        let query = checkpoint_pair_query(request)?.with_max_pairs(self.max_pairs);
         let pairs = self.source.resolve_checkpoint_pairs(query).await?;
+        if pairs.len() > self.max_pairs {
+            return Err(HistoricalError::CheckBudgetExceeded);
+        }
+        progress.checkpoint_pair_total(
+            u64::try_from(pairs.len()).map_err(|_| HistoricalError::CheckBudgetExceeded)?,
+        );
         if pairs.is_empty() {
             return Ok(empty_report(request));
         }

--- a/crates/historical-quote/src/error.rs
+++ b/crates/historical-quote/src/error.rs
@@ -16,6 +16,8 @@ pub enum HistoricalError {
     StateReconstructionFailed(String),
     #[error("historical request selector is invalid: {0}")]
     InvalidSelector(String),
+    #[error("historical state consistency check exceeds the checkpoint pair limit")]
+    CheckBudgetExceeded,
     #[error("canonical VM comparison is unsupported")]
     UnsupportedCanonicalVm,
 }

--- a/crates/historical-quote/src/history.rs
+++ b/crates/historical-quote/src/history.rs
@@ -11,6 +11,8 @@ use crate::HistoricalError;
 pub trait EngineProgress: Send + Sync {
     fn quote_comparison_completed(&self) {}
 
+    fn checkpoint_pair_total(&self, _total: u64) {}
+
     fn checkpoint_pair_completed(&self) {}
 }
 

--- a/crates/historical-quote/tests/consistency.rs
+++ b/crates/historical-quote/tests/consistency.rs
@@ -144,6 +144,27 @@ async fn structured_differences_are_bounded_without_losing_total_count(
 }
 
 #[tokio::test]
+async fn resolved_checkpoint_pairs_cannot_exceed_the_worker_limit(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let checker = ConsistencyChecker::with_limits(
+        Arc::new(FixtureSource::native_consistency(true)?),
+        ReadLimits::unbounded(),
+        100,
+        0,
+    );
+    let result = checker
+        .execute(
+            &consistency_request(native_pool()),
+            &CancellationToken::new(),
+            &(),
+        )
+        .await;
+
+    assert!(matches!(result, Err(HistoricalError::CheckBudgetExceeded)));
+    Ok(())
+}
+
+#[tokio::test]
 async fn canonical_vm_comparison_is_rejected_and_cancellation_is_observed(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let source = Arc::new(FixtureSource::native()?);

--- a/crates/state-history/src/reader.rs
+++ b/crates/state-history/src/reader.rs
@@ -66,6 +66,34 @@ impl<P: ReadConnectionProvider> StateHistoryReader<P> {
         }
     }
 
+    /// Returns the latest block that is safe for every requested backend.
+    ///
+    /// This is the bounded cutoff query used by service status. It does not
+    /// calculate retained intervals or load state-history objects.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the replica cannot provide a cutoff for every
+    /// requested backend.
+    pub async fn visible_through_block(
+        &self,
+        chain_id: u64,
+        backends: &[Backend],
+    ) -> anyhow::Result<u64> {
+        let mut connection = self
+            .connections
+            .acquire()
+            .await
+            .context("failed to acquire state history read connection")?;
+        let mut transaction = begin_range_transaction(&mut connection).await?;
+        let cutoff = coverage::visible_through_block(&mut transaction, chain_id, backends).await?;
+        transaction
+            .commit()
+            .await
+            .context("failed to commit state history cutoff transaction")?;
+        Ok(cutoff)
+    }
+
     pub async fn resolve_range(&self, request: &RangeRequest) -> anyhow::Result<RangePlan> {
         let rfq_bounds = request.rfq_bounds()?;
         let mut connection = self

--- a/crates/state-history/src/reader/checkpoints.rs
+++ b/crates/state-history/src/reader/checkpoints.rs
@@ -1,4 +1,5 @@
 use anyhow::{ensure, Context};
+use futures::TryStreamExt;
 use sqlx::Row;
 
 use super::{
@@ -35,6 +36,7 @@ pub struct CheckpointPairQuery {
     pub chain_id: u64,
     pub selection: CheckpointPairSelection,
     pub backends: Vec<Backend>,
+    pub max_pairs: Option<usize>,
 }
 
 impl CheckpointPairQuery {
@@ -43,6 +45,7 @@ impl CheckpointPairQuery {
             chain_id,
             selection,
             backends: Vec::new(),
+            max_pairs: None,
         }
     }
 
@@ -57,7 +60,14 @@ impl CheckpointPairQuery {
             chain_id,
             selection,
             backends,
+            max_pairs: None,
         }
+    }
+
+    #[must_use]
+    pub const fn with_max_pairs(mut self, max_pairs: usize) -> Self {
+        self.max_pairs = Some(max_pairs);
+        self
     }
 }
 
@@ -131,8 +141,14 @@ impl<P: ReadConnectionProvider> StateHistoryReader<P> {
         let mut transaction = begin_range_transaction(&mut connection).await?;
         let pairs = match &query.selection {
             CheckpointPairSelection::BlockRange(bounds) => {
-                range_checkpoint_pairs(&mut transaction, query.chain_id, *bounds, &query.backends)
-                    .await?
+                range_checkpoint_pairs(
+                    &mut transaction,
+                    query.chain_id,
+                    *bounds,
+                    &query.backends,
+                    query.max_pairs,
+                )
+                .await?
             }
             CheckpointPairSelection::Explicit(selections) => {
                 explicit_checkpoint_pairs(
@@ -140,6 +156,7 @@ impl<P: ReadConnectionProvider> StateHistoryReader<P> {
                     query.chain_id,
                     selections,
                     &query.backends,
+                    query.max_pairs,
                 )
                 .await?
             }
@@ -509,8 +526,9 @@ async fn range_checkpoint_pairs(
     chain_id: u64,
     bounds: BlockInterval,
     backends: &[Backend],
+    max_pairs: Option<usize>,
 ) -> anyhow::Result<Vec<CheckpointPair>> {
-    let rows = sqlx::query(
+    let mut rows = sqlx::query(
         "SELECT id, chain_id, generation, message_seq, state_version, kind, block_number,
                 rfq_observed_at_ms, backends, s3_key, archive_sha256, archive_bytes,
                 compressed_bytes, token_s3_key, token_sha256, token_count, token_bytes,
@@ -526,17 +544,22 @@ async fn range_checkpoint_pairs(
         bounds.end_inclusive,
         "checkpoint pair range end",
     )?)
-    .fetch_all(connection)
-    .await
-    .context("failed to select checkpoint pair range")?;
-    let manifests = rows
-        .iter()
-        .map(manifest_from_row)
-        .collect::<anyhow::Result<Vec<_>>>()?;
-    ensure_unique_positions(&manifests)?;
+    .fetch(&mut *connection);
+    let sentinel_limit = max_pairs.and_then(|limit| limit.checked_add(1));
     let mut pairs = Vec::new();
     let mut previous: Option<CheckpointManifest> = None;
-    for manifest in manifests {
+    let mut previous_position = None;
+    while let Some(row) = rows
+        .try_next()
+        .await
+        .context("failed to select checkpoint pair range")?
+    {
+        let manifest = manifest_from_row(&row)?;
+        ensure!(
+            previous_position != Some(manifest.position),
+            "checkpoint position is ambiguous because multiple complete kinds exist"
+        );
+        previous_position = Some(manifest.position);
         if manifest.kind == CheckpointKind::Boundary {
             previous = checkpoint_supports(&manifest, backends).then_some(manifest);
             continue;
@@ -549,6 +572,9 @@ async fn range_checkpoint_pairs(
                 earlier,
                 target: manifest,
             });
+            if sentinel_limit == Some(pairs.len()) {
+                break;
+            }
         }
     }
     Ok(pairs)
@@ -559,9 +585,13 @@ async fn explicit_checkpoint_pairs(
     chain_id: u64,
     selections: &[ExplicitCheckpointPair],
     backends: &[Backend],
+    max_pairs: Option<usize>,
 ) -> anyhow::Result<Vec<CheckpointPair>> {
-    let mut pairs = Vec::with_capacity(selections.len());
-    for selection in selections {
+    let sentinel_limit = max_pairs
+        .and_then(|limit| limit.checked_add(1))
+        .unwrap_or(usize::MAX);
+    let mut pairs = Vec::with_capacity(selections.len().min(sentinel_limit));
+    for selection in selections.iter().take(sentinel_limit) {
         ensure!(
             selection.earlier_position < selection.target_position,
             "explicit checkpoint pair must be ordered"
@@ -664,14 +694,4 @@ async fn segment_boundary_position(
         })
     })
     .transpose()
-}
-
-fn ensure_unique_positions(manifests: &[CheckpointManifest]) -> anyhow::Result<()> {
-    for pair in manifests.windows(2) {
-        ensure!(
-            pair[0].position != pair[1].position,
-            "checkpoint position is ambiguous because multiple complete kinds exist"
-        );
-    }
-    Ok(())
 }

--- a/crates/state-history/src/reader/coverage.rs
+++ b/crates/state-history/src/reader/coverage.rs
@@ -357,7 +357,7 @@ async fn required_block_times(
     Ok((observations, missing))
 }
 
-pub(super) async fn visible_through_block(
+pub(crate) async fn visible_through_block(
     connection: &mut sqlx::PgConnection,
     chain_id: u64,
     backends: &[Backend],

--- a/crates/state-history/tests/history_reads.rs
+++ b/crates/state-history/tests/history_reads.rs
@@ -347,6 +347,17 @@ async fn checkpoint_pairs_are_adjacent_and_never_cross_segments(
     assert_eq!(pairs[2].earlier.position, position(2, 0));
     assert_eq!(pairs[2].target.position, position(2, 10));
 
+    let bounded_pairs = reader
+        .resolve_checkpoint_pairs(
+            &CheckpointPairQuery::new(
+                CHAIN_ID,
+                CheckpointPairSelection::BlockRange(BlockInterval::new(100, 210)?),
+            )
+            .with_max_pairs(1),
+        )
+        .await?;
+    assert_eq!(bounded_pairs.len(), 2);
+
     let error = reader
         .resolve_checkpoint_pairs(&CheckpointPairQuery::new(
             CHAIN_ID,


### PR DESCRIPTION
Exposes the engine through authenticated job, coverage, status, and readiness endpoints, with bounded FIFO scheduling, cancellation, terminal result delivery, RDS IAM connections, and read only storage access. This keeps API lifecycle and resource admission separate from the reconstruction engine.